### PR TITLE
v1.8.3

### DIFF
--- a/mavis/breakpoint.py
+++ b/mavis/breakpoint.py
@@ -419,6 +419,50 @@ class BreakpointPair:
 
         return ''.join(first_seq).upper(), ''.join(second_seq).upper()
 
+    def untemplated_shift(self, reference_genome):
+        """gives a range for each breakpoint on the possible alignment range in the shifting the untemplated
+        sequence"""
+        if any([
+            self.untemplated_seq is None,
+            len(self.break1) + len(self.break2) > 2,
+            self.break1.orient == ORIENT.NS,
+            self.break2.orient == ORIENT.NS
+        ]):
+            raise AttributeError('Cannot calculate the shift for non specific breakpoint calls', self)
+        lutemp = len(self.untemplated_seq)
+        break1_shift = 0
+        if self.break1.orient == ORIENT.LEFT:
+            break1_seq = reference_genome[self.break1.chr].seq[self.break1.start - lutemp: self.break1.start]
+            for i in range(1, lutemp + 1):
+                if break1_seq[lutemp - i] == self.untemplated_seq[lutemp - i]:
+                    break1_shift += 1
+                else:
+                    break
+        else:
+            break1_seq = reference_genome[self.break1.chr].seq[self.break1.start - 1: self.break1.start + lutemp - 1]
+            for i in range(0, lutemp):
+                if break1_seq[i] == self.untemplated_seq[i]:
+                    break1_shift += 1
+                else:
+                    break
+
+        break2_shift = 0
+        if self.break2.orient == ORIENT.LEFT:
+            break2_seq = reference_genome[self.break2.chr].seq[self.break2.start - lutemp: self.break2.start]
+            for i in range(1, lutemp + 1):
+                if break2_seq[lutemp - i] == self.untemplated_seq[lutemp - i]:
+                    break2_shift += 1
+                else:
+                    break
+        else:
+            break2_seq = reference_genome[self.break2.chr].seq[self.break2.start - 1: self.break2.start + lutemp - 1]
+            for i in range(0, lutemp):
+                if break2_seq[i] == self.untemplated_seq[i]:
+                    break2_shift += 1
+                else:
+                    break
+        return (break2_shift, break1_shift)
+
     def get_bed_repesentation(self):
         bed = []
         if self.interchromosomal:

--- a/mavis/breakpoint.py
+++ b/mavis/breakpoint.py
@@ -419,6 +419,30 @@ class BreakpointPair:
 
         return ''.join(first_seq).upper(), ''.join(second_seq).upper()
 
+    @staticmethod
+    def _breakpoint_utemp_shift(breakpoint, untemplated_seq, reference_genome):
+        """
+        Calculates the amount of the untemplated sequence that could be aligned further.
+        Gives an idea of how much different alignments might differ.
+        """
+        break_shift = 0
+        lutemp = len(untemplated_seq)
+        if breakpoint.orient == ORIENT.LEFT:
+            break_seq = reference_genome[breakpoint.chr].seq[breakpoint.start - lutemp: breakpoint.start]
+            for i in range(1, lutemp + 1):
+                if break_seq[lutemp - i] == untemplated_seq[lutemp - i]:
+                    break_shift += 1
+                else:
+                    break
+        else:
+            break_seq = reference_genome[breakpoint.chr].seq[breakpoint.start - 1: breakpoint.start + lutemp - 1]
+            for i in range(0, lutemp):
+                if break_seq[i] == untemplated_seq[i]:
+                    break_shift += 1
+                else:
+                    break
+        return break_shift
+
     def untemplated_shift(self, reference_genome):
         """gives a range for each breakpoint on the possible alignment range in the shifting the untemplated
         sequence"""
@@ -429,38 +453,8 @@ class BreakpointPair:
             self.break2.orient == ORIENT.NS
         ]):
             raise AttributeError('Cannot calculate the shift for non specific breakpoint calls', self)
-        lutemp = len(self.untemplated_seq)
-        break1_shift = 0
-        if self.break1.orient == ORIENT.LEFT:
-            break1_seq = reference_genome[self.break1.chr].seq[self.break1.start - lutemp: self.break1.start]
-            for i in range(1, lutemp + 1):
-                if break1_seq[lutemp - i] == self.untemplated_seq[lutemp - i]:
-                    break1_shift += 1
-                else:
-                    break
-        else:
-            break1_seq = reference_genome[self.break1.chr].seq[self.break1.start - 1: self.break1.start + lutemp - 1]
-            for i in range(0, lutemp):
-                if break1_seq[i] == self.untemplated_seq[i]:
-                    break1_shift += 1
-                else:
-                    break
-
-        break2_shift = 0
-        if self.break2.orient == ORIENT.LEFT:
-            break2_seq = reference_genome[self.break2.chr].seq[self.break2.start - lutemp: self.break2.start]
-            for i in range(1, lutemp + 1):
-                if break2_seq[lutemp - i] == self.untemplated_seq[lutemp - i]:
-                    break2_shift += 1
-                else:
-                    break
-        else:
-            break2_seq = reference_genome[self.break2.chr].seq[self.break2.start - 1: self.break2.start + lutemp - 1]
-            for i in range(0, lutemp):
-                if break2_seq[i] == self.untemplated_seq[i]:
-                    break2_shift += 1
-                else:
-                    break
+        break1_shift = BreakpointPair._breakpoint_utemp_shift(self.break1, self.untemplated_seq, reference_genome)
+        break2_shift = BreakpointPair._breakpoint_utemp_shift(self.break2, self.untemplated_seq, reference_genome)
         return (break2_shift, break1_shift)
 
     def get_bed_repesentation(self):

--- a/mavis/config.py
+++ b/mavis/config.py
@@ -479,12 +479,14 @@ def augment_parser(arguments, parser, required=None):
                 '-v', '--version', action='version', version='%(prog)s version ' + __version__,
                 help='Outputs the version number')
         elif arg == 'aligner_reference':
+            default = REFERENCE_DEFAULTS[arg]
             parser.add_argument(
-                '--{}'.format(arg), default=REFERENCE_DEFAULTS[arg], required=required,
+                '--{}'.format(arg), default=default, required=required if not default else False,
                 help=REFERENCE_DEFAULTS.define(arg), type=filepath)
         elif arg in REFERENCE_DEFAULTS:
+            default = REFERENCE_DEFAULTS[arg]
             parser.add_argument(
-                '--{}'.format(arg), default=REFERENCE_DEFAULTS[arg], required=required,
+                '--{}'.format(arg), default=default, required=required if not default else False,
                 help=REFERENCE_DEFAULTS.define(arg), type=filepath, nargs='*')
         elif arg == 'config':
             parser.add_argument('config', help='path to the config file', type=filepath)

--- a/mavis/summary/summary.py
+++ b/mavis/summary/summary.py
@@ -222,16 +222,12 @@ def get_pairing_state(current_protocol, current_disease_state, other_protocol, o
     if current_protocol != other_protocol:
         is_matched = is_matched or inferred_is_matched
 
-    if curr == dg and other == ng:
+    if curr in {dg, dt} and other == ng:
         return PAIRING_STATE.GERMLINE if is_matched else PAIRING_STATE.SOMATIC
-    elif curr == dg and other == dt:
+    elif curr in {dg, ng} and other == dt:
         return PAIRING_STATE.EXP if is_matched else PAIRING_STATE.NO_EXP
     elif curr == dt and other == dg:
         return PAIRING_STATE.GENOMIC if is_matched else PAIRING_STATE.NO_GENOMIC
-    elif curr == dt and other == ng:
-        return PAIRING_STATE.GERMLINE if is_matched else PAIRING_STATE.SOMATIC
-    elif curr == ng and other == dt:
-        return PAIRING_STATE.EXP if is_matched else PAIRING_STATE.NO_EXP
     else:
         return PAIRING_STATE.MATCH if is_matched else PAIRING_STATE.NO_MATCH
 

--- a/mavis/summary/summary.py
+++ b/mavis/summary/summary.py
@@ -219,21 +219,21 @@ def get_pairing_state(current_protocol, current_disease_state, other_protocol, o
     dt = (PROTOCOL.TRANS, DISEASE_STATUS.DISEASED)
     ng = (PROTOCOL.GENOME, DISEASE_STATUS.NORMAL)
 
+    if current_protocol != other_protocol:
+        is_matched = is_matched or inferred_is_matched
+
     if curr == dg and other == ng:
         return PAIRING_STATE.GERMLINE if is_matched else PAIRING_STATE.SOMATIC
     elif curr == dg and other == dt:
-        return PAIRING_STATE.EXP if inferred_is_matched else PAIRING_STATE.NO_EXP
+        return PAIRING_STATE.EXP if is_matched else PAIRING_STATE.NO_EXP
     elif curr == dt and other == dg:
-        return PAIRING_STATE.GENOMIC if inferred_is_matched else PAIRING_STATE.NO_GENOMIC
+        return PAIRING_STATE.GENOMIC if is_matched else PAIRING_STATE.NO_GENOMIC
     elif curr == dt and other == ng:
-        return PAIRING_STATE.GERMLINE if inferred_is_matched else PAIRING_STATE.SOMATIC
+        return PAIRING_STATE.GERMLINE if is_matched else PAIRING_STATE.SOMATIC
     elif curr == ng and other == dt:
-        return PAIRING_STATE.EXP if inferred_is_matched else PAIRING_STATE.NO_EXP
+        return PAIRING_STATE.EXP if is_matched else PAIRING_STATE.NO_EXP
     else:
-        if current_protocol == other_protocol:
-            return PAIRING_STATE.MATCH if is_matched else PAIRING_STATE.NO_MATCH
-        else:
-            return PAIRING_STATE.MATCH if inferred_is_matched else PAIRING_STATE.NO_MATCH
+        return PAIRING_STATE.MATCH if is_matched else PAIRING_STATE.NO_MATCH
 
 
 def filter_by_evidence(

--- a/mavis/validate/base.py
+++ b/mavis/validate/base.py
@@ -149,6 +149,11 @@ class Evidence(BreakpointPair):
         except AttributeError:
             pass
         read.cigar = _cigar.join(cigar)
+        read.cigar = _cigar.merge_internal_events(
+            read.cigar,
+            inner_anchor=self.contig_aln_merge_inner_anchor,
+            outer_anchor=self.contig_aln_merge_outer_anchor
+        )
         read.reference_start = read.reference_start + prefix
 
         # makes sure all indels are called as far 'right' as possible
@@ -583,6 +588,7 @@ class Evidence(BreakpointPair):
                 elif opposite_breakpoint.orient == ORIENT.RIGHT:
                     if alignment.cigar[-1][0] == CIGAR.S and alignment.cigar[-1][1] > self.max_sc_preceeding_anchor:
                         continue
+            alignment.set_key()  # set the hash key before we add the read as evidence
             scores.append((s, _cigar.match_percent(alignment.cigar), alignment))
 
         scores = sorted(scores, key=lambda x: (x[0], x[1]), reverse=True) if scores else []

--- a/mavis/validate/evidence.py
+++ b/mavis/validate/evidence.py
@@ -304,6 +304,7 @@ class TranscriptomeEvidence(Evidence):
         return _cigar.join(new_cigar)
 
     def standardize_read(self, read):
+        read.cigar = self.exon_boundary_shift_cigar(read)  # do this twice to avoid merging events accidentally
         read = Evidence.standardize_read(self, read)
         read.cigar = self.exon_boundary_shift_cigar(read)
         return read

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 import re
 
 
-VERSION = '1.8.2'
+VERSION = '1.8.3'
 
 
 def parse_md_readme():

--- a/tests/integration/test_align.py
+++ b/tests/integration/test_align.py
@@ -42,7 +42,7 @@ class TestCallReadEvents(unittest.TestCase):
             Breakpoint('15', 71491956, orient='L', strand='-'),
             Breakpoint('15', 71491958, orient='R', strand='-'),
             untemplated_seq='')
-        events = align.call_read_events(read)
+        events = align.call_read_events(read, is_stranded=True)
         self.assertEqual(1, len(events))
         self.assertEqual(expected_bpp.break1, events[0].break1)
         self.assertEqual(expected_bpp.break2, events[0].break2)
@@ -390,7 +390,7 @@ class TestCallBreakpointPair(unittest.TestCase):
             query_sequence=seq,
             is_reverse=False
         )
-        bpp = align.call_paired_read_event(r1, r2)
+        bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
         self.assertEqual(STRAND.POS, bpp.break1.strand)
         self.assertEqual(STRAND.POS, bpp.break2.strand)
         self.assertEqual(ORIENT.LEFT, bpp.break1.orient)
@@ -423,7 +423,7 @@ class TestCallBreakpointPair(unittest.TestCase):
             query_sequence=seq,
             is_reverse=False
         )
-        bpp = align.call_paired_read_event(r1, r2)
+        bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
         self.assertEqual(STRAND.POS, bpp.break1.strand)
         self.assertEqual(STRAND.POS, bpp.break2.strand)
         self.assertEqual(ORIENT.LEFT, bpp.break1.orient)
@@ -454,7 +454,7 @@ class TestCallBreakpointPair(unittest.TestCase):
             query_sequence=seq,
             is_reverse=False
         )
-        bpp = align.call_paired_read_event(r1, r2)
+        bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
         self.assertEqual(STRAND.POS, bpp.break1.strand)
         self.assertEqual(STRAND.POS, bpp.break2.strand)
         self.assertEqual(ORIENT.RIGHT, bpp.break1.orient)
@@ -487,7 +487,7 @@ class TestCallBreakpointPair(unittest.TestCase):
             is_reverse=False
         )
         self.assertEqual(21, r1.reference_end)
-        bpp = align.call_paired_read_event(r1, r2)
+        bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
         self.assertEqual(STRAND.POS, bpp.break1.strand)
         self.assertEqual(STRAND.POS, bpp.break2.strand)
         self.assertEqual(ORIENT.LEFT, bpp.break1.orient)
@@ -522,7 +522,7 @@ class TestCallBreakpointPair(unittest.TestCase):
             query_sequence=reverse_complement(seq),
             is_reverse=True
         )
-        bpp = align.call_paired_read_event(r1, r2)
+        bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
         self.assertEqual(STRAND.POS, bpp.break1.strand)
         self.assertEqual(STRAND.NEG, bpp.break2.strand)
         self.assertEqual(ORIENT.LEFT, bpp.break1.orient)
@@ -544,7 +544,7 @@ class TestCallBreakpointPair(unittest.TestCase):
             reference_id=3, reference_start=2187, cigar=[(CIGAR.S, 117), (CIGAR.EQ, 8), (CIGAR.D, 1), (CIGAR.M, 120)],
             query_sequence=reverse_complement(s), is_reverse=True
         )
-        bpp = align.call_paired_read_event(read1, read2)
+        bpp = align.call_paired_read_event(read1, read2, is_stranded=True)
         self.assertEqual(STRAND.POS, bpp.break1.strand)
         self.assertEqual(STRAND.NEG, bpp.break2.strand)
         self.assertEqual(ORIENT.RIGHT, bpp.break1.orient)
@@ -585,7 +585,7 @@ class TestCallBreakpointPair(unittest.TestCase):
             query_sequence=reverse_complement(seq),
             is_reverse=True
         )
-        bpp = align.call_paired_read_event(r1, r2)
+        bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
         self.assertEqual(STRAND.POS, bpp.break1.strand)
         self.assertEqual(STRAND.NEG, bpp.break2.strand)
         self.assertEqual(ORIENT.LEFT, bpp.break1.orient)
@@ -662,7 +662,8 @@ class TestSelectContigAlignments(unittest.TestCase):
             contig_aln_min_score=DEFAULTS.contig_aln_min_score,
             outer_window1=Interval(1000, 1200),
             outer_window2=Interval(2000, 2200),
-            reference_genome=None
+            reference_genome=None,
+            bam_cache=mock.Mock(stranded=False)
         )
         read1 = SamRead(
             reference_id=3, reference_start=1114, cigar=[(CIGAR.S, 125), (CIGAR.EQ, 120)], query_sequence=s,

--- a/tests/integration/test_bam.py
+++ b/tests/integration/test_bam.py
@@ -37,10 +37,14 @@ class TestBamCache(unittest.TestCase):
     def test_add_read(self):
         fh = MockBamFileHandle()
         b = BamCache(fh)
-        r = MockRead('name')
+        r = mock.MagicMock(query_name='name', query_sequence='')
         b.add_read(r)
         self.assertEqual(1, len(b.cache.values()))
-        self.assertEqual(set([r]), b.cache['name'])
+        b.add_read(r)
+        self.assertEqual(1, len(b.cache.values()))
+        r.reference_start = 0
+        b.add_read(r)
+        self.assertEqual(1, len(b.cache.values()))
 
     def test_reference_id(self):
         fh = MockBamFileHandle({'1': 0})

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -630,7 +630,9 @@ class TestStandardizeRead(unittest.TestCase):
                 'TCATTATAACAGATAACGTGACCCTCAGCGATATCCCAAGTATTTTCCTGTTCTCATCTATACTATGGCAAAGGGGCAAATACCTCTCAGTAAAGAAAGAAATAACA'
                 'ACTTCTATCTTGGGCGAGGCATTTCTTCTGTTAGAACTTTGTACACGGAATAAAATAGATCTGTTTGTGCTTATCTTTCTCCTTAGAATTATTGAATTTGAAGTCTT'
                 'TCCCAGGGTGGGGGTGGAGTGAAGCTGGGGTTTCATAAGCACATAGATAGTAGTG', offset=224646450))},
-            bam_cache=MockObject(get_read_reference_name=lambda x: x.reference_name)
+            bam_cache=MockObject(get_read_reference_name=lambda x: x.reference_name),
+            contig_aln_merge_inner_anchor=10,
+            contig_aln_merge_outer_anchor=20
         )
 
     def test_bwa_mem(self):

--- a/tests/unit/test_bam.py
+++ b/tests/unit/test_bam.py
@@ -223,6 +223,10 @@ class TestMergeInternalEvents(unittest.TestCase):
         print(actual)
         self.assertEqual(exp, actual)
 
+    def test_mismatch_only(self):
+        exp = _cigar.convert_string_to_cigar('39=1X16=1X71=22S')
+        self.assertEqual(exp, _cigar.merge_internal_events(exp, 20, 15))
+
 
 class TestExtendSoftclipping(unittest.TestCase):
 

--- a/tests/unit/test_breakpoint.py
+++ b/tests/unit/test_breakpoint.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock
 
 from mavis.breakpoint import Breakpoint, BreakpointPair
 from mavis.constants import COLUMNS, ORIENT, STRAND, SVTYPE
@@ -460,3 +461,17 @@ class TestNetSize(unittest.TestCase):
             untemplated_seq='TT'
         )
         self.assertEqual(Interval(2), bpp.net_size())
+
+
+class TestUntemplatedShift(unittest.TestCase):
+
+    def test_indel(self):
+        ref = {'1': Mock(seq='AGAAAAAAAAAACAGAGTCTATTAAGGCATCTTCTATGGTCAGATATATCTATTTTTTTCTTTCTTTTTTTTACTTTCATTAAGTGCCACTAAAAAATTAGGTTCAATTAAACTTTATTAATCTCTTCTGAGTTTTGATTGAGTATATATATATATATACCCAGTTTCAAGCAGGTATCTGCCTTTAAAGATAAGAGACCTCCTAAATGCTTTCTTTTATTAGTTGCCCTGTTTCAGATTCAGCTTTGTATCTATATCACCTGTTAATATGTGTGGACTCACAGAAATGATCATTGAGGGAATGCACCCTGTTTGGGTG')}
+        bpp = BreakpointPair(
+            Breakpoint('1', 40237990 - 40237846, orient=ORIENT.LEFT),
+            Breakpoint('1', 40237991 - 40237846, orient=ORIENT.RIGHT),
+            untemplated_seq='GTATATATATATATATAT'
+        )
+        result = bpp.untemplated_shift(ref)
+        print(result)
+        self.assertEqual((0, 1), result)


### PR DESCRIPTION
Improvements
- prints log errors when the validation step was run after annotations (a partial rerun)
- standardization of spanning read calls
- pairing states for transcriptome vs genome using either pairing type (pairing, inferred_pairing)

Bug Fixes
- read evidence undercalled due to strand being set for unstranded sources
- explicit hashing of reads to avoid over-counting