### PR TITLE
#86: catching the empty file error

### DIFF
--- a/mavis/blat.py
+++ b/mavis/blat.py
@@ -341,7 +341,10 @@ def process_blat_output(
     if is_protein:
         raise NotImplementedError('currently does not support aligning protein sequences')
 
-    _, rows = Blat.read_pslx(aligner_output_file, query_id_mapping, is_protein=is_protein)
+    try:
+        _, rows = Blat.read_pslx(aligner_output_file, query_id_mapping, is_protein=is_protein)
+    except tab.tab.EmptyFileError:
+        rows = []
 
     # split the rows by query id
     rows_by_query = {}

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ os.environ['HTSLIB_CONFIGURE_OPTIONS'] = '--disable-lzma'  # only required for C
 
 setup(
     name='mavis',
-    version='1.5.2',
+    version='1.5.3',
     url='https://github.com/bcgsc/mavis.git',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
Bug Fixes
- Catch the empty file error thrown when no alignments are produced by blat