### PR TITLE
only upload coverage once

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,3 +73,4 @@ jobs:
         env_vars: OS,PYTHON
         name: codecov-umbrella
         fail_ci_if_error: true
+      if: matrix.python-version == 3.8


### PR DESCRIPTION
- to avoid the code-cov timeouts that require you to rerun the build, only upload the coverage once instead of once per python version being tested in the matrix