### PR TITLE
Bugfix/fix mismatched annotation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,7 +40,7 @@ pytest tests
 
 ```bash
 pip install .[docs]
-markdown_refdocs mavis -o docs/package --links
+markdown_refdocs mavis -o docs/package --link
 mkdocs build
 ```
 

--- a/mavis/annotate/file_io.py
+++ b/mavis/annotate/file_io.py
@@ -76,8 +76,8 @@ def load_masking_regions(*filepaths):
 
     .. code-block:: text
 
-        #chr    start   end     name
-        chr20	25600000	27500000	centromere
+        #chr    start       end         name
+        chr20   25600000    27500000    centromere
 
     Args:
         filepath (str): path to the input tab-delimited file
@@ -437,8 +437,8 @@ def load_templates(*filepaths):
 
     .. code-block:: text
 
-        chr1	0	2300000	p36.33	gneg
-        chr1	2300000	5400000	p36.32	gpos25
+        chr1    0   2300000 p36.33  gneg
+        chr1    2300000 5400000 p36.32  gpos25
 
     Args:
         filename (str): the path to the file with the cytoband template information

--- a/mavis/annotate/fusion.py
+++ b/mavis/annotate/fusion.py
@@ -562,6 +562,7 @@ class FusionTranscript(PreTranscript):
                     )
                     temp = reference_sequence[exon.start - 1 : exon.end]
                     e.seq = str(temp)
+
                     assert len(temp) == len(e)
                     s += temp
                     new_exons.append((e, exon))

--- a/mavis/annotate/genomic.py
+++ b/mavis/annotate/genomic.py
@@ -64,8 +64,7 @@ class IntergenicRegion(BioInterval):
 
 
 class Gene(BioInterval):
-    """
-    """
+    """"""
 
     def __init__(self, chr, start, end, name=None, strand=STRAND.NS, aliases=None, seq=None):
         """
@@ -162,8 +161,7 @@ class Gene(BioInterval):
 
 
 class Exon(BioInterval):
-    """
-    """
+    """"""
 
     def __init__(
         self,
@@ -277,8 +275,7 @@ class Exon(BioInterval):
 
 
 class PreTranscript(BioInterval):
-    """
-    """
+    """"""
 
     def __init__(
         self,
@@ -290,7 +287,7 @@ class PreTranscript(BioInterval):
         seq=None,
         is_best_transcript=False,
     ):
-        """ creates a new transcript object
+        """creates a new transcript object
 
         Args:
             exons (List[Exon]): list of Exon that make up the transcript

--- a/mavis/annotate/protein.py
+++ b/mavis/annotate/protein.py
@@ -263,8 +263,7 @@ class Translation(BioInterval):
 
     @property
     def transcript(self):
-        """mavis.annotate.genomic.Transcript: the spliced transcript this translation belongs to
-        """
+        """mavis.annotate.genomic.Transcript: the spliced transcript this translation belongs to"""
         return self.reference_object
 
     def convert_aa_to_cdna(self, pos):

--- a/mavis/annotate/variant.py
+++ b/mavis/annotate/variant.py
@@ -56,8 +56,13 @@ class Annotation(BreakpointPair):
                 raise TypeError('got multiple values for data elements:', conflicts)
         self.data.update(kwargs)
 
-        self.transcript1 = transcript1
-        self.transcript2 = transcript2
+        # match transcript to breakpoint if reveresed
+        if bpp.break1.key[0:3] < bpp.break2.key[0:3]:
+            self.transcript1 = transcript1
+            self.transcript2 = transcript2
+        else:
+            self.transcript2 = transcript1
+            self.transcript1 = transcript2
 
         self.encompassed_genes = set()
         self.genes_proximal_to_break1 = set()
@@ -699,14 +704,7 @@ def _gather_annotations(ref, bp, proximity=None):
         bpp.break2.start = b2_itvl[0]
         bpp.break2.end = b2_itvl[1]
 
-        # Swap annotations/position so lower is first
-        if bpp.break1.key[0:3] < bpp.break2.key[0:3]:
-            a = Annotation(bpp, a1, a2, proximity=proximity)
-        else:
-            temp = bpp.break1
-            bpp.break1 = bpp.break2
-            bpp.break2 = temp
-            a = Annotation(bpp, a2, a1, proximity=proximity)
+        a = Annotation(bpp, a1, a2, proximity=proximity)
 
         for gene in ref.get(bp.break1.chr, []):
             a.add_gene(gene)

--- a/mavis/annotate/variant.py
+++ b/mavis/annotate/variant.py
@@ -692,6 +692,16 @@ def _gather_annotations(ref, bp, proximity=None):
 
         b1_itvl = bp.break1 & a1
         b2_itvl = bp.break2 & a2
+
+        # Swap annotations/position so lower is first
+        if b2_itvl < b1_itvl:
+            temp = a1
+            a1 = a2
+            a2 = temp
+            temp = b1_itvl
+            b1_itvl = b2_itvl
+            b2_itvl = temp
+
         bpp = BreakpointPair.copy(bp)
         bpp.break1.start = b1_itvl[0]
         bpp.break1.end = b1_itvl[1]

--- a/mavis/annotate/variant.py
+++ b/mavis/annotate/variant.py
@@ -693,22 +693,20 @@ def _gather_annotations(ref, bp, proximity=None):
         b1_itvl = bp.break1 & a1
         b2_itvl = bp.break2 & a2
 
-        # Swap annotations/position so lower is first
-        if b2_itvl < b1_itvl:
-            temp = a1
-            a1 = a2
-            a2 = temp
-            temp = b1_itvl
-            b1_itvl = b2_itvl
-            b2_itvl = temp
-
         bpp = BreakpointPair.copy(bp)
         bpp.break1.start = b1_itvl[0]
         bpp.break1.end = b1_itvl[1]
         bpp.break2.start = b2_itvl[0]
         bpp.break2.end = b2_itvl[1]
 
-        a = Annotation(bpp, a1, a2, proximity=proximity)
+        # Swap annotations/position so lower is first
+        if bpp.break1.key[0:3] < bpp.break2.key[0:3]:
+            a = Annotation(bpp, a1, a2, proximity=proximity)
+        else:
+            temp = bpp.break1
+            bpp.break1 = bpp.break2
+            bpp.break2 = temp
+            a = Annotation(bpp, a2, a1, proximity=proximity)
 
         for gene in ref.get(bp.break1.chr, []):
             a.add_gene(gene)

--- a/mavis/assemble.py
+++ b/mavis/assemble.py
@@ -12,8 +12,7 @@ from .util import DEVNULL
 
 
 class Contig:
-    """
-    """
+    """"""
 
     def __init__(self, sequence, score):
         self.seq = sequence

--- a/mavis/blat.py
+++ b/mavis/blat.py
@@ -32,8 +32,7 @@ from .interval import Interval
 
 
 class Blat:
-    """
-    """
+    """"""
 
     @staticmethod
     def millibad(row, is_protein=False, is_mrna=True):

--- a/mavis/breakpoint.py
+++ b/mavis/breakpoint.py
@@ -73,8 +73,7 @@ class Breakpoint(Interval):
 
 
 class BreakpointPair:
-    """
-    """
+    """"""
 
     def __getattr__(self, attr):
         data = object.__getattribute__(self, 'data')

--- a/mavis/illustrate/elements.py
+++ b/mavis/illustrate/elements.py
@@ -93,8 +93,7 @@ def draw_exon_track(
     genomic_max=None,
     translation=None,
 ):
-    """
-    """
+    """"""
     colors = {} if colors is None else colors
     main_group = canvas.g(class_='exon_track')
 

--- a/mavis/interval.py
+++ b/mavis/interval.py
@@ -1,6 +1,5 @@
 class Interval:
-    """
-    """
+    """"""
 
     def __init__(self, start, end=None, freq=1, number_type=None):
         """
@@ -250,7 +249,7 @@ class Interval:
 
     @classmethod
     def convert_ratioed_pos(cls, mapping, pos, forward_to_reverse=None):
-        """ convert any given position given a mapping of intervals to another range
+        """convert any given position given a mapping of intervals to another range
 
         Args:
             mapping (Dict[Interval,Interval]): a mapping of a set of continuous intervals
@@ -460,7 +459,7 @@ class IntervalMapping:
         self.opposing_directions[src_interval] = opposing_directions
 
     def convert_ratioed_pos(self, pos):
-        """ convert any given position given a mapping of intervals to another range
+        """convert any given position given a mapping of intervals to another range
 
         Args:
             pos (Interval): a position in the first coordinate system
@@ -496,7 +495,7 @@ class IntervalMapping:
         raise IndexError(pos, 'position not found in mapping', self.mapping.keys())
 
     def convert_pos(self, pos):
-        """ convert any given position given a mapping of intervals to another range
+        """convert any given position given a mapping of intervals to another range
 
         Args:
             pos (int): a position in the first coordinate system

--- a/mavis/validate/call.py
+++ b/mavis/validate/call.py
@@ -762,8 +762,10 @@ def _call_interval_by_flanking_coverage(
     )  # minimum distance of the coverage
     max_interval = max_expected_fragment_size - read_length
     if coverage_d > max_interval:
-        msg = 'length of the coverage interval ({}) is greater than the maximum expected ({})'.format(
-            coverage_d, max_interval
+        msg = (
+            'length of the coverage interval ({}) is greater than the maximum expected ({})'.format(
+                coverage_d, max_interval
+            )
         )
         raise AssertionError(msg)
     if orientation == ORIENT.LEFT:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 import re
 
 
-VERSION = '2.2.6'
+VERSION = '2.2.7'
 
 
 def parse_md_readme():

--- a/setup.py
+++ b/setup.py
@@ -68,18 +68,13 @@ TEST_REQS = [
 ]
 
 
-DOC_REQS = [
-    'mkdocs',
-    'markdown_refdocs',
-    'mkdocs-material',
-    'markdown-include',
-]
+DOC_REQS = ['mkdocs', 'markdown_refdocs', 'mkdocs-material', 'markdown-include']
 
 
 INSTALL_REQS = [
     'Distance>=0.1.3',
     'Shapely>=1.6.4.post1',
-    'biopython>=1.70',
+    'biopython>=1.70, <1.78',
     'braceexpand==0.1.2',
     'colour',
     'networkx==1.11.0',
@@ -107,7 +102,7 @@ setup(
         'test': TEST_REQS,
         'dev': ['black', 'flake8'] + DOC_REQS + TEST_REQS + DEPLOY_REQS,
         'deploy': DEPLOY_REQS,
-        'tools': ['pyensembl', 'simplejson']
+        'tools': ['pyensembl', 'simplejson'],
     },
     tests_require=TEST_REQS,
     setup_requires=['pip>=9.0.0', 'setuptools>=36.0.0'],

--- a/tests/integration/test_annotate.py
+++ b/tests/integration/test_annotate.py
@@ -1424,6 +1424,22 @@ class TestAnnotationGathering(unittest.TestCase):
         self.assertEqual(1, len(ann_list))
         self.assertEqual(ann_list[0].transcript1, ann_list[0].transcript2)
 
+    def test_breakpoint_single_gene(self):
+        g = Gene(REF_CHR, 1000, 3000, strand=STRAND.POS)
+        t = PreTranscript(gene=g, exons=[(1001, 1100), (1501, 1600), (2001, 2100), (2501, 2600)])
+        g.transcripts.append(t)
+        ref = {REF_CHR: [g]}
+        b1 = Breakpoint(REF_CHR, 789, 1050, strand=STRAND.POS)
+        b2 = Breakpoint(REF_CHR, 800, strand=STRAND.POS)
+        bpp = BreakpointPair(b1, b2, event_type=SVTYPE.DEL, protocol=PROTOCOL.GENOME)
+        ann_list = sorted(_gather_annotations(ref, bpp), key=lambda x: (x.break1, x.break2))
+        self.assertEqual(3, len(ann_list))
+        for ann in ann_list:
+            self.assertTrue(ann.break1.start in ann.transcript1.position)
+            self.assertTrue(ann.break1.end in ann.transcript1.position)
+            self.assertTrue(ann.break2.start in ann.transcript2.position)
+            self.assertTrue(ann.break2.end in ann.transcript2.position)
+
 
 class TestAnnotate(unittest.TestCase):
     def test_reference_name_eq(self):


### PR DESCRIPTION
Seems like when Annotation() is created, the breakpoint positions got swapped (due to sorting of positions) but the transcripts didn't, so the breakpoint positions and transcripts don't line up anymore. Fix is to check if breakpoints are in the right order, and swap them before Annotation() is created.