### PR TITLE
v1.6.9: fix for single bp exon drawings

### DIFF
--- a/docs/source/pipeline.rst
+++ b/docs/source/pipeline.rst
@@ -54,11 +54,11 @@ This will create submission scripts as follows
 
     output_dir/
     |-- library1/
-    |   |-- validation/<jobdir>/submit.sh
-    |   `-- annotation/<jobdir>/submit.sh
+    |   |-- validate/<jobdir>/submit.sh
+    |   `-- annotate/<jobdir>/submit.sh
     |-- library2/
-    |   |-- validation/<jobdir>/submit.sh
-    |   `-- annotation/<jobdir>/submit.sh
+    |   |-- validate/<jobdir>/submit.sh
+    |   `-- annotate/<jobdir>/submit.sh
     |-- pairing/submit.sh
     |-- summary/submit.sh
     `-- submit_pipeline_<batchid>.sh

--- a/mavis/annotate/fusion.py
+++ b/mavis/annotate/fusion.py
@@ -160,7 +160,8 @@ class FusionTranscript(PreTranscript):
                 exon = Exon(
                     novel_exon_start, novel_exon_end, fusion_pre_transcript,
                     intact_start_splice=False,
-                    intact_end_splice=False
+                    intact_end_splice=False,
+                    seq=fusion_pre_transcript.seq[novel_exon_start - 1:novel_exon_end]
                 )
                 fusion_pre_transcript.exons.append(exon)
         fusion_pre_transcript.seq += seq2
@@ -168,7 +169,8 @@ class FusionTranscript(PreTranscript):
             exon = Exon(
                 ex.start + offset, ex.end + offset, fusion_pre_transcript,
                 intact_start_splice=ex.start_splice_site.intact,
-                intact_end_splice=ex.end_splice_site.intact
+                intact_end_splice=ex.end_splice_site.intact,
+                seq=ex.seq
             )
             fusion_pre_transcript.exons.append(exon)
             fusion_pre_transcript.exon_mapping[exon.position] = old_ex
@@ -221,7 +223,8 @@ class FusionTranscript(PreTranscript):
                 e = Exon(
                     novel_exon_start, novel_exon_end, fusion_pre_transcript,
                     intact_start_splice=False,
-                    intact_end_splice=False
+                    intact_end_splice=False,
+                    seq=fusion_pre_transcript.seq[novel_exon_start - 1:novel_exon_end]
                 )
                 fusion_pre_transcript.exons.append(e)
 
@@ -229,7 +232,8 @@ class FusionTranscript(PreTranscript):
             e = Exon(
                 ex.start + offset, ex.end + offset, fusion_pre_transcript,
                 intact_start_splice=ex.start_splice_site.intact,
-                intact_end_splice=ex.end_splice_site.intact
+                intact_end_splice=ex.end_splice_site.intact,
+                seq=ex.seq
             )
             fusion_pre_transcript.exons.append(e)
             fusion_pre_transcript.exon_mapping[e.position] = old_ex
@@ -348,14 +352,16 @@ class FusionTranscript(PreTranscript):
                     e = Exon(
                         novel_exon_start, novel_exon_end, fusion_pre_transcript,
                         intact_start_splice=False,
-                        intact_end_splice=False
+                        intact_end_splice=False,
+                        seq=fusion_pre_transcript.seq[novel_exon_start - 1:novel_exon_end]
                     )
                     fusion_pre_transcript.exons.append(e)
             for ex, old_ex in ex2:
                 e = Exon(
                     ex.start + offset, ex.end + offset, fusion_pre_transcript,
                     intact_start_splice=ex.start_splice_site.intact,
-                    intact_end_splice=ex.end_splice_site.intact
+                    intact_end_splice=ex.end_splice_site.intact,
+                    seq=ex.seq
                 )
                 fusion_pre_transcript.exons.append(e)
                 fusion_pre_transcript.exon_mapping[e.position] = old_ex
@@ -461,6 +467,7 @@ class FusionTranscript(PreTranscript):
                         strand=STRAND.POS
                     )
                     temp = reference_sequence[exon.start - 1:t]
+                    e.seq = str(temp)
                     s += temp
                     new_exons.append((e, exon))
         elif breakpoint.orient == ORIENT.RIGHT:  # three prime
@@ -483,6 +490,7 @@ class FusionTranscript(PreTranscript):
                         strand=STRAND.POS
                     )
                     temp = reference_sequence[exon.start - 1:exon.end]
+                    e.seq = str(temp)
                     assert len(temp) == len(e)
                     s += temp
                     new_exons.append((e, exon))
@@ -498,6 +506,7 @@ class FusionTranscript(PreTranscript):
                         intact_end_splice=intact_end_splice,
                         strand=STRAND.POS
                     )
+                    e.seq = str(temp)
                     s += temp
                     new_exons.append((e, exon))
         else:

--- a/mavis/illustrate/constants.py
+++ b/mavis/illustrate/constants.py
@@ -40,13 +40,14 @@ DEFAULTS.add('gene2_color', '#325556', defn='The color of genes near the second 
 DEFAULTS.add('label_color', '#000000', defn='The label color')
 DEFAULTS.add('domain_color', '#ccccb3', defn='Domain fill color')
 DEFAULTS.add('domain_mismatch_color', '#b2182b', defn='Domain fill color on 0%% match')
-DEFAULTS.add('novel_exon_color', '#000000', defn='Novel Exon fill color')
+DEFAULTS.add('novel_exon_color', '#5D3F6A', defn='Novel Exon fill color')
 DEFAULTS.add('splice_color', '#000000', defn='Splicing lines color')
 DEFAULTS.add('breakpoint_color', '#000000', defn='Breakpoint outline color')
 DEFAULTS.add('mask_fill', '#ffffff', defn='Color of mask (for deleted region etc.)')
 DEFAULTS.add('mask_opacity', 0.7, defn='opacity of the mask layer', cast_type=float_fraction)
 DEFAULTS.add('domain_scaffold_color', '#000000', defn='The color of the domain scaffold')
 DEFAULTS.add('drawing_width_iter_increase', 500, defn='The amount (in  pixels) by which to increase the drawing width upon failure to fit')
+DEFAULTS.add('exon_min_focus_size', 10, defn='minimum size of an exon for it to be granted a label or min exon width')
 
 
 class DiagramSettings:
@@ -73,13 +74,15 @@ class DiagramSettings:
         self.padding = 5
         self.scaffold_height = 3
         self.track_height = 50
+
+        self.ins_increase = 6
         # removing unsupported attr: 'alignment-baseline:central;dominant-baseline:central;' \
         self.font_style = 'font-size:{font_size}px;font-weight:bold;alignment-baseline:baseline;' \
             'text-anchor:{text_anchor};font-family: consolas, courier new, monospace'
         # ratio for courier new which is wider than consolas, used for estimating width
         self.font_width_height_ratio = 1229 / 2048
         self.font_central_shift_ratio = 0.3
-        self.abs_min_width = 0.01
+        self.non_focus_min_width = 2
 
         self.gene_default_color = self.gene1_color
         self.gene_min_buffer = 1000

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 import re
 
 
-VERSION = '1.6.8'
+VERSION = '1.6.9'
 
 
 def parse_md_readme():


### PR DESCRIPTION
BugFixes:
- fixed interval error for single bp exon/insertion drawings

New Features
- small insertions/novel exons are now drawn taller than the surrounding exons
- small exons are not labelled and therefore not required to be the min object size
- added the new configurable drawing parameter `exon_min_focus_size` to determine a 'small' exon
- 'small' exons in the fusion transcript add the sequence to their labels