### PR TITLE
Breakdancer support & Improved error messages

### DIFF
--- a/docs/source/tools_supported.rst
+++ b/docs/source/tools_supported.rst
@@ -8,23 +8,43 @@ MAVIS supports output from a wide-variety of SV callers. Assumptions are made fo
 the output and the publications for each tool. The tools and versions currently supported are given below. Versions listed
 indicate the version of the tool for which output files have been tested as input into MAVIS
 
-+-------------------------------+------------------------------------------------------------------------------------------+----------------+----------------------------------+
-| Name                          | Source                                                                                   | Version(s)     | Output File(s)                   |
-+===============================+==========================================================================================+================+==================================+
-| Chimerascan [Iyer-2011]_      | `code.google.com/archive/p/chimerascan <https://code.google.com/archive/p/chimerascan>`_ | 0.4.5          | ``*.bedpe``                      |
-+-------------------------------+------------------------------------------------------------------------------------------+----------------+----------------------------------+
-| DeFuse [McPherson-2011]_      | `bitbucket.org/dranew/defuse <https://bitbucket.org/dranew/defuse>`_                     | 0.6.2          | ``results/results.classify.tsv`` |
-+-------------------------------+------------------------------------------------------------------------------------------+----------------+----------------------------------+
-| DELLY [Rausch-2012]_          | `github.com/dellytools/delly <https://github.com/dellytools/delly>`_                     | 0.7.3          | ``*.vcf`` (converted from bcf)   |
-+-------------------------------+------------------------------------------------------------------------------------------+----------------+----------------------------------+
-| Manta [Chen-2016]_            | `github.com/Illumina/manta <https://github.com/Illumina/manta>`_                         | 1.0.0          | ``{diploidSV,somaticSV}.vcf``    |
-+-------------------------------+------------------------------------------------------------------------------------------+----------------+----------------------------------+
-| Pindel [Ye-2009]_             | `github.com/genome/pindel <https://github.com/genome/pindel>`_                           | 0.2.5b9        |                                  |
-+-------------------------------+------------------------------------------------------------------------------------------+----------------+----------------------------------+
-| Trans-ABySS [Robertson-2010]_ | `github.com/bcgsc/transabyss <https://github.com/bcgsc/transabyss>`_                     | 1.4.8 (custom) | ``fusions/*.tsv``                |
-+-------------------------------+------------------------------------------------------------------------------------------+----------------+----------------------------------+
+.. list-table::
+    :header-rows: 1
 
-.. note:: 
+    *   - Name
+        - Version(s)
+        - MAVIS input
+        - Publication
+    *   - `BreakDancer <https://github.com/genome/breakdancer>`_
+        - ``1.4.5``
+        -
+        - [Chen-2009]_
+    *   - `Chimerascan <https://code.google.com/archive/p/chimerascan>`_
+        - ``0.4.5``
+        - ``*.bedpe``
+        - [Iyer-2011]_
+    *   - `DeFuse <https://bitbucket.org/dranew/defuse>`_
+        - ``0.6.2``
+        - ``results/results.classify.tsv``
+        - [McPherson-2011]_
+    *   - `DELLY <https://github.com/dellytools/delly>`_
+        - ``0.6.1`` ``0.7.3``
+        - ``combined.vcf`` (converted from bcf)
+        - [Rausch-2012]_
+    *   - `Manta <https://github.com/Illumina/manta>`_
+        - ``1.0.0``
+        - ``{diploidSV,somaticSV}.vcf``
+        - [Chen-2016]_
+    *   - `Pindel <https://github.com/genome/pindel>`_
+        - ``0.2.5b9``
+        -
+        - [Ye-2009]_
+    *   - `Trans-ABySS <https://github.com/bcgsc/transabyss>`_
+        - ``1.4.8 (custom)``
+        - ``fusions/*.tsv``
+        - [Robertson-2010]_
+
+.. note::
 
     The trans-abyss version used was an in-house dev version. However the output columns are compatible with 1.4.8 as that
     was the version branched from
@@ -36,7 +56,7 @@ indicate the version of the tool for which output files have been tested as inpu
 Some post-processing on the delly output files is generally done prior to input. The output bcf files are converted to a vcf file
 
 .. code:: bash
-    
+
     bcftools concat -f /path/to/file/with/vcf/list --allow-overlaps --output-type v --output combined.vcf
 
 
@@ -49,10 +69,10 @@ Logic Example - :ref:`Chimerascan <Iyer-2011>`
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 
-The following is a description of how the conversion script for :ref:`Chimerascan <Iyer-2011>` was generated. While this is a built-in 
+The following is a description of how the conversion script for :ref:`Chimerascan <Iyer-2011>` was generated. While this is a built-in
 conversion command now, the logic could also have been put in an external script. As mentioned above, there are a number of
-assumptions that had to be made about the tools output to convert it to the :ref:`standard mavis format <mavis-input-format>`. 
-Assumptions were then verified by reviewing at a series of called events in :term:`IGV`. In the current example, 
+assumptions that had to be made about the tools output to convert it to the :ref:`standard mavis format <mavis-input-format>`.
+Assumptions were then verified by reviewing at a series of called events in :term:`IGV`. In the current example,
 :ref:`Chimerascan <Iyer-2011>` output has six columns of interest that were used in the conversion
 
 - start3p
@@ -63,14 +83,14 @@ Assumptions were then verified by reviewing at a series of called events in :ter
 - strand5p
 
 The above columns describe two segments which are joined. MAVIS requires the position of the join. It was assumed that the
-segments are always joined as a :term:`sense fusion`. Using this assumption there are four logical cases to determine the position of the breakpoints. 
+segments are always joined as a :term:`sense fusion`. Using this assumption there are four logical cases to determine the position of the breakpoints.
 
-i.e. the first case would be: If both strands are positive, then the end of the five-prime segment (end5p) 
+i.e. the first case would be: If both strands are positive, then the end of the five-prime segment (end5p)
 is the first breakpoint and the start of the three-prime segment is the second breakpoint
 
 The logic for all cases is shown in the code below
 
-   
+
 .. literalinclude:: ./../../mavis/tools.py
     :pyobject: _parse_chimerascan
     :emphasize-lines: 10-22
@@ -79,15 +99,15 @@ Calling A Custom Conversion Script
 +++++++++++++++++++++++++++++++++++++
 
 Custom conversion scripts can be specified during :ref:`automatic config generation <pipeline-config>` using the
-``--external_conversion`` option. 
+``--external_conversion`` option.
 
-.. note:: 
-    
+.. note::
+
     Any external conversion scripts must take a ``-o`` option which requires a single
     outputfile argument. This outputfile must be the converted file output by the script.
     Additionally, the conversion script must be specified by its full path name and have executeable permissions.
 
-In the following example the user has created a custom conversion script ``my_convert_script.py`` which they 
+In the following example the user has created a custom conversion script ``my_convert_script.py`` which they
 are passing an input file named ``my_input1.txt``.
 
 .. code:: bash

--- a/mavis/bam/read.py
+++ b/mavis/bam/read.py
@@ -246,7 +246,7 @@ def nsb_align(
     """
     ref = str(ref)
     if len(ref) < 1 or len(seq) < 1:
-        raise AttributeError('cannot overlap on an empty sequence')
+        raise AttributeError('cannot overlap on an empty sequence: len(ref)={}, len(seq)={}'.format(len(ref), len(seq)))
     if min_match < 0 or min_match > 1:
         raise AttributeError('min_match must be between 0 and 1')
 

--- a/mavis/tools.py
+++ b/mavis/tools.py
@@ -20,7 +20,8 @@ SUPPORTED_TOOL = MavisNamespace(
     PINDEL='pindel',
     CHIMERASCAN='chimerascan',
     MAVIS='mavis',
-    DEFUSE='defuse'
+    DEFUSE='defuse',
+    BREAKDANCER='breakdancer'
 )
 """
 Supported Tools used to call SVs and then used as input into MAVIS
@@ -288,6 +289,16 @@ def _convert_tool_row(row, file_type, stranded, assume_no_untemplated=True):
     elif file_type == SUPPORTED_TOOL.TA:
 
         std_row.update(_parse_transabyss(row))
+
+    elif file_type == SUPPORTED_TOOL.BREAKDANCER:
+
+        std_row.update({
+            'event_type': row['Type'],
+            'chr1': row['Chr1'],
+            'chr2': row['Chr2'],
+            'pos1_start': row['Pos1'],
+            'pos2_start': row['Pos2'],
+        })
 
     else:
         raise NotImplementedError('unsupported file type', file_type)

--- a/mavis/tools.py
+++ b/mavis/tools.py
@@ -7,6 +7,7 @@ from braceexpand import braceexpand
 from shortuuid import uuid
 import tab
 from pysam import VariantFile
+from argparse import Namespace
 
 from .breakpoint import Breakpoint, BreakpointPair
 from .constants import COLUMNS, MavisNamespace, ORIENT, STRAND, SVTYPE
@@ -90,45 +91,51 @@ def _parse_transabyss(row):
     if TRACKING_COLUMN not in row:
         std_row[TRACKING_COLUMN] = '{}-{}'.format(SUPPORTED_TOOL.TA, row['id'])
 
-    std_row['event_type'] = row.get('rearrangement', row['type'])
+    std_row[COLUMNS.event_type] = row.get('rearrangement', row['type'])
     for retained_column in ['genes', 'gene']:
         if retained_column in row:
             std_row['{}_{}'.format(SUPPORTED_TOOL.TA, retained_column)] = row[retained_column]
-    if std_row['event_type'] in ['LSR', 'translocation']:
-        del std_row['event_type']
+    if std_row[COLUMNS.event_type] in ['LSR', 'translocation']:
+        del std_row[COLUMNS.event_type]
     if 'breakpoint' in row:
-        std_row['orient1'], std_row['orient2'] = row['orientations'].split(',')
+        std_row[COLUMNS.break1_orientation], std_row[COLUMNS.break2_orientation] = row['orientations'].split(',')
         match = re.match(
             r'^(?P<chr1>[^:]+):(?P<pos1_start>\d+)\|(?P<chr2>[^:]+):(?P<pos2_start>\d+)$', row['breakpoint'])
         if not match:
             raise OSError(
                 'file format error: the breakpoint column did not satisfy the expected pattern', row)
-        std_row.update({k: match[k] for k in ['chr1', 'pos1_start', 'chr2', 'pos2_start']})
+        for group, col in zip(
+            ['chr1', 'pos1_start', 'chr2', 'pos2_start'],
+            [COLUMNS.break1_chromosome, COLUMNS.break1_position_start, COLUMNS.break2_chromosome, COLUMNS.break2_position_start]
+        ):
+            std_row[col] = match[group]
     else:
         std_row.update({
-            'chr1': row['chr'], 'pos1_start': int(row['chr_start']), 'pos2_start': int(row['chr_end'])
+            COLUMNS.break1_chromosome: row['chr'],
+            COLUMNS.break1_position_start: int(row['chr_start']),
+            COLUMNS.break2_position_start: int(row['chr_end'])
         })
-        if std_row['event_type'] == 'del':
-            std_row['pos1_start'] -= 1
-            std_row['pos2_start'] += 1
-        elif std_row['event_type'] == 'ins':
-            std_row['pos2_start'] += 1
+        if std_row[COLUMNS.event_type] == 'del':
+            std_row[COLUMNS.break1_position_start] -= 1
+            std_row[COLUMNS.break2_position_start] += 1
+        elif std_row[COLUMNS.event_type] == 'ins':
+            std_row[COLUMNS.break2_position_start] += 1
 
         # add the untemplated sequence where appropriate
-        if std_row['event_type'] == 'del':
+        if std_row[COLUMNS.event_type] == 'del':
             assert row['alt'] == 'na'
             std_row[COLUMNS.untemplated_seq] = ''
-        elif std_row['event_type'] in ['dup', 'ITD']:
-            length = std_row['pos2_start'] - std_row['pos1_start'] + 1
+        elif std_row[COLUMNS.event_type] in ['dup', 'ITD']:
+            length = std_row[COLUMNS.break2_position_start] - std_row[COLUMNS.break1_position_start] + 1
             if len(row['alt']) != length:
                 raise AssertionError(
                     'expected alternate sequence to be equal to the length of the event',
                     len(row['alt']), length, row, std_row)
             std_row[COLUMNS.untemplated_seq] = ''
-        elif std_row['event_type'] == 'ins':
+        elif std_row[COLUMNS.event_type] == 'ins':
             std_row[COLUMNS.untemplated_seq] = row['alt'].upper()
         else:
-            raise NotImplementedError('unexpected indel type', std_row['event_type'])
+            raise NotImplementedError('unexpected indel type', std_row[COLUMNS.event_type])
     return std_row
 
 
@@ -144,20 +151,20 @@ def _parse_chimerascan(row):
     if TRACKING_COLUMN not in row:
         std_row[TRACKING_COLUMN] = '{}-{}'.format(SUPPORTED_TOOL.CHIMERASCAN, row['chimera_cluster_id'])
 
-    std_row.update({'chr1': row['chrom5p'], 'chr2': row['chrom3p']})
+    std_row.update({COLUMNS.break1_chromosome: row['chrom5p'], COLUMNS.break2_chromosome: row['chrom3p']})
     if row['strand5p'] == '+':
-        std_row['pos1_start'] = row['end5p']
-        std_row['orient1'] = ORIENT.LEFT
+        std_row[COLUMNS.break1_position_start] = row['end5p']
+        std_row[COLUMNS.break1_orientation] = ORIENT.LEFT
     else:
-        std_row['pos1_start'] = row['start5p']
-        std_row['orient1'] = ORIENT.RIGHT
+        std_row[COLUMNS.break1_position_start] = row['start5p']
+        std_row[COLUMNS.break1_orientation] = ORIENT.RIGHT
     if row['strand3p'] == '+':
-        std_row['pos2_start'] = row['start3p']
-        std_row['orient2'] = ORIENT.RIGHT
+        std_row[COLUMNS.break2_position_start] = row['start3p']
+        std_row[COLUMNS.break2_orientation] = ORIENT.RIGHT
     else:
-        std_row['pos2_start'] = row['end3p']
-        std_row['orient2'] = ORIENT.LEFT
-    std_row['opposing_strands'] = row['strand5p'] != row['strand3p']
+        std_row[COLUMNS.break2_position_start] = row['end3p']
+        std_row[COLUMNS.break2_orientation] = ORIENT.LEFT
+    std_row[COLUMNS.opposing_strands] = row['strand5p'] != row['strand3p']
     return std_row
 
 
@@ -199,7 +206,7 @@ def _parse_vcf_record(record):
 
         if info.get('SVTYPE', None) == 'BND':
             chr2, end, orient2, ref, alt = _parse_bnd_alt(alt)
-            std_row['orient2'] = orient2
+            std_row[COLUMNS.break2_orientation] = orient2
             std_row[COLUMNS.untemplated_seq] = alt
             if record.ref != ref:
                 raise AssertionError(
@@ -212,33 +219,33 @@ def _parse_vcf_record(record):
                 std_row[COLUMNS.untemplated_seq] = alt[1:]
                 size = len(alt) - len(record.ref)
                 if size > 0:
-                    std_row['event_type'] = SVTYPE.INS
+                    std_row[COLUMNS.event_type] = SVTYPE.INS
                 elif size < 0:
-                    std_row['event_type'] = SVTYPE.DEL
-        std_row.update({'chr1': record.chrom, 'chr2': chr2})
+                    std_row[COLUMNS.event_type] = SVTYPE.DEL
+        std_row.update({COLUMNS.break1_chromosome: record.chrom, COLUMNS.break2_chromosome: chr2})
         if info.get('PRECISE', False):  # DELLY CI only apply when split reads were not used to refine the breakpoint which is then flagged
             std_row.update({
-                'pos1_start': record.pos,
-                'pos1_end': record.pos,
-                'pos2_start': end,
-                'pos2_end': end
+                COLUMNS.break1_position_start: record.pos,
+                COLUMNS.break1_position_end: record.pos,
+                COLUMNS.break2_position_start: end,
+                COLUMNS.break2_position_end: end
             })
         else:
             std_row.update({
-                'pos1_start': max(1, record.pos + info.get('CIPOS', (0, 0))[0]),
-                'pos1_end': record.pos + info.get('CIPOS', (0, 0))[1],
-                'pos2_start': max(1, end + info.get('CIEND', (0, 0))[0]),
-                'pos2_end': end + info.get('CIEND', (0, 0))[1]
+                COLUMNS.break1_position_start: max(1, record.pos + info.get('CIPOS', (0, 0))[0]),
+                COLUMNS.break1_position_end: record.pos + info.get('CIPOS', (0, 0))[1],
+                COLUMNS.break2_position_start: max(1, end + info.get('CIEND', (0, 0))[0]),
+                COLUMNS.break2_position_end: end + info.get('CIEND', (0, 0))[1]
             })
 
         if 'SVTYPE' in info:
-            std_row['event_type'] = info['SVTYPE']
+            std_row[COLUMNS.event_type] = info['SVTYPE']
 
         try:
             orient1, orient2 = info['CT'].split('to')
             connection_type = {'3': ORIENT.LEFT, '5': ORIENT.RIGHT, 'N': ORIENT.NS}
-            std_row['orient1'] = connection_type[orient1]
-            std_row['orient2'] = connection_type[orient2]
+            std_row[COLUMNS.break1_orientation] = connection_type[orient1]
+            std_row[COLUMNS.break2_orientation] = connection_type[orient2]
         except KeyError:
             pass
         records.append(std_row)
@@ -257,8 +264,8 @@ def _convert_tool_row(row, file_type, stranded, assume_no_untemplated=True):
             std_row[TRACKING_COLUMN] = getattr(row, TRACKING_COLUMN)
         except AttributeError:
             pass
-    std_row['orient1'] = std_row['orient2'] = ORIENT.NS
-    std_row['strand1'] = std_row['strand2'] = STRAND.NS
+    std_row[COLUMNS.break1_orientation] = std_row[COLUMNS.break2_orientation] = ORIENT.NS
+    std_row[COLUMNS.break1_strand] = std_row[COLUMNS.break2_strand] = STRAND.NS
     result = []
     # convert the specified file type to a standard format
     if file_type in [SUPPORTED_TOOL.DELLY, SUPPORTED_TOOL.MANTA, SUPPORTED_TOOL.PINDEL]:
@@ -271,11 +278,13 @@ def _convert_tool_row(row, file_type, stranded, assume_no_untemplated=True):
 
     elif file_type == SUPPORTED_TOOL.DEFUSE:
 
-        std_row['orient1'] = ORIENT.LEFT if row['genomic_strand1'] == STRAND.POS else ORIENT.RIGHT
-        std_row['orient2'] = ORIENT.LEFT if row['genomic_strand2'] == STRAND.POS else ORIENT.RIGHT
+        std_row[COLUMNS.break1_orientation] = ORIENT.LEFT if row['genomic_strand1'] == STRAND.POS else ORIENT.RIGHT
+        std_row[COLUMNS.break2_orientation] = ORIENT.LEFT if row['genomic_strand2'] == STRAND.POS else ORIENT.RIGHT
         std_row.update({
-            'chr1': row['gene_chromosome1'], 'chr2': row['gene_chromosome2'],
-            'pos1_start': row['genomic_break_pos1'], 'pos2_start': row['genomic_break_pos2']
+            COLUMNS.break1_chromosome: row['gene_chromosome1'],
+            COLUMNS.break2_chromosome: row['gene_chromosome2'],
+            COLUMNS.break1_position_start: row['genomic_break_pos1'],
+            COLUMNS.break2_position_start: row['genomic_break_pos2']
         })
         if TRACKING_COLUMN in row:
             std_row[TRACKING_COLUMN] = row[TRACKING_COLUMN]
@@ -289,22 +298,24 @@ def _convert_tool_row(row, file_type, stranded, assume_no_untemplated=True):
     elif file_type == SUPPORTED_TOOL.BREAKDANCER:
 
         std_row.update({
-            'event_type': row['Type'],
-            'chr1': row['Chr1'],
-            'chr2': row['Chr2'],
-            'pos1_start': row['Pos1'],
-            'pos2_start': row['Pos2'],
+            COLUMNS.event_type: row['Type'],
+            COLUMNS.break1_chromosome: row['Chr1'],
+            COLUMNS.break2_chromosome: row['Chr2'],
+            COLUMNS.break1_position_start: row['Pos1'],
+            COLUMNS.break2_position_start: row['Pos2'],
         })
 
+    elif file_type == SUPPORTED_TOOL.MAVIS:
+        std_row = row
     else:
         raise NotImplementedError('unsupported file type', file_type)
 
     if stranded:
-        std_row['strand1'] = STRAND.expand(std_row['strand1'])
-        std_row['strand2'] = STRAND.expand(std_row['strand2'])
+        std_row[COLUMNS.break1_strand] = STRAND.expand(std_row[COLUMNS.break1_strand])
+        std_row[COLUMNS.break2_strand] = STRAND.expand(std_row[COLUMNS.break2_strand])
     else:
-        std_row['strand1'] = [STRAND.NS]
-        std_row['strand2'] = [STRAND.NS]
+        std_row[COLUMNS.break1_strand] = [STRAND.NS]
+        std_row[COLUMNS.break2_strand] = [STRAND.NS]
 
     if not std_row.get(TRACKING_COLUMN, None):
         std_row[TRACKING_COLUMN] = '{}-{}'.format(file_type, std_row.get('id', uuid()))
@@ -312,9 +323,10 @@ def _convert_tool_row(row, file_type, stranded, assume_no_untemplated=True):
         std_row[COLUMNS.untemplated_seq] = ''
 
     combinations = list(itertools.product(
-        ORIENT.expand(std_row['orient1']), ORIENT.expand(std_row['orient2']),
-        std_row['strand1'], std_row['strand2'], TOOL_SVTYPE_MAPPING[std_row['event_type']] if 'event_type' in std_row else [None],
-        [True, False] if 'opposing_strands' not in std_row else [std_row['opposing_strands']]
+        ORIENT.expand(std_row[COLUMNS.break1_orientation]), ORIENT.expand(std_row[COLUMNS.break2_orientation]),
+        std_row[COLUMNS.break1_strand], std_row[COLUMNS.break2_strand],
+        TOOL_SVTYPE_MAPPING[std_row[COLUMNS.event_type]] if COLUMNS.event_type in std_row else [None],
+        [True, False] if std_row.get(COLUMNS.opposing_strands, None) is None else [std_row[COLUMNS.opposing_strands]]
     ))
     # add the product of all uncertainties as breakpoint pairs
     for orient1, orient2, strand1, strand2, event_type, oppose in combinations:
@@ -322,23 +334,23 @@ def _convert_tool_row(row, file_type, stranded, assume_no_untemplated=True):
 
             bpp = BreakpointPair(
                 Breakpoint(
-                    std_row['chr1'],
-                    std_row['pos1_start'],
-                    std_row.get('pos1_end', std_row['pos1_start']),
+                    std_row[COLUMNS.break1_chromosome],
+                    std_row[COLUMNS.break1_position_start],
+                    std_row.get(COLUMNS.break1_position_end, std_row[COLUMNS.break1_position_start]),
                     orient=orient1, strand=strand1
                 ),
                 Breakpoint(
-                    std_row.get('chr2', std_row['chr1']),
-                    std_row['pos2_start'],
-                    std_row.get('pos2_end', std_row['pos2_start']),
+                    std_row.get(COLUMNS.break2_chromosome, std_row[COLUMNS.break1_chromosome]),
+                    std_row[COLUMNS.break2_position_start],
+                    std_row.get(COLUMNS.break2_position_end, std_row[COLUMNS.break2_position_start]),
                     orient=orient2, strand=strand2
                 ),
                 opposing_strands=oppose,
-                untemplated_seq=std_row.get('untemplated_seq', None),
+                untemplated_seq=std_row.get(COLUMNS.untemplated_seq, None),
                 event_type=event_type,
                 data={
                     COLUMNS.tools: file_type,
-                    COLUMNS.tracking_id: std_row['tracking_id']
+                    COLUMNS.tracking_id: std_row[COLUMNS.tracking_id]
                 },
                 stranded=stranded
             )
@@ -358,18 +370,25 @@ def _convert_tool_row(row, file_type, stranded, assume_no_untemplated=True):
 def _convert_tool_output(input_file, file_type=SUPPORTED_TOOL.MAVIS, stranded=False, log=devnull, assume_no_untemplated=True):
     log('reading:', input_file)
     result = []
-    if file_type == SUPPORTED_TOOL.MAVIS:
-        result = read_bpp_from_input_file(input_file)
+    if file_type in [SUPPORTED_TOOL.DELLY, SUPPORTED_TOOL.MANTA, SUPPORTED_TOOL.PINDEL]:
+        rows = []
+        for vcf_record in VariantFile(input_file).fetch():
+            rows.extend(_parse_vcf_record(vcf_record))
+    elif file_type == SUPPORTED_TOOL.BREAKDANCER:
+        with open(input_file, 'r') as fh:
+            # comments in breakdancer are marked with a single # so they need to be discarded before reading
+            lines = fh.readlines()
+            header = 0
+            while header < len(lines) and lines[header].startswith('#'):
+                header += 1
+            lines = lines[header - 1:]
+            input_file = Namespace(readlines=lambda: lines)
+        _, rows = tab.read_file(input_file, allow_short=True)
     else:
-        if file_type in [SUPPORTED_TOOL.DELLY, SUPPORTED_TOOL.MANTA, SUPPORTED_TOOL.PINDEL]:
-            rows = []
-            for vcf_record in VariantFile(input_file).fetch():
-                rows.extend(_parse_vcf_record(vcf_record))
-        else:
-            dummy, rows = tab.read_file(input_file)
-        log('found', len(rows), 'rows')
-        for row in rows:
-            std_rows = _convert_tool_row(row, file_type, stranded, assume_no_untemplated=assume_no_untemplated)
-            result.extend(std_rows)
+        _, rows = tab.read_file(input_file)
+    log('found', len(rows), 'rows')
+    for row in rows:
+        std_rows = _convert_tool_row(row, file_type, stranded, assume_no_untemplated=assume_no_untemplated)
+        result.extend(std_rows)
     log('generated', len(result), 'breakpoint pairs')
     return result

--- a/mavis/tools.py
+++ b/mavis/tools.py
@@ -81,10 +81,6 @@ def convert_tool_output(input_file, file_type=SUPPORTED_TOOL.MAVIS, stranded=Fal
     return result
 
 
-def _parse_breakdancer(row):
-    pass  # TODO: add breakdancer support
-
-
 def _parse_transabyss(row):
     """
     transforms the transabyss output into the common format for expansion. Maps the input column

--- a/mavis/tools.py
+++ b/mavis/tools.py
@@ -326,7 +326,7 @@ def _convert_tool_row(row, file_type, stranded, assume_no_untemplated=True):
         ORIENT.expand(std_row[COLUMNS.break1_orientation]), ORIENT.expand(std_row[COLUMNS.break2_orientation]),
         std_row[COLUMNS.break1_strand], std_row[COLUMNS.break2_strand],
         TOOL_SVTYPE_MAPPING[std_row[COLUMNS.event_type]] if COLUMNS.event_type in std_row else [None],
-        [True, False] if std_row.get(COLUMNS.opposing_strands, None) is None else [std_row[COLUMNS.opposing_strands]]
+        [True, False] if std_row.get(COLUMNS.opposing_strands, None) is None else [tab.cast_boolean(std_row[COLUMNS.opposing_strands])]
     ))
     # add the product of all uncertainties as breakpoint pairs
     for orient1, orient2, strand1, strand2, event_type, oppose in combinations:

--- a/mavis/util.py
+++ b/mavis/util.py
@@ -492,13 +492,13 @@ def read_bpp_from_input_file(filename, expand_orient=False, expand_strand=False,
                     stranded=row[COLUMNS.stranded],
                 )
                 bpp.data.update(data)
-                if putative_event_type is not None:
+                if putative_event_type:
                     bpp.data[COLUMNS.event_type] = putative_event_type
                     if putative_event_type not in BreakpointPair.classify(bpp):
                         raise InvalidRearrangement(
                             'error: expected one of', BreakpointPair.classify(bpp),
                             'but found', putative_event_type, str(bpp), row)
-                if expand_svtype and putative_event_type is None:
+                if expand_svtype and not putative_event_type:
                     for svtype in BreakpointPair.classify(bpp, distance=lambda x, y: Interval(y - x)):
                         new_bpp = bpp.copy()
                         new_bpp.data[COLUMNS.event_type] = svtype

--- a/mavis/validate/base.py
+++ b/mavis/validate/base.py
@@ -57,6 +57,14 @@ class Evidence(BreakpointPair):
             untemplated_seq=untemplated_seq,
             **data
         )
+        # check that the breakpoints are within the reference length
+        if reference_genome:
+            if self.break1.start < 1 or self.break1.end > len(reference_genome[self.break1.chr].seq):
+                raise ValueError('Breakpoint {}-{} is outside the range of the reference sequence {} (1-{})'.format(
+                    self.break1.start, self.break1.end, self.break1.chr, len(reference_genome[self.break1.chr].seq)))
+            if self.break2.start < 1 or self.break2.end > len(reference_genome[self.break2.chr].seq):
+                raise ValueError('Breakpoint {}-{} is outside the range of the reference sequence {} (1-{})'.format(
+                    self.break2.start, self.break2.end, self.break2.chr, len(reference_genome[self.break2.chr].seq)))
         defaults = dict()
         for arg in kwargs:
             if arg not in DEFAULTS.__dict__:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -206,6 +206,9 @@ class MockLongString(str):
             index -= self.offset
         return str.__getitem__(self, index)
 
+    def __len__(self):
+        return self.offset + str.__len__(self)
+
 
 def mock_read_pair(mock1, mock2):
     if mock1.reference_id != mock2.reference_id:

--- a/tests/unit/test_tool.py
+++ b/tests/unit/test_tool.py
@@ -568,3 +568,110 @@ class TestParseBndAlt(unittest.TestCase):
         self.assertEqual(ORIENT.LEFT, orient)
         self.assertEqual('AGTG', seq)
         self.assertEqual('A', ref)
+
+
+class TestBreakDancer(unittest.TestCase):
+    def test_itx(self):
+        row = {
+            'Chr1': '1',
+            'Pos1': '10001',
+            'Orientation1': '83+126-',
+            'Chr2': '1',
+            'Pos2': '10546',
+            'Orientation2': '83+126-',
+            'Type': 'ITX',
+            'Size': '-352',
+            'Score': '99',
+            'num_Reads': '43'
+        }
+        bpps = _convert_tool_row(row, SUPPORTED_TOOL.BREAKDANCER, False, True)
+        self.assertEqual(1, len(bpps))
+        self.assertEqual(SVTYPE.DUP, bpps[0].event_type)
+        self.assertEqual(10001, bpps[0].break1.start)
+        self.assertEqual(10001, bpps[0].break1.end)
+        self.assertEqual(ORIENT.RIGHT, bpps[0].break1.orient)
+        self.assertEqual(10546, bpps[0].break2.start)
+        self.assertEqual(10546, bpps[0].break2.end)
+        self.assertEqual(ORIENT.LEFT, bpps[0].break2.orient)
+        self.assertEqual(False, bpps[0].opposing_strands)
+
+    def test_deletion(self):
+        row = {
+            'Chr1': '1',
+            'Pos1': '869445',
+            'Orientation1': '89+21-',
+            'Chr2': '1',
+            'Pos2': '870225',
+            'Orientation2': '5+93-',
+            'Type': 'DEL',
+            'Size': '892',
+            'Score': '99',
+            'num_Reads': '67'
+        }
+        bpps = _convert_tool_row(row, SUPPORTED_TOOL.BREAKDANCER, False, True)
+        self.assertEqual(1, len(bpps))
+        self.assertEqual(SVTYPE.DEL, bpps[0].event_type)
+        self.assertEqual(869445, bpps[0].break1.start)
+        self.assertEqual(869445, bpps[0].break1.end)
+        self.assertEqual(ORIENT.LEFT, bpps[0].break1.orient)
+        self.assertEqual(870225, bpps[0].break2.start)
+        self.assertEqual(870225, bpps[0].break2.end)
+        self.assertEqual(ORIENT.RIGHT, bpps[0].break2.orient)
+        self.assertEqual(False, bpps[0].opposing_strands)
+
+    def test_inversion(self):
+        row = {
+            'Chr1': '1',
+            'Pos1': '13143396',
+            'Orientation1': '18+4-',
+            'Chr2': '1',
+            'Pos2': '13218683',
+            'Orientation2': '10+10-',
+            'Type': 'INV',
+            'Size': '74618',
+            'Score': '31',
+            'num_Reads': '2'
+        }
+        bpps = _convert_tool_row(row, SUPPORTED_TOOL.BREAKDANCER, False, True)
+        self.assertEqual(2, len(bpps))
+        self.assertEqual(SVTYPE.INV, bpps[0].event_type)
+        self.assertEqual(13143396, bpps[0].break1.start)
+        self.assertEqual(13143396, bpps[0].break1.end)
+        self.assertEqual(ORIENT.LEFT, bpps[0].break1.orient)
+        self.assertEqual(13218683, bpps[0].break2.start)
+        self.assertEqual(13218683, bpps[0].break2.end)
+        self.assertEqual(ORIENT.LEFT, bpps[0].break2.orient)
+        self.assertEqual(True, bpps[0].opposing_strands)
+
+        self.assertEqual(SVTYPE.INV, bpps[1].event_type)
+        self.assertEqual(13143396, bpps[1].break1.start)
+        self.assertEqual(13143396, bpps[1].break1.end)
+        self.assertEqual(ORIENT.RIGHT, bpps[1].break1.orient)
+        self.assertEqual(13218683, bpps[1].break2.start)
+        self.assertEqual(13218683, bpps[1].break2.end)
+        self.assertEqual(ORIENT.RIGHT, bpps[1].break2.orient)
+        self.assertEqual(True, bpps[1].opposing_strands)
+
+    def test_insertion(self):
+        row = {
+            'Chr1': '1',
+            'Pos1': '20216146',
+            'Orientation1': '23+26-',
+            'Chr2': '1',
+            'Pos2': '20218060',
+            'Orientation2': '23+26-',
+            'Type': 'INS',
+            'Size': '-421',
+            'Score': '99',
+            'num_Reads': '3'
+        }
+        bpps = _convert_tool_row(row, SUPPORTED_TOOL.BREAKDANCER, False, True)
+        self.assertEqual(1, len(bpps))
+        self.assertEqual(SVTYPE.INS, bpps[0].event_type)
+        self.assertEqual(20216146, bpps[0].break1.start)
+        self.assertEqual(20216146, bpps[0].break1.end)
+        self.assertEqual(ORIENT.LEFT, bpps[0].break1.orient)
+        self.assertEqual(20218060, bpps[0].break2.start)
+        self.assertEqual(20218060, bpps[0].break2.end)
+        self.assertEqual(ORIENT.RIGHT, bpps[0].break2.orient)
+        self.assertEqual(False, bpps[0].opposing_strands)


### PR DESCRIPTION
- Adds support for breakdancer output
- Added flexibility for reading partially filled out mavis-style input files (helpful for reading files built from publication events which may be missing information)
- Stacks reference transcripts in diagrams when drawing fails due to width