### PR TITLE
v1.6.3 release

### DIFF
--- a/mavis/annotate/constants.py
+++ b/mavis/annotate/constants.py
@@ -17,7 +17,7 @@ DEFAULTS.add(
     'min_domain_mapping_match', 0.9, cast_type=float_fraction,
     defn='a number between 0 and 1 representing the minimum percent match a domain must map to the fusion transcript '
     'to be displayed')
-DEFAULTS.add('min_orf_size', 300, defn='the minimum length (in amino acids) to retain a putative open reading frame (ORF)')
+DEFAULTS.add('min_orf_size', 300, defn='the minimum length (in base pairs) to retain a putative open reading frame (ORF)')
 DEFAULTS.add('max_orf_cap', 3, defn='the maximum number of ORFs to return (best putative ORFs will be retained)')
 DEFAULTS.add(
     'annotation_filters', 'choose_more_annotated,choose_transcripts_by_priority',

--- a/mavis/annotate/variant.py
+++ b/mavis/annotate/variant.py
@@ -735,8 +735,12 @@ def annotate_events(
                     min_domain_mapping_match=min_domain_mapping_match
                 )
                 ann.fusion = ft
-            except (NotSpecifiedError, AttributeError, NotImplementedError):
-                pass
+            except NotSpecifiedError:
+                pass  # shouldn't build fusions for non-specific calls anyway
+            except AttributeError:
+                pass  # will be thrown when transcript1/2 are intergenic ranges and not actual transcripts
+            except NotImplementedError:
+                pass  # anti-sense fusions will throw this error
             except KeyError as e:
                 log('warning. could not build fusion product', repr(e))
         log('generated', len(ann_list), 'annotations', time_stamp=False)

--- a/mavis/bam/cache.py
+++ b/mavis/bam/cache.py
@@ -177,7 +177,7 @@ class BamCache:
         Returns:
             :class:`set` of :class:`pysam.AlignedSegment`: set of reads gathered from the region
         """
-        # try using the cache to avoid fetching regions more than once
+        # try using the cache to make grabbing mate pairs easier
         result = []
         bin_limit = int(read_limit / sample_bins) if read_limit else None
         chrom = input_chrom

--- a/mavis/bam/read.py
+++ b/mavis/bam/read.py
@@ -100,6 +100,29 @@ class SamRead(pysam.AlignedSegment):
         return result
 
 
+def pileup(reads, filter_func=None):
+    """
+    For a given set of reads generate a pileup of all reads (exlcuding those for which the filter_func returns True)
+
+    Args:
+        reads (iterable of pysam.AlignedSegment): reads to pileup
+        filter_func (callable): function which takes in a  read and returns True if it should be ignored and False otherwise
+
+    Returns:
+        iterable of tuple of int and int: tuples of genomic position and read count at that position
+
+    Note:
+        returns positions using 1-based indexing
+    """
+    hist = {}  # genome position => frequency count
+    for read in reads:
+        if filter_func and filter_func(read):
+            continue
+        for pos in read.get_reference_positions():
+            hist[pos + 1] = hist.get(pos + 1, 0) + 1
+    return sorted(hist.items())
+
+
 def map_ref_range_to_query_range(read, ref_range):
     """
     Args:

--- a/mavis/breakpoint.py
+++ b/mavis/breakpoint.py
@@ -108,6 +108,23 @@ class BreakpointPair:
                 return False
         return True
 
+    def __lt__(self, other):
+        if self.break1.key < other.break1.key:
+            return True
+        elif self.break1.key > other.break1.key:
+            return False
+        elif self.break2.key < other.break2.key:
+            return True
+        elif self.break2.key > other.break2.key:
+            return False
+        elif self.untemplated_seq == other.untemplated_seq:
+            return False
+        elif self.untemplated_seq is None:
+            return False
+        elif other.untemplated_seq is None:
+            return True
+        return self.untemplated_seq < other.untemplated_seq
+
     @property
     def interchromosomal(self):
         """:class:`bool`: True if the breakpoints are on different chromosomes, False otherwise"""

--- a/mavis/constants.py
+++ b/mavis/constants.py
@@ -643,7 +643,8 @@ COLUMNS = MavisNamespace(
     protein_synon='protein_synon',
     supplementary_call='supplementary_call',
     net_size='net_size',
-    repeat_count='repeat_count'
+    repeat_count='repeat_count',
+    assumed_untemplated='assumed_untemplated'
 )
 """:class:`MavisNamespace`: Column names for i/o files used throughout the pipeline
 
@@ -740,6 +741,7 @@ COLUMNS = MavisNamespace(
 - :term:`untemplated_seq`
 - :term:`validation_id`
 - :term:`repeat_count`
+- :term:`assumed_untemplated`
 """
 
 

--- a/mavis/illustrate/diagram.py
+++ b/mavis/illustrate/diagram.py
@@ -327,8 +327,8 @@ def draw_multi_transcript_overlay(config, gene, vmarkers=None, window_buffer=0, 
                 for dom in translation.domains:
                     labels.set_key(dom.name, dom.name)
 
-    st = min([max([gene.start - window_buffer, 1])] + [m.start for m in vmarkers] + [p.xmin for p in plots])
-    end = max([gene.end + window_buffer] + [m.end for m in vmarkers] + [p.xmax for p in plots])
+    st = min([max([gene.start - window_buffer, 1])] + [m.start for m in vmarkers] + [p.xmin for p in plots if p.xmin])
+    end = max([gene.end + window_buffer] + [m.end for m in vmarkers] + [p.xmax for p in plots if p.xmax])
 
     mapping = generate_interval_mapping(
         all_exons,
@@ -344,10 +344,11 @@ def draw_multi_transcript_overlay(config, gene, vmarkers=None, window_buffer=0, 
     y = config.marker_top_margin
 
     for plot in plots:
-        plot_group = draw_scatter(config, canvas, plot, mapping)
-        main_group.add(plot_group)
-        plot_group.translate(x, y)
-        y += plot.height + config.padding * 2
+        if plot.points:
+            plot_group = draw_scatter(config, canvas, plot, mapping)
+            main_group.add(plot_group)
+            plot_group.translate(x, y)
+            y += plot.height + config.padding * 2
 
     regular_transcripts = sorted([us_tx for us_tx in gene.transcripts if not us_tx.is_best_transcript], key=lambda x: x.name)
     for us_tx in regular_transcripts:

--- a/mavis/illustrate/scatter.py
+++ b/mavis/illustrate/scatter.py
@@ -38,7 +38,6 @@ def bam_to_scatter(bam_file, chrom, start, end, bin_size, strand=None, axis_name
         if strand is None:
             return False
         try:
-
             return sequenced_strand(read, VALIDATION_DEFAULTS.strand_determining_read) != strand
         except ValueError:
             return True

--- a/mavis/main.py
+++ b/mavis/main.py
@@ -302,27 +302,29 @@ def parse_overlay_args(parser, required, optional):
             parser.error('argument --marker: start and end must be integers: {}'.format(marker))
 
     defaults = [None, None, 1, None, True]
+    bam_file, bin_size, ymax, stranded = range(1, 5)
+
     for plot in args.read_depth_plots:
         for i, d in enumerate(defaults):
             if i >= len(plot):
                 plot.append(d)
-        if not os.path.exists(plot[1]):
-            parser.error('argument --read_depth_plots: the bam file given does not exist: {}'.format(plot[1]))
+        if not os.path.exists(plot[bam_file]):
+            parser.error('argument --read_depth_plots: the bam file given does not exist: {}'.format(plot[bam_file]))
         try:
-            plot[2] = int(plot[2])
+            plot[bin_size] = int(plot[bin_size])
         except ValueError:
-            parser.error('argument --read_depth_plots: bin size must be an integer: {}'.format(plot[2]))
+            parser.error('argument --read_depth_plots: bin size must be an integer: {}'.format(plot[bin_size]))
         try:
-            if str(plot[3]).lower() in ['null', 'none']:
-                plot[3] = None
+            if str(plot[ymax]).lower() in ['null', 'none']:
+                plot[ymax] = None
             else:
-                plot[3] = int(plot[3])
+                plot[ymax] = int(plot[ymax])
         except ValueError:
-            parser.error('argument --read_depth_plots: ymax must be an integer: {}'.format(plot[3]))
+            parser.error('argument --read_depth_plots: ymax must be an integer: {}'.format(plot[ymax]))
         try:
-            plot[4] = tab.cast_boolean(plot[4])
+            plot[stranded] = tab.cast_boolean(plot[stranded])
         except TypeError:
-            parser.error('argument --read_depth_plots: stranded must be an boolean: {}'.format(plot[4]))
+            parser.error('argument --read_depth_plots: stranded must be an boolean: {}'.format(plot[stranded]))
     return args
 
 

--- a/mavis/main.py
+++ b/mavis/main.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 import time
 
+import tab
+
 from . import __version__
 from .annotate.base import BioInterval
 from .annotate.constants import DEFAULTS as ANNOTATION_DEFAULTS
@@ -22,8 +24,7 @@ from .constants import SUBCOMMAND, PROTOCOL
 from .error import DrawingFitError
 from .illustrate.constants import DEFAULTS as ILLUSTRATION_DEFAULTS, DiagramSettings
 from .illustrate.diagram import draw_multi_transcript_overlay
-from .illustrate.scatter import ScatterPlot
-from .interval import Interval
+from .illustrate.scatter import bam_to_scatter
 from .pairing.constants import DEFAULTS as PAIRING_DEFAULTS
 from .pairing.main import main as pairing_main
 from .submit import SubmissionScript, SCHEDULER_CONFIG
@@ -277,12 +278,12 @@ def parse_overlay_args(parser, required, optional):
     """
     required.add_argument('gene_name', help='Gene ID or gene alias to be drawn')
     augment_parser(['annotations'], required, optional)
-    augment_parser(['drawing_width_iter_increase', 'max_drawing_retries', 'width'], optional)
+    augment_parser(['drawing_width_iter_increase', 'max_drawing_retries', 'width', 'min_mapping_quality'], optional)
     optional.add_argument(
         '--buffer_length', default=0, type=int, help='minimum genomic length to plot on either side of the target gene')
     optional.add_argument(
-        '--read_depth_plot', dest='read_depth_plots', metavar='<axis name STR> <bam FILEPATH> [bin size INT]',
-        nmin=2, nmax=3, help='bam file to use as data for plotting read_depth', action=RangeAppendAction)
+        '--read_depth_plot', dest='read_depth_plots', metavar='<axis name STR> <bam FILEPATH> [bin size INT] [ymax INT] [stranded BOOL]',
+        nmin=2, nmax=5, help='bam file to use as data for plotting read_depth', action=RangeAppendAction)
     optional.add_argument(
         '--marker', dest='markers', metavar='<label STR> <start INT> [end INT]', nmin=2, nmax=3,
         help='Marker on the diagram given by genomic position, May be a single position or a range. '
@@ -300,28 +301,40 @@ def parse_overlay_args(parser, required, optional):
         except ValueError:
             parser.error('argument --marker: start and end must be integers: {}'.format(marker))
 
+    defaults = [None, None, 1, None, True]
     for plot in args.read_depth_plots:
-        if len(plot) < 3:
-            plot.append(1)
+        for i, d in enumerate(defaults):
+            if i >= len(plot):
+                plot.append(d)
         if not os.path.exists(plot[1]):
             parser.error('argument --read_depth_plots: the bam file given does not exist: {}'.format(plot[1]))
         try:
             plot[2] = int(plot[2])
         except ValueError:
             parser.error('argument --read_depth_plots: bin size must be an integer: {}'.format(plot[2]))
+        try:
+            if str(plot[3]).lower() in ['null', 'none']:
+                plot[3] = None
+            else:
+                plot[3] = int(plot[3])
+        except ValueError:
+            parser.error('argument --read_depth_plots: ymax must be an integer: {}'.format(plot[3]))
+        try:
+            plot[4] = tab.cast_boolean(plot[4])
+        except TypeError:
+            parser.error('argument --read_depth_plots: stranded must be an boolean: {}'.format(plot[4]))
     return args
 
 
 def overlay_main(
     gene_name, output, buffer_length, read_depth_plots, markers,
     annotations, annotations_filename,
-    drawing_width_iter_increase, max_drawing_retries,
+    drawing_width_iter_increase, max_drawing_retries, min_mapping_quality,
     **kwargs
 ):
     """
     generates an overlay diagram
     """
-    import pysam
     # check options formatting
     gene_to_draw = None
 
@@ -340,30 +353,17 @@ def overlay_main(
     x_end = gene_to_draw.end + buffer_length
 
     plots = []
-    for axis_name, bam_file, bin_size in read_depth_plots:
+    for axis_name, bam_file, bin_size, ymax, stranded in read_depth_plots:
         # one plot per bam
+        plots.append(bam_to_scatter(
+            bam_file, gene_to_draw.chr, x_start, x_end,
+            strand=gene.get_strand() if stranded else None,
+            ymax=ymax,
+            bin_size=bin_size,
+            axis_name=axis_name,
+            min_mapping_quality=min_mapping_quality
+        ))
         log('reading:', bam_file)
-        samfile = pysam.AlignmentFile(bam_file, 'rb')
-        try:
-            points = []
-            for pileupcolumn in samfile.pileup(gene_to_draw.chr, x_start, x_end):
-                points.append((pileupcolumn.pos, pileupcolumn.n))
-
-            temp = [x for x in range(0, len(points), bin_size)]
-            temp.append(None)
-            avg_points = []
-            for st, end in zip(temp[0::], temp[1::]):
-                pos = [x for x, y in points[st:end]]
-                pos = Interval(min(pos), max(pos))
-                cov = [y for x, y in points[st:end]]
-                cov = Interval(sum(cov) / len(cov))
-                avg_points.append((pos, cov))
-            log('scatter plot {} has {} points'.format(axis_name, len(avg_points)))
-            plots.append(ScatterPlot(
-                avg_points, axis_name, ymin=0, ymax=max([y.start for x, y in avg_points] + [100])
-            ))
-        finally:
-            samfile.close()
 
     for i, (marker_name, marker_start, marker_end) in enumerate(markers):
         markers[i] = BioInterval(gene_to_draw.chr, marker_start, marker_end, name=marker_name)

--- a/mavis/summary/main.py
+++ b/mavis/summary/main.py
@@ -333,7 +333,7 @@ def main(
                 not row.get(COLUMNS.cdna_synon, ''),
                 str(row.get(COLUMNS.fusion_cdna_coding_start, None)) != 'None',
                 row[COLUMNS.library] == lib,
-                str(row.get(COLUMNS.supplementary_call, False)) != True
+                str(row.get(COLUMNS.supplementary_call, False)) != 'True'
             ]):
                 lib_rows.append(row)
         output_tabbed_file(lib_rows, filename, header=output_columns)

--- a/mavis/summary/main.py
+++ b/mavis/summary/main.py
@@ -91,6 +91,7 @@ def main(
             COLUMNS.cdna_synon,
             COLUMNS.net_size,
             COLUMNS.tracking_id,
+            COLUMNS.assumed_untemplated,
             'dgv',
             'summary_pairing']
         }, COLUMNS.call_method: CALL_METHOD.INPUT},
@@ -286,6 +287,7 @@ def main(
         COLUMNS.protein_synon,
         COLUMNS.cdna_synon,
         COLUMNS.net_size,
+        COLUMNS.assumed_untemplated,
         'dgv'}
 
     rows = []

--- a/mavis/summary/summary.py
+++ b/mavis/summary/summary.py
@@ -251,20 +251,15 @@ def filter_by_evidence(
                 removed.append(bpp)
                 continue
         elif bpp.call_method == CALL_METHOD.SPLIT:
+            linking_split_reads = bpp.linking_split_reads
+            if bpp.event_type == SVTYPE.INS:
+                linking_split_reads += bpp.flanking_pairs
             if any([
-                bpp.break1_split_reads < filter_min_split_reads,
-                bpp.break2_split_reads < filter_min_split_reads,
-                all([
-                    bpp.event_type != SVTYPE.INS,
-                    bpp.linking_split_reads < filter_min_linking_split_reads
-                ]),
-                all([
-                    bpp.event_type == SVTYPE.INS,
-                    bpp.flanking_pairs < filter_min_linking_split_reads,
-                    bpp.break2_split_reads_forced + bpp.break1_split_reads_forced < filter_min_linking_split_reads
-                ]),
-                bpp.break1_split_reads - bpp.break1_split_reads_forced < 1,
-                bpp.break2_split_reads - bpp.break2_split_reads_forced < 1
+                bpp.break1_split_reads + bpp.break1_split_reads_forced < filter_min_split_reads,
+                bpp.break2_split_reads + bpp.break2_split_reads_forced < filter_min_split_reads,
+                linking_split_reads < filter_min_linking_split_reads,
+                bpp.break1_split_reads < 1,
+                bpp.break2_split_reads < 1
             ]):
                 removed.append(bpp)
                 continue

--- a/mavis/validate/constants.py
+++ b/mavis/validate/constants.py
@@ -158,10 +158,10 @@ DEFAULTS.add(
     'amount of softclipping that is allowed on the right. If this is set to None then there is no limit on softclipping')
 DEFAULTS.add(
     'min_anchor_exact', 6, defn='Applies to re-aligning softclipped reads to the opposing breakpoint. The minimum '
-    'number of consecutive exact matches to anchor a read to initiate targetted realignment')
+    'number of consecutive exact matches to anchor a read to initiate targeted realignment')
 DEFAULTS.add(
     'min_anchor_fuzzy', 10, defn='Applies to re-aligning softclipped reads to the opposing breakpoint. The minimum '
-    'length of a fuzzy match to anchor a read to initiate targetted realignment')
+    'length of a fuzzy match to anchor a read to initiate targeted realignment')
 DEFAULTS.add(
     'min_anchor_match', 0.9, cast_type=float_fraction,
     defn='Minimum percent match for a read to be kept as evidence')

--- a/mavis/validate/constants.py
+++ b/mavis/validate/constants.py
@@ -142,7 +142,7 @@ DEFAULTS.add(
     'fetch_reads_limit', 3000,
     defn='maximum number of reads, cap, to loop over for any given evidence window')
 DEFAULTS.add(
-    'trans_fetch_reads_limit', 9000, cast_type=nullable_int,
+    'trans_fetch_reads_limit', 12000, cast_type=nullable_int,
     defn='Related to :term:`fetch_reads_limit`. Overrides fetch_reads_limit for transcriptome libraries when set. '
     'If this has a value of None then fetch_reads_limit will be used for transcriptome libraries instead')
 DEFAULTS.add(
@@ -209,3 +209,9 @@ DEFAULTS.add(
 DEFAULTS.add(
     'outer_window_min_event_size', 125,
     defn='the minimum size of an event in order for flanking read evidence to be collected')
+DEFAULTS.add(
+    'write_evidence_files', True, defn='write the intermediate bam and bed files containing the raw evidence collected and '
+    'contigs aligned. Not required for subsequent steps but can be useful in debugging and deep investigation of events')
+DEFAULTS.add(
+    'clean_aligner_files', False, defn='Remove the aligner output files after the validation stage is complete. Not'
+    ' required for subsequent steps but can be useful in debugging and deep investigation of events')

--- a/mavis/validate/main.py
+++ b/mavis/validate/main.py
@@ -232,8 +232,8 @@ def main(
                 ', flanking pairs: {}{}'.format(
                     0 if not call.contig else len(call.contig.input_reads),
                     len(call.spanning_reads),
-                    len(call.break1_split_reads), len(call.break1_tgt_align_split_read_names()),
-                    len(call.break2_split_reads), len(call.break2_tgt_align_split_read_names()),
+                    len(call.break1_split_read_names()), len(call.break1_split_read_names(tgt=True)),
+                    len(call.break2_split_read_names()), len(call.break2_split_read_names(tgt=True)),
                     len(call.linking_split_read_names()),
                     len(call.flanking_pairs),
                     '' if not call.has_compatible else '(' + str(len(call.compatible_flanking_pairs)) + ')'

--- a/mavis/validate/main.py
+++ b/mavis/validate/main.py
@@ -179,7 +179,7 @@ def main(
         reference_genome=reference_genome,
         aligner_fa_input_file=contig_aligner_fa,
         aligner_output_file=contig_aligner_output,
-        clean_files=False,
+        clean_files=validation_settings.clean_aligner_files,
         aligner=kwargs.get('aligner', validation_settings.aligner),
         aligner_reference=aligner_reference,
         aligner_output_log=contig_aligner_log,
@@ -256,57 +256,58 @@ def main(
     output_tabbed_file(filtered_evidence_clusters, failed_output_file)
     write_bed_file(passed_bed_file, itertools.chain.from_iterable([e.get_bed_repesentation() for e in event_calls]))
 
-    with pysam.AlignmentFile(contig_bam, 'wb', template=input_bam_cache.fh) as fh:
-        log('writing:', contig_bam)
-        for evidence in evidence_clusters:
-            for contig in evidence.contigs:
-                for aln in contig.alignments:
-                    aln.read1.cigar = _cigar.convert_for_igv(aln.read1.cigar)
-                    fh.write(aln.read1)
-                    if aln.read2:
-                        aln.read2.cigar = _cigar.convert_for_igv(aln.read2.cigar)
-                        fh.write(aln.read2)
+    if validation_settings.write_evidence_files:
+        with pysam.AlignmentFile(contig_bam, 'wb', template=input_bam_cache.fh) as fh:
+            log('writing:', contig_bam)
+            for evidence in evidence_clusters:
+                for contig in evidence.contigs:
+                    for aln in contig.alignments:
+                        aln.read1.cigar = _cigar.convert_for_igv(aln.read1.cigar)
+                        fh.write(aln.read1)
+                        if aln.read2:
+                            aln.read2.cigar = _cigar.convert_for_igv(aln.read2.cigar)
+                            fh.write(aln.read2)
 
-    # write the evidence
-    with pysam.AlignmentFile(raw_evidence_bam, 'wb', template=input_bam_cache.fh) as fh:
-        log('writing:', raw_evidence_bam)
-        reads = set()
-        for evidence in evidence_clusters:
-            reads.update(evidence.supporting_reads())
-        for read in reads:
-            read.cigar = _cigar.convert_for_igv(read.cigar)
-            fh.write(read)
-    # now sort the contig bam
-    sort = re.sub('.bam$', '.sorted.bam', contig_bam)
-    log('sorting the bam file:', contig_bam)
-    if samtools_version <= (1, 2, 0):
-        subprocess.call(samtools_v0_sort(contig_bam, sort), shell=True)
-    else:
-        subprocess.call(samtools_v1_sort(contig_bam, sort), shell=True)
-    contig_bam = sort
-    log('indexing the sorted bam:', contig_bam)
-    subprocess.call(['samtools', 'index', contig_bam])
+        # write the evidence
+        with pysam.AlignmentFile(raw_evidence_bam, 'wb', template=input_bam_cache.fh) as fh:
+            log('writing:', raw_evidence_bam)
+            reads = set()
+            for evidence in evidence_clusters:
+                reads.update(evidence.supporting_reads())
+            for read in reads:
+                read.cigar = _cigar.convert_for_igv(read.cigar)
+                fh.write(read)
+        # now sort the contig bam
+        sort = re.sub('.bam$', '.sorted.bam', contig_bam)
+        log('sorting the bam file:', contig_bam)
+        if samtools_version <= (1, 2, 0):
+            subprocess.call(samtools_v0_sort(contig_bam, sort), shell=True)
+        else:
+            subprocess.call(samtools_v1_sort(contig_bam, sort), shell=True)
+        contig_bam = sort
+        log('indexing the sorted bam:', contig_bam)
+        subprocess.call(['samtools', 'index', contig_bam])
 
-    # then sort the evidence bam file
-    sort = re.sub('.bam$', '.sorted.bam', raw_evidence_bam)
-    log('sorting the bam file:', raw_evidence_bam)
-    if samtools_version <= (1, 2, 0):
-        subprocess.call(samtools_v0_sort(raw_evidence_bam, sort), shell=True)
-    else:
-        subprocess.call(samtools_v1_sort(raw_evidence_bam, sort), shell=True)
-    raw_evidence_bam = sort
-    log('indexing the sorted bam:', raw_evidence_bam)
-    subprocess.call(['samtools', 'index', raw_evidence_bam])
+        # then sort the evidence bam file
+        sort = re.sub('.bam$', '.sorted.bam', raw_evidence_bam)
+        log('sorting the bam file:', raw_evidence_bam)
+        if samtools_version <= (1, 2, 0):
+            subprocess.call(samtools_v0_sort(raw_evidence_bam, sort), shell=True)
+        else:
+            subprocess.call(samtools_v1_sort(raw_evidence_bam, sort), shell=True)
+        raw_evidence_bam = sort
+        log('indexing the sorted bam:', raw_evidence_bam)
+        subprocess.call(['samtools', 'index', raw_evidence_bam])
 
-    # write the igv batch file
-    with open(igv_batch_file, 'w') as fh:
-        log('writing:', igv_batch_file)
-        fh.write('new\ngenome {}\n'.format(reference_genome_filename))
+        # write the igv batch file
+        with open(igv_batch_file, 'w') as fh:
+            log('writing:', igv_batch_file)
+            fh.write('new\ngenome {}\n'.format(reference_genome_filename))
 
-        fh.write('load {} name="{}"\n'.format(passed_bed_file, 'passed events'))
-        fh.write('load {} name="{}"\n'.format(contig_bam, 'aligned contigs'))
-        fh.write('load {} name="{}"\n'.format(evidence_bed, 'evidence windows'))
-        fh.write('load {} name="{}"\n'.format(raw_evidence_bam, 'raw evidence'))
-        fh.write('load {} name="{} {} input"\n'.format(bam_file, library, protocol))
+            fh.write('load {} name="{}"\n'.format(passed_bed_file, 'passed events'))
+            fh.write('load {} name="{}"\n'.format(contig_bam, 'aligned contigs'))
+            fh.write('load {} name="{}"\n'.format(evidence_bed, 'evidence windows'))
+            fh.write('load {} name="{}"\n'.format(raw_evidence_bam, 'raw evidence'))
+            fh.write('load {} name="{} {} input"\n'.format(bam_file, library, protocol))
 
     generate_complete_stamp(output, log, start_time=start_time)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ os.environ['HTSLIB_CONFIGURE_OPTIONS'] = '--disable-lzma'  # only required for C
 
 setup(
     name='mavis',
-    version='1.6.2',
+    version='1.6.3',
     url='https://github.com/bcgsc/mavis.git',
     packages=find_packages(),
     install_requires=[

--- a/tests/end_to_end/__init__.py
+++ b/tests/end_to_end/__init__.py
@@ -1,0 +1,15 @@
+import glob
+import os
+
+
+def glob_exists(*pos, strict=True, n=1):
+    globexpr = os.path.join(*pos)
+    l = glob.glob(globexpr)
+    if strict and len(l) == n:
+        return l[0] if len(l) == 1 else l
+    elif not strict and len(l) > 0:
+        return l
+    else:
+        print(globexpr)
+        print(l)
+        return False

--- a/tests/end_to_end/data/clean_pipeline_config.cfg
+++ b/tests/end_to_end/data/clean_pipeline_config.cfg
@@ -1,0 +1,89 @@
+[reference]
+template_metadata = tests/integration/data/cytoBand.txt
+annotations = tests/integration/data/mock_annotations.json
+masking = tests/integration/data/mock_masking.tab
+reference_genome = tests/integration/data/mock_reference_genome.fa
+aligner_reference = tests/integration/data/mock_reference_genome.2bit
+dgv_annotation = tests/integration/data/mock_dgv_annotation.txt
+
+[annotate]
+draw_fusions_only = False
+
+[validate]
+# evidence related settings
+aligner = blat
+assembly_include_flanking_pairs = True
+assembly_include_half_mapped_reads = True
+assembly_max_kmer_size = -1
+assembly_max_kmer_strict = True
+assembly_max_paths = 4
+assembly_min_edge_weight = 2
+assembly_min_exact_match_to_remap = 4
+assembly_min_nc_edge_weight = 4
+assembly_min_remap_coverage = 0
+assembly_min_remapped_seq = 3
+assembly_min_tgt_to_exclude_half_map = 7
+assembly_strand_concordance = 0.51
+blat_min_identity = 0.9
+call_error = 10
+contig_aln_max_event_size = 50
+contig_aln_merge_inner_anchor = 20
+contig_aln_merge_outer_anchor = 15
+contig_aln_min_anchor_size = 50
+contig_aln_min_query_consumption = 0.7
+fetch_reads_bins = 5
+fetch_reads_limit = 10000
+fetch_min_bin_size = 50
+filter_secondary_alignments = True
+fuzzy_mismatch_number = 1
+max_sc_preceeding_anchor = 6
+min_anchor_exact = 6
+min_anchor_fuzzy = 10
+min_anchor_match = 0.9
+min_double_aligned_to_estimate_insertion_size = 2
+min_flanking_pairs_resolution = 3
+min_linking_split_reads = 1
+min_mapping_quality = 5
+min_non_target_aligned_split_reads = 1
+min_sample_size_to_apply_percentage = 10
+min_softclipping = 6
+min_spanning_reads_resolution = 3
+min_splits_reads_resolution = 3
+stdev_count_abnormal = 3.0
+strand_determining_read = 2
+outer_window_min_event_size = 125
+write_evidence_files = False
+clean_aligner_files = True
+
+[cluster]
+uninformative_filter = True
+limit_to_chr =
+
+[mock-A36971]
+read_length = 150
+median_fragment_size = 400
+stdev_fragment_size = 97
+bam_file = tests/integration/data/mock_reads_for_events.sorted.bam
+protocol = genome
+inputs = tests/integration/data/mock_sv_events.tsv
+strand_specific = False
+disease_status=diseased
+
+[mock-A47933]
+read_length = 75
+median_fragment_size = 188
+stdev_fragment_size = 50
+bam_file = tests/integration/data/mock_trans_reads_for_events.sorted.bam
+protocol = transcriptome
+inputs = tests/integration/data/mock_sv_events.tsv
+strand_specific = True
+disease_status=diseased
+
+[summary]
+filter_min_remapped_reads = 5
+filter_min_spanning_reads = 5
+filter_min_flanking_reads = 10
+filter_min_split_reads = 5
+filter_min_linking_split_reads = 1
+filter_cdna_synon = True
+filter_protein_synon = True

--- a/tests/end_to_end/data/pipeline_config.cfg
+++ b/tests/end_to_end/data/pipeline_config.cfg
@@ -63,7 +63,7 @@ median_fragment_size = 400
 stdev_fragment_size = 97
 bam_file = tests/integration/data/mock_reads_for_events.sorted.bam
 protocol = genome
-inputs = tests/integration/data/mock_sv_events.tsv
+inputs = mock_converted
 strand_specific = False
 disease_status=diseased
 
@@ -73,7 +73,7 @@ median_fragment_size = 188
 stdev_fragment_size = 50
 bam_file = tests/integration/data/mock_trans_reads_for_events.sorted.bam
 protocol = transcriptome
-inputs = tests/integration/data/mock_sv_events.tsv
+inputs = mock_converted
 strand_specific = True
 disease_status=diseased
 
@@ -85,3 +85,11 @@ filter_min_split_reads = 5
 filter_min_linking_split_reads = 1
 filter_cdna_synon = True
 filter_protein_synon = True
+
+[convert]
+assume_no_untemplated = True
+mock_converted = convert_tool_output
+    tests/integration/data/mock_sv_events.tsv
+    mavis
+    False
+

--- a/tests/end_to_end/test_full_pipeline.py
+++ b/tests/end_to_end/test_full_pipeline.py
@@ -18,6 +18,7 @@ from . import glob_exists
 DATA_PREFIX = os.path.join(os.path.dirname(__file__), 'data')
 CONFIG = os.path.join(DATA_PREFIX, 'pipeline_config.cfg')
 BWA_CONFIG = os.path.join(DATA_PREFIX, 'bwa_pipeline_config.cfg')
+CLEAN_CONFIG = os.path.join(DATA_PREFIX, 'clean_pipeline_config.cfg')
 MOCK_GENOME = 'mock-A36971'
 MOCK_TRANS = 'mock-A47933'
 
@@ -163,6 +164,85 @@ class TestPipeline(unittest.TestCase):
                 'validation-passed.tab'
             ]:
                 self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.VALIDATE + '/*-1', '*.' + suffix))
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.VALIDATE + '/*-1', '*.COMPLETE'))
+
+            # run annotation
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.ANNOTATE))
+            qsub = unique_exists(os.path.join(self.temp_output, lib, SUBCOMMAND.ANNOTATE, '*-1/submit.sh'))
+            args = convert_qsub_to_args(qsub)
+            with patch.object(sys, 'argv', args):
+                self.assertEqual(0, main())
+            # check the generated files
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.ANNOTATE + '/*-1', 'annotations.tab'))
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.ANNOTATE + '/*-1', 'annotations.fusion-cdna.fa'))
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.ANNOTATE + '/*-1', 'drawings'))
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.ANNOTATE + '/*-1', 'drawings', '*svg', strict=False))
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.ANNOTATE + '/*-1', 'drawings', '*json', strict=False))
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.ANNOTATE + '/*-1', '*.COMPLETE'))
+        # now run the pairing
+        self.assertTrue(glob_exists(self.temp_output, SUBCOMMAND.PAIR))
+        qsub = unique_exists(os.path.join(self.temp_output, SUBCOMMAND.PAIR, 'submit.sh'))
+        args = convert_qsub_to_args(qsub, sub=[('SGE_TASK_ID', '1')])
+        with patch.object(sys, 'argv', args):
+            self.assertEqual(0, main())
+
+        self.assertTrue(glob_exists(self.temp_output, SUBCOMMAND.PAIR, 'mavis_paired*.tab'))
+        self.assertTrue(glob_exists(self.temp_output, SUBCOMMAND.PAIR, '*.COMPLETE'))
+
+        # now run the summary
+        self.assertTrue(glob_exists(self.temp_output, SUBCOMMAND.SUMMARY))
+        qsub = unique_exists(os.path.join(self.temp_output, SUBCOMMAND.SUMMARY, 'submit.sh'))
+        args = convert_qsub_to_args(qsub, sub=[('SGE_TASK_ID', '1')])
+        with patch.object(sys, 'argv', args):
+            self.assertEqual(0, main())
+
+        self.assertTrue(glob_exists(self.temp_output, SUBCOMMAND.SUMMARY, 'mavis_summary*.tab', n=3))
+        self.assertTrue(glob_exists(self.temp_output, SUBCOMMAND.SUMMARY, '*.COMPLETE'))
+
+        with patch.object(sys, 'argv', ['mavis', SUBCOMMAND.CHECKER, '-o', self.temp_output]):
+            self.assertEqual(0, main())
+        self.assertTrue(glob_exists(self.temp_output, 'submit_pipeline*.sh'))
+
+    def test_clean_files(self):
+        args = ['mavis', SUBCOMMAND.PIPELINE, CLEAN_CONFIG, '-o', self.temp_output]
+        with patch.object(sys, 'argv', args):
+            self.assertEqual(0, main())
+
+        # check that the subdirectories were built
+        for lib in[MOCK_GENOME + '_*', MOCK_TRANS + '_*']:
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.CLUSTER))
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.CLUSTER, 'batch-*-1.tab'))
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.CLUSTER, 'filtered_pairs.tab'))
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.CLUSTER, 'clusters.bed'))
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.CLUSTER, 'cluster_assignment.tab'))
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.CLUSTER, '*.COMPLETE'))
+
+            # run validation
+            self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.VALIDATE))
+            qsub = unique_exists(os.path.join(self.temp_output, lib, SUBCOMMAND.VALIDATE, '*-1/submit.sh'))
+            args = convert_qsub_to_args(qsub)  # read the arguments from the file
+            print(args)
+            with patch.object(sys, 'argv', args):
+                self.assertEqual(0, main())
+
+            for suffix in [
+                'evidence.bed',
+                'validation-failed.tab',
+                'validation-passed.tab'
+            ]:
+                self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.VALIDATE + '/*-1', '*.' + suffix))
+            for suffix in [
+                'contigs.bam',
+                'contigs.blat_out.pslx',
+                'contigs.fa',
+                'contigs.sorted.bam',
+                'contigs.sorted.bam.bai',
+                'igv.batch',
+                'raw_evidence.bam',
+                'raw_evidence.sorted.bam',
+                'raw_evidence.sorted.bam.bai',
+            ]:
+                self.assertFalse(glob_exists(self.temp_output, lib, SUBCOMMAND.VALIDATE + '/*-1', '*.' + suffix))
             self.assertTrue(glob_exists(self.temp_output, lib, SUBCOMMAND.VALIDATE + '/*-1', '*.COMPLETE'))
 
             # run annotation

--- a/tests/end_to_end/test_full_pipeline.py
+++ b/tests/end_to_end/test_full_pipeline.py
@@ -13,24 +13,13 @@ from mavis.util import unique_exists
 from mock import patch
 
 
+from . import glob_exists
+
 DATA_PREFIX = os.path.join(os.path.dirname(__file__), 'data')
 CONFIG = os.path.join(DATA_PREFIX, 'pipeline_config.cfg')
 BWA_CONFIG = os.path.join(DATA_PREFIX, 'bwa_pipeline_config.cfg')
 MOCK_GENOME = 'mock-A36971'
 MOCK_TRANS = 'mock-A47933'
-
-
-def glob_exists(*pos, strict=True, n=1):
-    globexpr = os.path.join(*pos)
-    l = glob.glob(globexpr)
-    if strict and len(l) == n:
-        return l[0] if len(l) == 1 else l
-    elif not strict and len(l) > 0:
-        return l
-    else:
-        print(globexpr)
-        print(l)
-        return False
 
 
 def convert_qsub_to_args(filename, sub=None):

--- a/tests/end_to_end/test_overlay.py
+++ b/tests/end_to_end/test_overlay.py
@@ -1,0 +1,143 @@
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from mock import patch
+
+from mavis.constants import SUBCOMMAND
+from mavis.main import main
+
+from . import glob_exists
+
+
+ANNOTATIONS = os.path.join(os.path.dirname(__file__), '../integration/data/annotations_subsample.json')
+BAM = os.path.join(os.path.dirname(__file__), '../integration/data/mock_reads_for_events.sorted.bam')
+
+
+class TestOverlayOptions(unittest.TestCase):
+    def setUp(self):
+        # create the temp output directory to store file outputs
+        self.temp_output = tempfile.mkdtemp()
+        print('output dir', self.temp_output)
+
+    def test_basic(self):
+        with patch.object(sys, 'argv', [
+            'mavis', SUBCOMMAND.OVERLAY, '--annotations', ANNOTATIONS, 'GAGE4', '--output', self.temp_output
+        ]):
+            try:
+                returncode = main()
+            except SystemExit as err:
+                self.assertEqual(0, err.code)
+            else:
+                self.assertEqual(0, returncode)
+                self.assertTrue(glob_exists(os.path.join(self.temp_output, '*GAGE4*.svg')))
+
+    def test_marker(self):
+        with patch.object(sys, 'argv', [
+            'mavis', SUBCOMMAND.OVERLAY, '--annotations', ANNOTATIONS, 'GAGE4', '--output', self.temp_output,
+            '--marker', 'm', '49364900'
+        ]):
+            try:
+                returncode = main()
+            except SystemExit as err:
+                self.assertEqual(0, err.code)
+            else:
+                self.assertEqual(0, returncode)
+                self.assertTrue(glob_exists(os.path.join(self.temp_output, '*GAGE4*.svg')))
+
+    def test_marker_range(self):
+        with patch.object(sys, 'argv', [
+            'mavis', SUBCOMMAND.OVERLAY, '--annotations', ANNOTATIONS, 'GAGE4', '--output', self.temp_output,
+            '--marker', 'm', '49364900', '49365900'
+        ]):
+            try:
+                returncode = main()
+            except SystemExit as err:
+                self.assertEqual(0, err.code)
+            else:
+                self.assertEqual(0, returncode)
+                self.assertTrue(glob_exists(os.path.join(self.temp_output, '*GAGE4*.svg')))
+
+    def test_marker_not_enough_args(self):
+        with patch.object(sys, 'argv', [
+            'mavis', SUBCOMMAND.OVERLAY, '--annotations', ANNOTATIONS, 'GAGE4', '--output', self.temp_output,
+            '--marker', 'm'
+        ]):
+            try:
+                returncode = main()
+            except SystemExit as err:
+                self.assertNotEqual(0, err.code)
+            else:
+                self.assertNotEqual(0, returncode)
+                self.assertTrue(glob_exists(os.path.join(self.temp_output, '*GAGE4*.svg')))
+
+        with patch.object(sys, 'argv', [
+            'mavis', SUBCOMMAND.OVERLAY, '--annotations', ANNOTATIONS, 'GAGE4', '--output', self.temp_output,
+            '--marker'
+        ]):
+            try:
+                returncode = main()
+            except SystemExit as err:
+                self.assertNotEqual(0, err.code)
+            else:
+                self.assertNotEqual(0, returncode)
+                self.assertTrue(glob_exists(os.path.join(self.temp_output, '*GAGE4*.svg')))
+
+    def test_marker_not_int(self):
+        with patch.object(sys, 'argv', [
+            'mavis', SUBCOMMAND.OVERLAY, '--annotations', ANNOTATIONS, 'GAGE4', '--output', self.temp_output,
+            '--marker', 'm', 'k'
+        ]):
+            try:
+                returncode = main()
+            except SystemExit as err:
+                self.assertNotEqual(0, err.code)
+            else:
+                self.assertNotEqual(0, returncode)
+                self.assertTrue(glob_exists(os.path.join(self.temp_output, '*GAGE4*.svg')))
+
+    def test_read_depth_plot(self):
+        with patch.object(sys, 'argv', [
+            'mavis', SUBCOMMAND.OVERLAY, '--annotations', ANNOTATIONS, 'GAGE4', '--output', self.temp_output,
+            '--read_depth_plot', 'axis', BAM
+        ]):
+            try:
+                returncode = main()
+            except SystemExit as err:
+                self.assertEqual(0, err.code)
+            else:
+                self.assertEqual(0, returncode)
+                self.assertTrue(glob_exists(os.path.join(self.temp_output, '*GAGE4*.svg')))
+
+    def test_read_depth_plot_binned(self):
+        with patch.object(sys, 'argv', [
+            'mavis', SUBCOMMAND.OVERLAY, '--annotations', ANNOTATIONS, 'GAGE4', '--output', self.temp_output,
+            '--read_depth_plot', 'axis', BAM, '10'
+        ]):
+            try:
+                returncode = main()
+            except SystemExit as err:
+                self.assertEqual(0, err.code)
+            else:
+                self.assertEqual(0, returncode)
+                self.assertTrue(glob_exists(os.path.join(self.temp_output, '*GAGE4*.svg')))
+
+    def test_read_depth_plot_not_binned_but_stranded(self):
+        with patch.object(sys, 'argv', [
+            'mavis', SUBCOMMAND.OVERLAY, '--annotations', ANNOTATIONS, 'GAGE4', '--output', self.temp_output,
+            '--read_depth_plot', 'axis', BAM, 'none', 'True'
+        ]):
+            try:
+                returncode = main()
+            except SystemExit as err:
+                self.assertEqual(0, err.code)
+            else:
+                self.assertEqual(0, returncode)
+                self.assertTrue(glob_exists(os.path.join(self.temp_output, '*GAGE4*.svg')))
+
+    def tearDown(self):
+        # remove the temp directory and outputs
+        shutil.rmtree(self.temp_output)

--- a/tests/end_to_end/test_overlay.py
+++ b/tests/end_to_end/test_overlay.py
@@ -126,9 +126,10 @@ class TestOverlayOptions(unittest.TestCase):
                 self.assertTrue(glob_exists(os.path.join(self.temp_output, '*GAGE4*.svg')))
 
     def test_read_depth_plot_not_binned_but_stranded(self):
+        # no ymax
         with patch.object(sys, 'argv', [
             'mavis', SUBCOMMAND.OVERLAY, '--annotations', ANNOTATIONS, 'GAGE4', '--output', self.temp_output,
-            '--read_depth_plot', 'axis', BAM, 'none', 'True'
+            '--read_depth_plot', 'axis', BAM, '1', 'none', 'True'
         ]):
             try:
                 returncode = main()

--- a/tests/integration/data/mock_sv_events.tsv
+++ b/tests/integration/data/mock_sv_events.tsv
@@ -28,7 +28,7 @@ False	gene3	27175	27175	gene3	27176	27176	R	L	+	+	duplication	transcriptome	conv
 False	gene3	27175	27175	gene3	27176	27176	R	L	+	+	duplication	genome	convert_ta.py_v0.0.1	mock-A36971	1:207249992
 True	gene1	34090	34090	gene5	608	608	R	R	-	+	inverted translocation	transcriptome	convert_ta.py_v0.0.1	mock-A47933	15:40854971|7:26241389
 False	gene5	608	608	gene1	33309	33309	R	R	+	-	inverted translocation	genome	convert_ta.py_v0.0.1	mock-A36971	7:26252971|15:40854190
-False	gene2	22408	22408	gene2	23783	23783	R	L	+	+	duplication	transcriptome	convert_ta.py_v0.0.1	mock-A47933	15:41623873|15:41625248#this one is pretty low qual
+False	gene2	22979	22979	gene2	23783	23783	R	L	+	+	duplication	transcriptome	convert_ta.py_v0.0.1	mock-A47933	15:41623873|15:41625248#this one is pretty low qual
 False	gene2	19827	19827	gene2	27045	27045	R	L	+	+	duplication	genome	convert_ta.py_v0.0.1	mock-A36971	15:41621292|15:41628510
 False	gene6	77430	77430	gene6	89472	89472	L	R	+	+	deletion	genome	convert_ta.py_v0.0.1	mock-A36971	10:89700299|10:89712341
-False	gene6	77430	77430	gene6	89472	89472	L	R	+	+	deletion	transcriptome	convert_ta.py_v0.0.1	mock-A47933	approx 10:89700299|10:89712341
+False	gene6	70057	77430	gene6	89472	94742	L	R	+	+	deletion	transcriptome	convert_ta.py_v0.0.1	mock-A47933	approx 10:89700299|10:89712341

--- a/tests/integration/test_breakpoint.py
+++ b/tests/integration/test_breakpoint.py
@@ -131,6 +131,7 @@ class TestLt(unittest.TestCase):
         bpp2 = BreakpointPair(Breakpoint('1', 1, 10, orient=ORIENT.LEFT), Breakpoint('2', 1, orient=ORIENT.LEFT), untemplated_seq=None)
         self.assertTrue(bpp2 < bpp1)
 
+
 class TestBreakpointSequenceHomology(unittest.TestCase):
 
     def test_left_pos_right_pos(self):

--- a/tests/integration/test_breakpoint.py
+++ b/tests/integration/test_breakpoint.py
@@ -115,6 +115,22 @@ class TestNetSizeTransEGFR(unittest.TestCase):
         self.assertEqual(Interval(-44), bpp.net_size(self.egfr_distance))
 
 
+class TestLt(unittest.TestCase):
+    def test_break1(self):
+        bpp1 = BreakpointPair(Breakpoint('1', 1, 10, orient=ORIENT.LEFT), Breakpoint('2', 1, orient=ORIENT.LEFT), untemplated_seq='')
+        bpp2 = BreakpointPair(Breakpoint('1', 1, 9, orient=ORIENT.LEFT), Breakpoint('2', 1, orient=ORIENT.LEFT), untemplated_seq='')
+        self.assertTrue(bpp2 < bpp1)
+
+    def test_useq(self):
+        bpp1 = BreakpointPair(Breakpoint('1', 1, 10, orient=ORIENT.LEFT), Breakpoint('2', 1, orient=ORIENT.LEFT), untemplated_seq='')
+        bpp2 = BreakpointPair(Breakpoint('1', 1, 10, orient=ORIENT.LEFT), Breakpoint('2', 1, orient=ORIENT.LEFT), untemplated_seq=None)
+        self.assertTrue(bpp2 > bpp1)
+
+    def test_break2(self):
+        bpp1 = BreakpointPair(Breakpoint('1', 1, 10, orient=ORIENT.LEFT), Breakpoint('2', 1, orient=ORIENT.RIGHT), untemplated_seq='')
+        bpp2 = BreakpointPair(Breakpoint('1', 1, 10, orient=ORIENT.LEFT), Breakpoint('2', 1, orient=ORIENT.LEFT), untemplated_seq=None)
+        self.assertTrue(bpp2 < bpp1)
+
 class TestBreakpointSequenceHomology(unittest.TestCase):
 
     def test_left_pos_right_pos(self):

--- a/tests/integration/test_illustrate.py
+++ b/tests/integration/test_illustrate.py
@@ -433,3 +433,5 @@ class TestDraw(unittest.TestCase):
         self.assertEqual(2, len(canvas.elements))  # defs counts as element
         if OUTPUT_SVG:
             canvas.saveas('test_draw_overlay.svg')
+
+

--- a/tests/integration/test_illustrate.py
+++ b/tests/integration/test_illustrate.py
@@ -433,5 +433,3 @@ class TestDraw(unittest.TestCase):
         self.assertEqual(2, len(canvas.elements))  # defs counts as element
         if OUTPUT_SVG:
             canvas.saveas('test_draw_overlay.svg')
-
-

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -7,7 +7,7 @@ from mavis.constants import ORIENT, PYSAM_READ_FLAGS, NA_MAPPING_QUALITY
 from mavis.validate.evidence import GenomeEvidence
 from mavis.validate.base import Evidence
 from mavis.bam.read import SamRead
-from mavis.bam.cigar import convert_string_to_cigar, join
+from mavis.bam import cigar as _cigar
 
 from . import BAM_INPUT, FULL_BAM_INPUT, mock_read_pair, MockRead, REFERENCE_GENOME_FILE, RUN_FULL, MockObject, MockLongString
 
@@ -54,11 +54,28 @@ class TestFullEvidenceGathering(unittest.TestCase):
             outer_window_min_event_size=0,
             min_mapping_quality=20
         )
+        print(ge.min_expected_fragment_size, ge.max_expected_fragment_size)
         print(ge.break1.chr, ge.outer_window1)
         print(ge.break1.chr, ge.inner_window1)
         print(ge.break2.chr, ge.outer_window2)
         print(ge.break2.chr, ge.inner_window2)
         return ge
+
+    def print_evidence(self, ev):
+        print('evidence for', ev)
+        print('flanking pairs')
+        for pair, mate in ev.flanking_pairs:
+            print(pair.query_name, pair.reference_name, ':', pair.reference_start, _cigar.convert_cigar_to_string(pair.cigar))
+            print(mate.query_name, mate.reference_name, ':', mate.reference_start, _cigar.convert_cigar_to_string(mate.cigar))
+
+        print('first breakpoint split reads')
+        for read in ev.split_reads[0]:
+            print(read.query_name, read.reference_name, ':', read.reference_start, _cigar.convert_cigar_to_string(read.cigar))
+
+        print('second breakpoint split reads')
+        for read in ev.split_reads[1]:
+            print(read.query_name, read.reference_name, ':', read.reference_start, _cigar.convert_cigar_to_string(read.cigar))
+        print()
 
     def count_original_reads(self, reads):
         count = 0
@@ -127,6 +144,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
         self.assertEqual(35, self.count_original_reads(ev1.split_reads[0]))
         self.assertEqual(11, self.count_original_reads(ev1.split_reads[1]))
@@ -140,7 +158,9 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
+        self.assertEqual(49, len(ev1.flanking_pairs))
         self.assertEqual(22, self.count_original_reads(ev1.split_reads[0]))
         self.assertEqual(14, self.count_original_reads(ev1.split_reads[1]))
 
@@ -152,6 +172,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
         self.assertEqual(4, self.count_original_reads(ev1.split_reads[0]))
         self.assertEqual(10, self.count_original_reads(ev1.split_reads[1]))
@@ -165,6 +186,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
         self.assertEqual(8, self.count_original_reads(ev1.split_reads[0]))
         self.assertEqual(9, self.count_original_reads(ev1.split_reads[1]))
@@ -178,6 +200,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
         self.assertEqual(20, self.count_original_reads(ev1.split_reads[0]))
         self.assertEqual(18, self.count_original_reads(ev1.split_reads[1]))
@@ -191,6 +214,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -208,6 +232,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -226,6 +251,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -244,6 +270,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
         self.assertEqual(20, self.count_original_reads(ev1.split_reads[0]))
         self.assertEqual(18, self.count_original_reads(ev1.split_reads[1]))
         self.assertEqual(0, len(ev1.spanning_reads))
@@ -256,6 +283,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -274,6 +302,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -292,6 +321,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -327,6 +357,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -344,6 +375,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -362,6 +394,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -384,6 +417,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -403,6 +437,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -420,6 +455,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -438,6 +474,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -456,6 +493,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
 
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
@@ -474,6 +512,7 @@ class TestFullEvidenceGathering(unittest.TestCase):
             opposing_strands=False
         )
         ev1.load_evidence()
+        self.print_evidence(ev1)
         print(len(ev1.spanning_reads))
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
         self.assertEqual(0, len(ev1.split_reads[0]))
@@ -603,14 +642,14 @@ class TestStandardizeRead(unittest.TestCase):
         read.query_sequence = 'TCAGCTCTCTTAGGGCACACCCTCCAAGGTGCCTAAATGCCATCCCAGGATTGGTTCCAGTGTCTATTATCTGTTTGACTCCAAATGGCCAAACACCTGACTTCCTCTCTGGTAGCCTGGCTTTTATCTTCTAGGACATCCAGGGCCCCTCTCTTTGCCTTCCCCTCTTTCTTCCTTCTACTGCTTCAGCAGACATCATGTG'
         read.reference_start = 224646710
         read.reference_id = 0
-        print(convert_string_to_cigar('183=12D19='))
-        read.cigar = join(convert_string_to_cigar('183=12D19='))
+        print(_cigar.convert_string_to_cigar('183=12D19='))
+        read.cigar = _cigar.join(_cigar.convert_string_to_cigar('183=12D19='))
         read.query_name = 'name'
         read.mapping_quality = NA_MAPPING_QUALITY
         std_read = Evidence.standardize_read(self.mock_evidence, read)
         print(SamRead.__repr__(read))
         print(SamRead.__repr__(std_read))
-        self.assertEqual(convert_string_to_cigar('186=12D16='), std_read.cigar)
+        self.assertEqual(_cigar.convert_string_to_cigar('186=12D16='), std_read.cigar)
         self.assertEqual(read.reference_start, std_read.reference_start)
 
 

--- a/tests/unit/test_bam.py
+++ b/tests/unit/test_bam.py
@@ -1,38 +1,79 @@
 import unittest
 
-from mavis.bam.cigar import merge_indels, merge_internal_events, QUERY_ALIGNED_STATES, extend_softclipping
-from mavis.bam.read import convert_events_to_softclipping
+from mavis.bam import cigar as _cigar
+from mavis.bam import read as _read
 from mavis.constants import CIGAR, ORIENT
 
-from .mock import Mock
+from .mock import Mock, MockFunction
+
+
+class TestPileUp(unittest.TestCase):
+
+    def mock_read(self, positions, **kwargs):
+        return Mock(get_reference_positions=MockFunction(positions), **kwargs)
+
+    def test_sparse_coverage(self):
+        reads = [
+            self.mock_read(range(0, 5)),
+            self.mock_read(range(20, 25))
+        ]
+        pileup = _read.pileup(reads)
+        expected = [(r, 1) for r in range(1, 6)] + [(r, 1) for r in range(21, 26)]
+        self.assertEqual(expected, pileup)
+
+    def test_dense_coverage(self):
+        reads = [
+            self.mock_read(range(0, 5)),
+            self.mock_read(range(0, 5)),
+            self.mock_read(range(1, 6)),
+            self.mock_read(range(2, 7)),
+            self.mock_read(range(3, 8)),
+            self.mock_read(range(1, 8))
+        ]
+        pileup = _read.pileup(reads)
+        expected = list(zip(range(1, 9), [2, 4, 5, 6, 6, 4, 3, 2]))
+        self.assertEqual(expected, pileup)
+
+    def test_filter_reads(self):
+        reads = [
+            self.mock_read(range(0, 5), mapping_quality=0),
+            self.mock_read(range(0, 5), mapping_quality=0),
+            self.mock_read(range(1, 6), mapping_quality=0),
+            self.mock_read(range(2, 7), mapping_quality=0),
+            self.mock_read(range(3, 8), mapping_quality=10),
+            self.mock_read(range(1, 8), mapping_quality=10)
+        ]
+        pileup = _read.pileup(reads, filter_func=lambda x: True if x.mapping_quality < 1 else False)
+        expected = list(zip(range(2, 9), [1, 1, 2, 2, 2, 2, 2]))
+        self.assertEqual(expected, pileup)
 
 
 class TestConvertEventsToSoftclipping(unittest.TestCase):
 
     def test_left_large_deletion(self):
         read = Mock(cigar=[(CIGAR.EQ, 10), (CIGAR.D, 10), (CIGAR.EQ, 40)], query_sequence='A' * 50)
-        converted = convert_events_to_softclipping(read, ORIENT.LEFT, 5, 5)
+        converted = _read.convert_events_to_softclipping(read, ORIENT.LEFT, 5, 5)
         self.assertEqual([(CIGAR.EQ, 10), (CIGAR.S, 40)], converted.cigar)
 
     def test_left_anchor_after_event(self):
         read = Mock(
             cigar=[(CIGAR.EQ, 4), (CIGAR.D, 10), (CIGAR.EQ, 40), (CIGAR.D, 10), (CIGAR.EQ, 6)], query_sequence='A' * 50)
-        converted = convert_events_to_softclipping(read, ORIENT.LEFT, 5, 5)
+        converted = _read.convert_events_to_softclipping(read, ORIENT.LEFT, 5, 5)
         self.assertEqual([(CIGAR.EQ, 4), (CIGAR.D, 10), (CIGAR.EQ, 40), (CIGAR.S, 6)], converted.cigar)
 
     def test_left_all_mismatch_error(self):
         read = Mock(cigar=[(CIGAR.X, 10), (CIGAR.D, 10), (CIGAR.X, 40)], query_sequence='A' * 50)
-        converted = convert_events_to_softclipping(read, ORIENT.LEFT, 5, 5)
+        converted = _read.convert_events_to_softclipping(read, ORIENT.LEFT, 5, 5)
         self.assertEqual(read, converted)
 
     def test_left_combined_small_events(self):
         read = Mock(cigar=[(CIGAR.EQ, 10), (CIGAR.D, 6), (CIGAR.I, 5), (CIGAR.EQ, 35)], query_sequence='A' * 50)
-        converted = convert_events_to_softclipping(read, ORIENT.LEFT, 10, 10)
+        converted = _read.convert_events_to_softclipping(read, ORIENT.LEFT, 10, 10)
         self.assertEqual([(CIGAR.EQ, 10), (CIGAR.S, 40)], converted.cigar)
 
     def test_right_large_deletion(self):
         read = Mock(cigar=[(CIGAR.EQ, 10), (CIGAR.D, 10), (CIGAR.EQ, 40)], query_sequence='A' * 50, reference_start=100)
-        converted = convert_events_to_softclipping(read, ORIENT.RIGHT, 5, 5)
+        converted = _read.convert_events_to_softclipping(read, ORIENT.RIGHT, 5, 5)
         self.assertEqual([(CIGAR.S, 10), (CIGAR.EQ, 40)], converted.cigar)
         self.assertEqual(read.reference_start + 20, converted.reference_start)
 
@@ -40,7 +81,7 @@ class TestConvertEventsToSoftclipping(unittest.TestCase):
         read = Mock(
             cigar=[(CIGAR.EQ, 6), (CIGAR.D, 10), (CIGAR.EQ, 40), (CIGAR.D, 10), (CIGAR.EQ, 4)],
             query_sequence='A' * 50, reference_start=100)
-        converted = convert_events_to_softclipping(read, ORIENT.RIGHT, 5, 5)
+        converted = _read.convert_events_to_softclipping(read, ORIENT.RIGHT, 5, 5)
         self.assertEqual([(CIGAR.S, 6), (CIGAR.EQ, 40), (CIGAR.D, 10), (CIGAR.EQ, 4)], converted.cigar)
         self.assertEqual(read.reference_start + 16, converted.reference_start)
 
@@ -51,13 +92,13 @@ class TestConvertEventsToSoftclipping(unittest.TestCase):
         read = Mock(cigar=cigar, query_sequence='A' * 365, reference_start=88217410)
 
         with self.assertRaises(NotImplementedError):
-            convert_events_to_softclipping(read, ORIENT.LEFT, 50, 50)
+            _read.convert_events_to_softclipping(read, ORIENT.LEFT, 50, 50)
 
         read.cigar = [(CIGAR.EQ if x == CIGAR.M else x, y) for x, y in read.cigar]
-        converted = convert_events_to_softclipping(read, ORIENT.LEFT, 50, 50)
+        converted = _read.convert_events_to_softclipping(read, ORIENT.LEFT, 50, 50)
         self.assertEqual([(CIGAR.EQ, 137), (CIGAR.S, 365 - 137)], converted.cigar)
 
-        converted = convert_events_to_softclipping(read, ORIENT.RIGHT, 50, 100)
+        converted = _read.convert_events_to_softclipping(read, ORIENT.RIGHT, 50, 100)
         self.assertEqual(read.cigar, converted.cigar)
 
     def test_multiple_events(self):
@@ -65,9 +106,9 @@ class TestConvertEventsToSoftclipping(unittest.TestCase):
             (CIGAR.EQ, 18), (CIGAR.X, 1), (CIGAR.EQ, 30), (CIGAR.D, 8146), (CIGAR.EQ, 10),
             (CIGAR.D, 62799), (CIGAR.EQ, 28), (CIGAR.D, 2), (CIGAR.EQ, 27), (CIGAR.S, 77)
         ]
-        l = sum([v for c, v in cigar if c in QUERY_ALIGNED_STATES])
+        l = sum([v for c, v in cigar if c in _cigar.QUERY_ALIGNED_STATES])
         read = Mock(cigar=cigar, query_sequence=('N' * l), reference_start=1000)
-        converted = convert_events_to_softclipping(read, ORIENT.RIGHT, 50, 50)
+        converted = _read.convert_events_to_softclipping(read, ORIENT.RIGHT, 50, 50)
         exp = [(CIGAR.S, 59), (CIGAR.EQ, 28), (CIGAR.D, 2), (CIGAR.EQ, 27), (CIGAR.S, 77)]
         self.assertEqual(exp, converted.cigar)
 
@@ -81,9 +122,9 @@ class TestConvertEventsToSoftclipping(unittest.TestCase):
             (4, 94), (7, 1), (8, 1), (7, 10), (8, 1), (7, 4), (1, 2), (7, 40),
             (4, 38 + 8 + 20 + 1 + 26 + 10 + 4)
         ]
-        l = sum([v for c, v in cigar if c in QUERY_ALIGNED_STATES])
+        l = sum([v for c, v in cigar if c in _cigar.QUERY_ALIGNED_STATES])
         read = Mock(cigar=cigar, query_sequence=('N' * l), reference_start=1000)
-        converted = convert_events_to_softclipping(read, ORIENT.LEFT, 50, 50)
+        converted = _read.convert_events_to_softclipping(read, ORIENT.LEFT, 50, 50)
         self.assertEqual(exp, converted.cigar)
 
 
@@ -91,24 +132,24 @@ class TestMergeIndels(unittest.TestCase):
 
     def test_no_events(self):
         c = [(CIGAR.EQ, 1)]
-        self.assertEqual(c, merge_indels(c))
+        self.assertEqual(c, _cigar.merge_indels(c))
 
         c = [(CIGAR.EQ, 1), (CIGAR.X, 3), (CIGAR.EQ, 10)]
-        self.assertEqual(c, merge_indels(c))
+        self.assertEqual(c, _cigar.merge_indels(c))
 
     def test_del_before_ins(self):
         c = [(CIGAR.EQ, 1), (CIGAR.D, 1), (CIGAR.I, 2), (CIGAR.EQ, 2)]
         exp = [(CIGAR.EQ, 1), (CIGAR.I, 2), (CIGAR.D, 1), (CIGAR.EQ, 2)]
-        self.assertEqual(exp, merge_indels(c))
+        self.assertEqual(exp, _cigar.merge_indels(c))
 
     def test_ins_before_del(self):
         exp = [(CIGAR.EQ, 1), (CIGAR.I, 2), (CIGAR.D, 1), (CIGAR.EQ, 2)]
-        self.assertEqual(exp, merge_indels(exp))
+        self.assertEqual(exp, _cigar.merge_indels(exp))
 
     def test_mixed(self):
         c = [(CIGAR.EQ, 1), (CIGAR.I, 2), (CIGAR.D, 1), (CIGAR.I, 2), (CIGAR.D, 1), (CIGAR.EQ, 2)]
         exp = [(CIGAR.EQ, 1), (CIGAR.I, 4), (CIGAR.D, 2), (CIGAR.EQ, 2)]
-        self.assertEqual(exp, merge_indels(c))
+        self.assertEqual(exp, _cigar.merge_indels(c))
 
 
 class TestMergeInternalEvents(unittest.TestCase):
@@ -117,51 +158,51 @@ class TestMergeInternalEvents(unittest.TestCase):
         c = [(CIGAR.EQ, 10), (CIGAR.X, 2), (CIGAR.EQ, 5), (CIGAR.D, 2), (CIGAR.EQ, 10)]
         exp = [(CIGAR.EQ, 10), (CIGAR.I, 7), (CIGAR.D, 9), (CIGAR.EQ, 10)]
 
-        self.assertEqual(c, merge_internal_events(c, 5))
-        self.assertEqual(exp, merge_internal_events(c, 6))
+        self.assertEqual(c, _cigar.merge_internal_events(c, 5))
+        self.assertEqual(exp, _cigar.merge_internal_events(c, 6))
 
     def test_mismatch_and_insertion(self):
         c = [(CIGAR.EQ, 10), (CIGAR.X, 2), (CIGAR.EQ, 5), (CIGAR.I, 2), (CIGAR.EQ, 10)]
         exp = [(CIGAR.EQ, 10), (CIGAR.I, 9), (CIGAR.D, 7), (CIGAR.EQ, 10)]
 
-        self.assertEqual(c, merge_internal_events(c, 5))
-        self.assertEqual(exp, merge_internal_events(c, 6))
+        self.assertEqual(c, _cigar.merge_internal_events(c, 5))
+        self.assertEqual(exp, _cigar.merge_internal_events(c, 6))
 
     def test_insertions(self):
         c = [(CIGAR.EQ, 10), (CIGAR.I, 2), (CIGAR.EQ, 5), (CIGAR.I, 2), (CIGAR.EQ, 10)]
         exp = [(CIGAR.EQ, 10), (CIGAR.I, 9), (CIGAR.D, 5), (CIGAR.EQ, 10)]
 
-        self.assertEqual(c, merge_internal_events(c, 5))
-        self.assertEqual(exp, merge_internal_events(c, 6))
+        self.assertEqual(c, _cigar.merge_internal_events(c, 5))
+        self.assertEqual(exp, _cigar.merge_internal_events(c, 6))
 
     def test_deletions(self):
         c = [(CIGAR.EQ, 10), (CIGAR.D, 2), (CIGAR.EQ, 5), (CIGAR.D, 2), (CIGAR.EQ, 10)]
         exp = [(CIGAR.EQ, 10), (CIGAR.I, 5), (CIGAR.D, 9), (CIGAR.EQ, 10)]
 
-        self.assertEqual(c, merge_internal_events(c, 5))
-        self.assertEqual(exp, merge_internal_events(c, 6))
+        self.assertEqual(c, _cigar.merge_internal_events(c, 5))
+        self.assertEqual(exp, _cigar.merge_internal_events(c, 6))
 
     def test_insertion_and_deletion(self):
         c = [(CIGAR.EQ, 10), (CIGAR.I, 2), (CIGAR.EQ, 5), (CIGAR.D, 2), (CIGAR.EQ, 10)]
         exp = [(CIGAR.EQ, 10), (CIGAR.I, 7), (CIGAR.D, 7), (CIGAR.EQ, 10)]
 
-        self.assertEqual(c, merge_internal_events(c, 5))
-        self.assertEqual(exp, merge_internal_events(c, 6))
+        self.assertEqual(c, _cigar.merge_internal_events(c, 5))
+        self.assertEqual(exp, _cigar.merge_internal_events(c, 6))
 
     def test_no_internal_events(self):
         c = [(CIGAR.EQ, 10), (CIGAR.EQ, 10)]
         exp = [(CIGAR.EQ, 20)]
 
-        self.assertEqual(exp, merge_internal_events(c, 10))
+        self.assertEqual(exp, _cigar.merge_internal_events(c, 10))
 
         c = [(CIGAR.X, 10), (CIGAR.EQ, 10)]
 
-        self.assertEqual(c, merge_internal_events(c, 10))
+        self.assertEqual(c, _cigar.merge_internal_events(c, 10))
 
     def test_single_internal_event(self):
         c = [(CIGAR.EQ, 10), (CIGAR.X, 5), (CIGAR.EQ, 10)]
 
-        self.assertEqual(c, merge_internal_events(c, 10))
+        self.assertEqual(c, _cigar.merge_internal_events(c, 10))
 
     def test_long_suffix_and_prefix(self):
         c = [
@@ -177,7 +218,7 @@ class TestMergeInternalEvents(unittest.TestCase):
             (CIGAR.I, 1 + 7 + 38 + 1 + 1 + 17 + 1 + 1), (CIGAR.D, 714 + 7 + 1 + 1 + 17 + 1 + 1 + 1),
             (CIGAR.EQ, 26), (CIGAR.D, 17), (CIGAR.EQ, 10), (CIGAR.S, 4)
         ]
-        actual = merge_internal_events(c, 20, 15)
+        actual = _cigar.merge_internal_events(c, 20, 15)
         print(c)
         print(actual)
         self.assertEqual(exp, actual)
@@ -188,33 +229,33 @@ class TestExtendSoftclipping(unittest.TestCase):
     def test_simple(self):
         self.assertEqual(
             ([(CIGAR.S, 10), (CIGAR.M, 10)], 0),
-            extend_softclipping([(CIGAR.S, 10), (CIGAR.M, 10)], 1)
+            _cigar.extend_softclipping([(CIGAR.S, 10), (CIGAR.M, 10)], 1)
         )
 
     def test_deletions(self):
         self.assertEqual(
             ([(CIGAR.S, 10), (CIGAR.M, 10)], 1),
-            extend_softclipping([(CIGAR.I, 10), (CIGAR.D, 1), (CIGAR.M, 10)], 1)
+            _cigar.extend_softclipping([(CIGAR.I, 10), (CIGAR.D, 1), (CIGAR.M, 10)], 1)
         )
 
     def test_mismatch(self):
         with self.assertRaises(AttributeError):
-            extend_softclipping([(CIGAR.X, 10), (CIGAR.M, 20), (CIGAR.X, 10)], 30)
+            _cigar.extend_softclipping([(CIGAR.X, 10), (CIGAR.M, 20), (CIGAR.X, 10)], 30)
 
     def test_insert(self):
         self.assertEqual(
             ([(CIGAR.S, 17), (CIGAR.M, 10), (CIGAR.S, 5)], 2),
-            extend_softclipping([(CIGAR.S, 10), (CIGAR.M, 2), (CIGAR.I, 5), (CIGAR.M, 10), (CIGAR.I, 5)], 5)
+            _cigar.extend_softclipping([(CIGAR.S, 10), (CIGAR.M, 2), (CIGAR.I, 5), (CIGAR.M, 10), (CIGAR.I, 5)], 5)
         )
 
     def test_hardclipping(self):
         c = [(CIGAR.H, 10), (CIGAR.EQ, 10)]
-        cnew, prefix = extend_softclipping(c, 1)
+        cnew, prefix = _cigar.extend_softclipping(c, 1)
         self.assertEqual(0, prefix)
         self.assertEqual(c, cnew)
 
     def test_hardclipping_right(self):
         c = [(CIGAR.EQ, 30), (CIGAR.H, 120)]
-        cnew, prefix = extend_softclipping(c, 6)
+        cnew, prefix = _cigar.extend_softclipping(c, 6)
         self.assertEqual(0, prefix)
         self.assertEqual(c, cnew)


### PR DESCRIPTION
New features
- ymax and stranded options for overlay diagram read depth plots
- clean up option for aligner output files
- write option for outputting evidence bams, bed files etc (can be turned off now)

Improvements
- Producing products for exact calls where untemplated sequence was not resolved by assuming it is empty
- Caching less transcriptome reads to reduce memory footprint

Bugfixes
- (minor) improved resolve by split reads, previously was not resolving unstranded calls because it was assuming the strands represented different resolutions