### PR TITLE
v1.8.1

### DIFF
--- a/mavis/constants.py
+++ b/mavis/constants.py
@@ -125,7 +125,7 @@ class MavisNamespace(argparse.Namespace):
             ....
         """
         if value not in self.values():
-            raise KeyError('value {0} is not a valid member'.format(value), self.values())
+            raise KeyError('value {0} is not a valid member of '.format(repr(value)), self.values())
         return value
 
     def reverse(self, value):
@@ -220,11 +220,11 @@ class MavisNamespace(argparse.Namespace):
             >>> nspace.add('thing', value=1, cast_type=int, defn='I am a thing')
         """
         if len(pos) > 1:
-            raise TypeError('add() takes 3 positional arguments but more were given')
+            raise TypeError('add({}) takes 3 positional arguments but more were given'.format(', '.join([str(p) for p in pos])))
 
         for value, argname in zip(pos, ['value', 'cast_type', 'defn'][:len(pos)]):
             if argname in kwargs:
-                raise TypeError('add() got multiple values for argument {}'.format(repr(argname)))
+                raise TypeError('add({}, ...) got multiple values for argument {}'.format(attr, repr(argname)))
             kwargs['value'] = pos[0]
         value = kwargs.pop('value', attr)
         self[attr] = value
@@ -235,14 +235,14 @@ class MavisNamespace(argparse.Namespace):
         if 'defn' in kwargs:
             self._defns[attr] = kwargs.pop('defn')
         if kwargs:
-            raise TypeError('invalid arguments: {}'.format(kwargs.keys()))
+            raise TypeError('invalid arguments for {}: {}'.format(attr, kwargs.keys()))
 
     def __call__(self, value):
         try:
             return self.enforce(value)
         except KeyError:
-            raise TypeError('Invalid value {}. Cannot cast to type {}. Must be a valid member: {}'.format(
-                repr(value), self.__class__.__name__, self.values()))
+            raise TypeError('Invalid value {} for {}. Cannot cast to type {}. Must be a valid member: {}'.format(
+                repr(value), attr, self.__class__.__name__, self.values()))
 
 
 def float_fraction(num):

--- a/mavis/submit.py
+++ b/mavis/submit.py
@@ -41,7 +41,7 @@ OPTIONS.add('validation_memory', 16000, defn='default memory limit (MB) for the 
 OPTIONS.add('trans_validation_memory', 18000, defn='default memory limit (MB) for the validation stage (for transcriptomes)')
 OPTIONS.add('annotation_memory', 12000, defn='default memory limit (MB) for the annotation stage')
 OPTIONS.add('scheduler', SCHEDULER.SLURM, defn='The scheduler being used', cast_type=SCHEDULER)
-OPTIONS.add('mail_type', '', cast_type=MAIL_TYPE.enforce, defn='When to notify the mail_user (if given)')
+OPTIONS.add('mail_type', 'NONE', cast_type=MAIL_TYPE.enforce, defn='When to notify the mail_user (if given)')
 OPTIONS.add('mail_user', '', defn='User to send notifications to')
 
 

--- a/mavis/util.py
+++ b/mavis/util.py
@@ -20,24 +20,6 @@ from .interval import Interval
 ENV_VAR_PREFIX = 'MAVIS_'
 
 
-def assert_equal_attributes(attrs, iterable):
-    """
-    check that a set of items have equal values for some number of attributes.
-    """
-    if not iterable:
-        raise ValueError('cannot operate on an empty iterable')
-    result = MavisNamespace()
-    for attr in attrs:
-        value = None
-        for item in iterable:
-            if value is None:
-                value = getattr(item, attr)
-            elif value != getattr(item, attr):
-                raise AssertionError('input items differ on value of attribute {}: {} vs {}'.format(attr, value, getattr(item, attr)))
-        result[attr] = value
-    return result
-
-
 def cast(value, cast_func):
     """
     cast a value to a given type

--- a/mavis/validate/base.py
+++ b/mavis/validate/base.py
@@ -702,7 +702,8 @@ class Evidence(BreakpointPair):
 
             ctg_reads = {r.query_sequence for r in ctg.input_reads}
             ctg_reads.update({reverse_complement(r) for r in ctg_reads})
-            if ctg_reads & break1_reads and ctg_reads & break2_reads:
+            if (ctg_reads & break1_reads and ctg_reads & break2_reads) or \
+                    (not self.interchromosomal and len(self.break1 | self.break2) < self.read_length):
                 filtered_contigs.append(ctg)
         log('filtered contigs from {} to {} based on remapped reads from both breakpoints'.format(len(contigs), len(filtered_contigs)), time_stamp=False)
         contigs = filtered_contigs

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 import re
 
 
-VERSION = '1.8.0'
+VERSION = '1.8.1'
 
 
 def parse_md_readme():

--- a/tests/end_to_end/__init__.py
+++ b/tests/end_to_end/__init__.py
@@ -13,3 +13,10 @@ def glob_exists(*pos, strict=True, n=1):
         print(globexpr)
         print(file_list)
         return False
+
+
+DATA_PREFIX = os.path.join(os.path.dirname(__file__), 'data')
+
+
+def data(*path):
+    return os.path.join(DATA_PREFIX, *path)

--- a/tests/end_to_end/data/bwa_pipeline_config.cfg
+++ b/tests/end_to_end/data/bwa_pipeline_config.cfg
@@ -67,7 +67,7 @@ median_fragment_size = 188
 stdev_fragment_size = 50
 bam_file = tests/integration/data/mock_trans_reads_for_events.sorted.bam
 protocol = transcriptome
-inputs = tests/integration/data/mock_sv_events.tsv
+inputs = tests/integration/data/mock_trans_sv_events.tsv
 strand_specific = True
 disease_status=diseased
 

--- a/tests/end_to_end/data/clean_pipeline_config.cfg
+++ b/tests/end_to_end/data/clean_pipeline_config.cfg
@@ -69,7 +69,7 @@ median_fragment_size = 188
 stdev_fragment_size = 50
 bam_file = tests/integration/data/mock_trans_reads_for_events.sorted.bam
 protocol = transcriptome
-inputs = tests/integration/data/mock_sv_events.tsv
+inputs = tests/integration/data/mock_trans_sv_events.tsv
 strand_specific = True
 disease_status=diseased
 

--- a/tests/end_to_end/data/missing_reference.cfg
+++ b/tests/end_to_end/data/missing_reference.cfg
@@ -63,7 +63,7 @@ median_fragment_size = 188
 stdev_fragment_size = 50
 bam_file = tests/integration/data/mock_trans_reads_for_events.sorted.bam
 protocol = transcriptome
-inputs = mock_converted
+inputs = tests/integration/data/mock_trans_sv_events.tsv
 strand_specific = True
 disease_status=diseased
 

--- a/tests/end_to_end/data/no_opt_pipeline.cfg
+++ b/tests/end_to_end/data/no_opt_pipeline.cfg
@@ -64,7 +64,7 @@ median_fragment_size = 188
 stdev_fragment_size = 50
 bam_file = tests/integration/data/mock_trans_reads_for_events.sorted.bam
 protocol = transcriptome
-inputs = mock_converted
+inputs = tests/integration/data/mock_trans_sv_events.tsv
 strand_specific = True
 disease_status=diseased
 

--- a/tests/end_to_end/data/pipeline_config.cfg
+++ b/tests/end_to_end/data/pipeline_config.cfg
@@ -67,7 +67,7 @@ median_fragment_size = 188
 stdev_fragment_size = 50
 bam_file = tests/integration/data/mock_trans_reads_for_events.sorted.bam
 protocol = transcriptome
-inputs = mock_converted
+inputs = tests/integration/data/mock_trans_sv_events.tsv
 strand_specific = True
 disease_status=diseased
 

--- a/tests/end_to_end/test_convert.py
+++ b/tests/end_to_end/test_convert.py
@@ -114,6 +114,9 @@ class TestConvert(unittest.TestCase):
     def test_cnvnator(self):
         self.run_main(os.path.join(DATA_PREFIX, 'cnvnator.tab'), SUPPORTED_TOOL.CNVNATOR, False)
 
+    def test_breakdancer(self):
+        self.run_main(os.path.join(DATA_PREFIX, 'breakdancer_output.txt'), SUPPORTED_TOOL.BREAKDANCER, False)
+
 
 def tearDownModule():
     # remove the temp directory and outputs

--- a/tests/end_to_end/test_full_pipeline.py
+++ b/tests/end_to_end/test_full_pipeline.py
@@ -11,13 +11,7 @@ from mavis.constants import SUBCOMMAND
 from mavis.main import main
 from mavis.util import unique_exists
 
-from . import glob_exists
-
-DATA_PREFIX = os.path.join(os.path.dirname(__file__), 'data')
-
-
-def data(*path):
-    return os.path.join(DATA_PREFIX, *path)
+from . import glob_exists, data
 
 
 CONFIG = data('pipeline_config.cfg')

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -229,7 +229,6 @@ def mock_read_pair(mock1, mock2):
     mock1.next_reference_start = mock2.reference_start
     mock1.mate_is_reverse = mock2.is_reverse
     mock1.is_paired = True
-    mock1.is_read1 = True
     mock1.is_read2 = not mock1.is_read1
     if mock1.template_length is None:
         mock1.template_length = mock2.reference_end - mock1.reference_start

--- a/tests/integration/data/mock_sv_events.tsv
+++ b/tests/integration/data/mock_sv_events.tsv
@@ -24,11 +24,7 @@ False	reference1	2000	2000	reference1	2001	2001	L	R	+	+	insertion	genome	convert
 False	reference16	2000	2000	reference16	2001	2001	L	R	+	+	insertion	genome	convert_ta.py_v0.0.1	mock-A36971	16:57847634
 False	reference12	10000	10000	reference12	10001	10021	R	L	+	+	duplication	genome	convert_ta.py_v0.0.1	mock-A36971	12:53207583 reported as an insertion
 False	reference17	1974	1974	reference17	2020	2020	R	L	+	+	duplication	genome	convert_ta.py_v0.0.1	mock-A36971	17:72889676 reported as an insertion
-False	gene3	27175	27175	gene3	27176	27176	R	L	+	+	duplication	transcriptome	convert_ta.py_v0.0.1	mock-A47933	1:207249992
 False	gene3	27175	27175	gene3	27176	27176	R	L	+	+	duplication	genome	convert_ta.py_v0.0.1	mock-A36971	1:207249992
-True	gene1	34090	34090	gene5	608	608	R	R	-	+	inverted translocation	transcriptome	convert_ta.py_v0.0.1	mock-A47933	15:40854971|7:26241389
 False	gene5	608	608	gene1	33309	33309	R	R	+	-	inverted translocation	genome	convert_ta.py_v0.0.1	mock-A36971	7:26252971|15:40854190
-False	gene2	22979	22979	gene2	23783	23783	R	L	+	+	duplication	transcriptome	convert_ta.py_v0.0.1	mock-A47933	15:41623873|15:41625248#this one is pretty low qual
 False	gene2	19827	19827	gene2	27045	27045	R	L	+	+	duplication	genome	convert_ta.py_v0.0.1	mock-A36971	15:41621292|15:41628510
 False	gene6	77430	77430	gene6	89472	89472	L	R	+	+	deletion	genome	convert_ta.py_v0.0.1	mock-A36971	10:89700299|10:89712341
-False	gene6	70057	77430	gene6	89472	94742	L	R	+	+	deletion	transcriptome	convert_ta.py_v0.0.1	mock-A47933	approx 10:89700299|10:89712341

--- a/tests/integration/data/mock_trans_sv_events.tsv
+++ b/tests/integration/data/mock_trans_sv_events.tsv
@@ -1,0 +1,6 @@
+## False	reference9	2000	2000	reference9	2001	2001	L	R	+	+	insertion	genome	convert_ta.py_v0.0.1	mock-A36971	9:66466004
+#stranded	break1_chromosome	break1_position_start	break1_position_end	break2_chromosome	break2_position_start	break2_position_end	break1_orientation	break2_orientation	break1_strand	break2_strand	event_type	protocol	tools	library	comment
+False	gene3	27175	27175	gene3	27176	27176	R	L	+	+	duplication	transcriptome	convert_ta.py_v0.0.1	mock-A47933	1:207249992
+True	gene1	34090	34090	gene5	608	608	R	R	-	+	inverted translocation	transcriptome	convert_ta.py_v0.0.1	mock-A47933	15:40854971|7:26241389
+False	gene2	22979	22979	gene2	23783	23783	R	L	+	+	duplication	transcriptome	convert_ta.py_v0.0.1	mock-A47933	15:41623873|15:41625248#this one is pretty low qual
+False	gene6	70057	77430	gene6	89472	94742	L	R	+	+	deletion	transcriptome	convert_ta.py_v0.0.1	mock-A47933	approx 10:89700299|10:89712341

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,0 +1,63 @@
+import unittest
+from unittest.mock import mock_open, patch
+import configparser
+
+from mavis.config import MavisConfig
+
+
+STUB = """
+[reference]
+template_metadata = tests/integration/data/cytoBand.txt
+annotations = tests/integration/data/mock_annotations.json
+masking = tests/integration/data/mock_masking.tab
+reference_genome = tests/integration/data/mock_reference_genome.fa
+aligner_reference = tests/integration/data/mock_reference_genome.2bit
+dgv_annotation = tests/integration/data/mock_dgv_annotation.txt
+
+[mock-A36971]
+read_length = 150
+median_fragment_size = 400
+stdev_fragment_size = 97
+bam_file = tests/integration/data/mock_reads_for_events.sorted.bam
+protocol = genome
+inputs = mock_converted
+strand_specific = False
+disease_status=diseased
+
+[mock-A47933]
+read_length = 75
+median_fragment_size = 188
+stdev_fragment_size = 50
+bam_file = tests/integration/data/mock_trans_reads_for_events.sorted.bam
+protocol = transcriptome
+inputs = mock_converted
+strand_specific = True
+disease_status=diseased
+
+[convert]
+assume_no_untemplated = True
+# addfile twice to check this notation is ok (will collapse them anyway)
+mock_converted = convert_tool_output
+    tests/integration/data/mock_sv_events.tsv
+    tests/integration/data/mock_sv_events.tsv
+    mavis
+    False
+"""
+
+
+class TestConfig(unittest.TestCase):
+
+    def mock_config(self, content=""):
+        with patch('configparser.ConfigParser.read', configparser.ConfigParser.read_string), patch('os.path.isfile') as isfile, patch('os.path.exists') as exists:
+            isfile.return_value = True
+            exists.return_value = True
+            return MavisConfig.read(content)
+
+    def test_error_in_schedule(self):
+        with self.assertRaises(ValueError):
+            content = STUB + '\n[schedule]\nmail_type=\n'
+            print(content)
+            self.mock_config(content)
+
+    def test_ok(self):
+        self.mock_config(STUB)

--- a/tests/integration/test_validate_call.py
+++ b/tests/integration/test_validate_call.py
@@ -5,7 +5,7 @@ from mavis.align import call_paired_read_event, select_contig_alignments
 from mavis.annotate.file_io import load_reference_genome
 from mavis.annotate.genomic import PreTranscript, Transcript
 from mavis.bam.cache import BamCache
-from mavis.bam.read import sequenced_strand, SamRead
+from mavis.bam.read import sequenced_strand, SamRead, read_pair_type
 from mavis.bam.cigar import convert_string_to_cigar
 from mavis.breakpoint import Breakpoint, BreakpointPair
 from mavis.constants import CALL_METHOD, CIGAR, ORIENT, PYSAM_READ_FLAGS, STRAND, SVTYPE
@@ -1033,16 +1033,17 @@ class TestCallByFlankingReadsTranscriptome(unittest.TestCase):
         )
         # now add the flanking pairs
         pair = mock_read_pair(
-            MockRead('name', '1', 951, 1051, is_reverse=True, query_alignment_length=50),
-            MockRead('name', '1', 2299, 2399, is_reverse=False, query_alignment_length=50)
+            MockRead('name', '1', 951, 1051, is_reverse=False, query_alignment_length=50, is_read1=False),
+            MockRead('name', '1', 2299, 2399, is_reverse=True, query_alignment_length=50)
         )
+        print(read_pair_type(pair[0]))
         # following help in debugging the mockup
-        self.assertTrue(pair[0].is_reverse)
-        self.assertTrue(pair[0].is_read1)
-        self.assertFalse(pair[0].is_read2)
-        self.assertFalse(pair[1].is_reverse)
-        self.assertFalse(pair[1].is_read1)
-        self.assertTrue(pair[1].is_read2)
+        self.assertFalse(pair[0].is_reverse)
+        self.assertFalse(pair[0].is_read1)
+        self.assertTrue(pair[0].is_read2)
+        self.assertTrue(pair[1].is_reverse)
+        self.assertTrue(pair[1].is_read1)
+        self.assertFalse(pair[1].is_read2)
         self.assertEqual(STRAND.POS, sequenced_strand(pair[0], 2))
         self.assertEqual(STRAND.POS, evidence.decide_sequenced_strand([pair[0]]))
         self.assertEqual(STRAND.POS, sequenced_strand(pair[1], 2))


### PR DESCRIPTION
Improvements
- Better error messages for config validation errors
- Set 0mq only for non-best blat alignments (even when multiple tie)
- merge data columns when collapsing bpps read from tools
- collect extra breakdancer columns
- greedy algorithm to remove fragment size outliers during call by flanking pairs to avoid coverage too large errors and allow more calls