### PR TITLE
Issue #195: Restore the aliases to be a list not a single string

### DIFF
--- a/tools/generate_ensembl_json.pl
+++ b/tools/generate_ensembl_json.pl
@@ -157,11 +157,11 @@ END_MESSAGE
         my $gid = $gene->stable_id();
 
         # get all hugo aliases for this ensembl gene
-        my $hugo = "";
+        my $hugo = [];
 
         # use the ensembl hugo name if not otherwise given
         if (defined $gene->external_name()) {
-            $hugo = $gene->external_name();
+            $hugo = [$gene->external_name()];
         }
 
         my $gjson = {


### PR DESCRIPTION
BugFix from the 2.2.5 release where these were defaulted to strings instead of arrays