### PR TITLE
v1.8.4

### DIFF
--- a/mavis/summary/constants.py
+++ b/mavis/summary/constants.py
@@ -22,7 +22,7 @@ DEFAULTS.add('filter_min_flanking_reads', 10, defn='Minimum number of flanking p
 DEFAULTS.add('filter_min_split_reads', 5, defn='Minimum number of split reads for a call by split reads')
 DEFAULTS.add('filter_min_linking_split_reads', 1, defn='Minimum number of linking split reads for a call by split reads')
 DEFAULTS.add('filter_cdna_synon', True, defn='Filter all annotations synonymous at the cdna level')
-DEFAULTS.add('filter_protein_synon', True, defn='Filter all annotations synonymous at the protein level')
+DEFAULTS.add('filter_protein_synon', False, defn='Filter all annotations synonymous at the protein level')
 DEFAULTS.add(
     'filter_trans_homopolymers', True,
     defn='Filter all single bp ins/del/dup events that are in a homopolymer region of at least '

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 import re
 
 
-VERSION = '1.8.3'
+VERSION = '1.8.4'
 
 
 def parse_md_readme():

--- a/tab/tab.py
+++ b/tab/tab.py
@@ -330,7 +330,7 @@ def read_file(inputfile, delimiter='\t', header=None, strict=True, suppress_inde
             raise EmptyFileError('no lines beyond comments to read as header')
         line = re.sub(r'(^#)|([\r\n\s]*$)', '', lines[current_line_index])  # clean the header
         current_line_index += 1
-        header = line.split(delimiter) if delimiter in line else []
+        header = line.split(delimiter) if line else []
     if not header:
         raise EmptyFileError('header is empty', inputfile)
     # create the file transform object


### PR DESCRIPTION
Bugfix
- files where the delimiter was missing from the header were being reported as empty instead of throwing an error