### PR TITLE
v1.6.8 release: transcriptome config generation BugFix

### DIFF
--- a/mavis/config.py
+++ b/mavis/config.py
@@ -558,11 +558,10 @@ def generate_config(args, parser, log=devnull):
     if SUBCOMMAND.VALIDATE not in args.skip_stage:
         # load the annotations if we need them
         if any([l.is_trans() for l in libs]):
-            if not args.get('annotations'):
+            if not args.get('annotations_filename'):
                 parser.error('argument --annotations: is required to gather bam stats for transcriptome libraries')
-            log('loading the reference annotations file', args.annotations)
-            args.annotations_filename = args.annotations
-            args.annotations = load_annotations(args.annotations)
+            log('loading the reference annotations file', args.annotations_filename)
+            args.annotations = load_annotations(args.annotations_filename)
         for i, libconf in enumerate(libs):
             log('generating the config section for:', libconf.library)
             libs[i] = LibraryConfig.build(

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 import re
 
 
-VERSION = '1.6.7'
+VERSION = '1.6.8'
 
 
 def parse_md_readme():
@@ -13,7 +13,7 @@ def parse_md_readme():
     try:
         from m2r import parse_from_file
         rst_lines = parse_from_file('README.md').split('\n')
-        long_description = ['.. image:: http://mavis.bcgsc.ca/docs/latest/_static/acronym.svg\n']  # backup since pip can't handle raw directives
+        long_description = ['.. image:: http://mavis.bcgsc.ca/docs/latest/_static/acronym.svg\n\n']  # backup since pip can't handle raw directives
         i = 0
         while i < len(rst_lines):
             if re.match(r'^..\s+raw::.*', rst_lines[i]):
@@ -21,7 +21,7 @@ def parse_md_readme():
                 while re.match(r'^(\s\s+|\t|$).*', rst_lines[i]):
                     i += 1
             else:
-                long_description.append(rst_lines[i])
+                long_description.append(re.sub('>`_ ', '>`__ ', rst_lines[i]))  # anonymous links
                 i += 1
         long_description = '\n'.join(long_description)
     except (ImportError, OSError):


### PR DESCRIPTION
BugFixes
- fixed bug in auto-generating configs where transcriptomes did not work. Was trying to load the annotations from the annotations argument after it had been renames to annotations_filename. This is because this function used to skip the rename prior to the subparsers improvements. A test has been added to ensure this will not be missed again