### PR TITLE
Convert to pytest syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
     extras_require={
         'docs': DOC_REQS,
         'test': TEST_REQS,
-        'dev': ['black', 'flake8'] + DOC_REQS + TEST_REQS + DEPLOY_REQS,
+        'dev': ['black==20.8b1', 'flake8'] + DOC_REQS + TEST_REQS + DEPLOY_REQS,
         'deploy': DEPLOY_REQS,
         'tools': ['pyensembl', 'simplejson'],
     },

--- a/src/mavis/annotate/genomic.py
+++ b/src/mavis/annotate/genomic.py
@@ -64,7 +64,7 @@ class IntergenicRegion(BioInterval):
 
 
 class Gene(BioInterval):
-    """"""
+    """ """
 
     def __init__(self, chr, start, end, name=None, strand=STRAND.NS, aliases=None, seq=None):
         """
@@ -161,7 +161,7 @@ class Gene(BioInterval):
 
 
 class Exon(BioInterval):
-    """"""
+    """ """
 
     def __init__(
         self,
@@ -275,7 +275,7 @@ class Exon(BioInterval):
 
 
 class PreTranscript(BioInterval):
-    """"""
+    """ """
 
     def __init__(
         self,

--- a/src/mavis/assemble.py
+++ b/src/mavis/assemble.py
@@ -12,7 +12,7 @@ from .util import DEVNULL
 
 
 class Contig:
-    """"""
+    """ """
 
     def __init__(self, sequence, score):
         self.seq = sequence

--- a/src/mavis/blat.py
+++ b/src/mavis/blat.py
@@ -32,7 +32,7 @@ from .util import LOG
 
 
 class Blat:
-    """"""
+    """ """
 
     @staticmethod
     def millibad(row, is_protein=False, is_mrna=True):

--- a/src/mavis/illustrate/elements.py
+++ b/src/mavis/illustrate/elements.py
@@ -93,7 +93,7 @@ def draw_exon_track(
     genomic_max=None,
     translation=None,
 ):
-    """"""
+    """ """
     colors = {} if colors is None else colors
     main_group = canvas.g(class_='exon_track')
 

--- a/src/tools/find_repeats.py
+++ b/src/tools/find_repeats.py
@@ -15,17 +15,29 @@ def parse_arguments():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-o', '--output',
-        help='path to the output file', required=True, metavar='FILEPATH'
+        '-o', '--output', help='path to the output file', required=True, metavar='FILEPATH'
     )
     parser.add_argument(
-        '-n', '--input', required=True, metavar='FILEPATH',
-        help='Path to the Input reference genome fasta file'
+        '-n',
+        '--input',
+        required=True,
+        metavar='FILEPATH',
+        help='Path to the Input reference genome fasta file',
     )
     parser.add_argument(
-        '--min_length', default=20, type=int, help='Minimum total length of the repeat region to find', metavar='INT')
+        '--min_length',
+        default=20,
+        type=int,
+        help='Minimum total length of the repeat region to find',
+        metavar='INT',
+    )
     parser.add_argument(
-        '--repeat_seq', default='N', type=str, help='Repeat sequence to look for. Case insensitive', nargs='+')
+        '--repeat_seq',
+        default='N',
+        type=str,
+        help='Repeat sequence to look for. Case insensitive',
+        nargs='+',
+    )
     args = parser.parse_args()
     if args.min_length < 2:
         parser.error('argument --min_length: cannot specify a shorter repeat than 2 bases')
@@ -43,7 +55,7 @@ def main():
         os.path.basename(__file__),
         'input: {}'.format(args.input),
         'min_length: {}'.format(args.min_length),
-        'repeat_seq: {}'.format(', '.join(args.repeat_seq))
+        'repeat_seq: {}'.format(', '.join(args.repeat_seq)),
     ]
     log('writing:', args.output)
     with open(args.output, 'w') as fh:
@@ -61,21 +73,33 @@ def main():
                 visited.add(seq)
             spans = []
             for repseq in repeat_sequences:
-                log('finding {}_repeat (min_length: {}), for chr{} (length: {})'.format(repseq, args.min_length, chrom, len(seq)))
+                log(
+                    'finding {}_repeat (min_length: {}), for chr{} (length: {})'.format(
+                        repseq, args.min_length, chrom, len(seq)
+                    )
+                )
                 index = 0
                 while index < len(seq):
                     next_n = seq.find(repseq, index)
                     if next_n < 0:
                         break
                     index = next_n
-                    while index + len(repseq) <= len(seq) and seq[index:index + len(repseq)] == repseq:
+                    while (
+                        index + len(repseq) <= len(seq)
+                        and seq[index : index + len(repseq)] == repseq
+                    ):
                         index += len(repseq)
                     span = BioInterval(chrom, next_n + 1, index, name='repeat_{}'.format(repseq))
                     if len(span) >= args.min_length and len(span) >= 2 * len(repseq):
                         spans.append(span)
             log('found', len(spans), 'spans', time_stamp=False)
             for span in spans:
-                fh.write('{}\t{}\t{}\t{}\n'.format(span.reference_object, span.start, span.end, span.name))
+                fh.write(
+                    '{}\t{}\t{}\t{}\n'.format(
+                        span.reference_object, span.start, span.end, span.name
+                    )
+                )
+
 
 if __name__ == '__main__':
     main()

--- a/src/tools/generate_ensembl_json.py
+++ b/src/tools/generate_ensembl_json.py
@@ -438,10 +438,10 @@ class EnsemblAnnotation(object):
         """
         Select a canonical transcript for each human gene using Ensembl rules.
 
-        For human, the canonical transcript for a gene is set according to the following hierarchy: 
-        - 1. Longest CCDS translation with no stop codons. 
-        - 2. If no (1), choose the longest Ensembl/Havana merged translation with no stop codons. 
-        - 3. If no (2), choose the longest translation with no stop codons. 
+        For human, the canonical transcript for a gene is set according to the following hierarchy:
+        - 1. Longest CCDS translation with no stop codons.
+        - 2. If no (1), choose the longest Ensembl/Havana merged translation with no stop codons.
+        - 3. If no (2), choose the longest translation with no stop codons.
         - 4. If no translation, choose the longest non-protein-coding transcript.
 
         See: http://uswest.ensembl.org/Help/Glossary?id=346

--- a/tests/end_to_end/test_convert.py
+++ b/tests/end_to_end/test_convert.py
@@ -1,4 +1,3 @@
-import glob
 import os
 import shutil
 import sys
@@ -23,7 +22,7 @@ def setUpModule():
     print('output dir', TEMP_OUTPUT)
 
 
-class TestConvert(unittest.TestCase):
+class TestConvert:
     def run_main(self, inputfile, file_type, strand_specific=False):
         outputfile = os.path.join(TEMP_OUTPUT, file_type + '.tab')
         args = [
@@ -41,7 +40,7 @@ class TestConvert(unittest.TestCase):
         with patch.object(sys, 'argv', args):
             main()
             print('output', outputfile)
-            self.assertTrue(unique_exists(outputfile))
+            assert unique_exists(outputfile)
         result = {}
         for pair in read_bpp_from_input_file(outputfile):
             result.setdefault(pair.data['tracking_id'], []).append(pair)
@@ -56,44 +55,44 @@ class TestConvert(unittest.TestCase):
     def test_delly(self):
         result = self.run_main(get_data('delly_events.vcf'), SUPPORTED_TOOL.DELLY, False)
         # test the contents were converted successfully
-        self.assertEqual(1, len(result['delly-DUP00000424']))
+        assert len(result['delly-DUP00000424']) == 1
         bpp = result['delly-DUP00000424'][0]
         print(bpp.data)
         print(bpp)
-        self.assertEqual(SVTYPE.DUP, bpp.event_type)
-        self.assertEqual('1', bpp.break1.chr)
-        self.assertEqual('1', bpp.break2.chr)
-        self.assertEqual(224646569, bpp.break1.start)
-        self.assertEqual(224646569, bpp.break1.end)
-        self.assertEqual(224800120, bpp.break2.start)
-        self.assertEqual(224800120, bpp.break2.end)
-        self.assertEqual(1, len(result['delly-TRA00020624']))
+        assert bpp.event_type == SVTYPE.DUP
+        assert bpp.break1.chr == '1'
+        assert bpp.break2.chr == '1'
+        assert bpp.break1.start == 224646569
+        assert bpp.break1.end == 224646569
+        assert bpp.break2.start == 224800120
+        assert bpp.break2.end == 224800120
+        assert len(result['delly-TRA00020624']) == 1
         bpp = result['delly-TRA00020624'][0]
-        self.assertEqual(SVTYPE.TRANS, bpp.event_type)
-        self.assertEqual('10', bpp.break1.chr)
-        self.assertEqual('19', bpp.break2.chr)
-        self.assertEqual(7059510 - 670, bpp.break1.start)
-        self.assertEqual(7059510 + 670, bpp.break1.end)
-        self.assertEqual(17396810 - 670, bpp.break2.start)
-        self.assertEqual(17396810 + 670, bpp.break2.end)
-        self.assertEqual(len(result), 31)
+        assert bpp.event_type == SVTYPE.TRANS
+        assert bpp.break1.chr == '10'
+        assert bpp.break2.chr == '19'
+        assert bpp.break1.start == 7059510 - 670
+        assert bpp.break1.end == 7059510 + 670
+        assert bpp.break2.start == 17396810 - 670
+        assert bpp.break2.end == 17396810 + 670
+        assert 31 == len(result)
 
     def test_manta(self):
         result = self.run_main(get_data('manta_events.vcf'), SUPPORTED_TOOL.MANTA, False)
         # ensure weird bnd type is converted correctly
         bnd_id = 'manta-MantaBND:173633:0:1:0:0:0:0'
-        self.assertEqual(1, len(result[bnd_id]))
+        assert len(result[bnd_id]) == 1
         bpp = result[bnd_id][0]
-        self.assertEqual(SVTYPE.TRANS, bpp.event_type)
-        self.assertEqual('10', bpp.break1.chr)
-        self.assertEqual('19', bpp.break2.chr)
-        self.assertEqual(7059511 - 0, bpp.break1.start)
-        self.assertEqual(7059511 + 1, bpp.break1.end)
-        self.assertEqual(17396810, bpp.break2.start)
-        self.assertEqual(17396810, bpp.break2.end)
-        self.assertEqual(ORIENT.LEFT, bpp.break2.orient)
+        assert bpp.event_type == SVTYPE.TRANS
+        assert bpp.break1.chr == '10'
+        assert bpp.break2.chr == '19'
+        assert bpp.break1.start == 7059511 - 0
+        assert bpp.break1.end == 7059511 + 1
+        assert bpp.break2.start == 17396810
+        assert bpp.break2.end == 17396810
+        assert bpp.break2.orient == ORIENT.LEFT
         somatic_event = result['manta-MantaDEL:20644:0:2:0:0:0'][0]
-        self.assertEqual(True, somatic_event.data.get('SOMATIC', False))
+        assert somatic_event.data.get('SOMATIC', False) is True
 
     def test_pindel(self):
         self.run_main(get_data('pindel_events.vcf'), SUPPORTED_TOOL.PINDEL, False)
@@ -107,7 +106,7 @@ class TestConvert(unittest.TestCase):
         print(results.keys())
         record = results['vcf-460818'][0]
         print(record, record.data)
-        self.assertEqual('Pathogenic', record.data['CLNSIG'])
+        assert record.data['CLNSIG'] == 'Pathogenic'
 
     def test_breakseq2(self):
         self.run_main(get_data('breakseq.vcf'), SUPPORTED_TOOL.BREAKSEQ, False)

--- a/tests/end_to_end/test_help.py
+++ b/tests/end_to_end/test_help.py
@@ -1,110 +1,106 @@
-import os
-import subprocess
 import sys
-import unittest
 from unittest.mock import patch
-
 
 from mavis.constants import SUBCOMMAND
 from mavis.main import main
 
 
-class TestHelpMenu(unittest.TestCase):
+class TestHelpMenu:
     def test_main(self):
         with patch.object(sys, 'argv', ['mavis', '-h']):
             try:
                 returncode = main()
             except SystemExit as err:
-                self.assertEqual(0, err.code)
+                assert err.code == 0
             else:
-                self.assertEqual(0, returncode)
+                assert returncode == 0
 
     def test_pipeline(self):
         with patch.object(sys, 'argv', ['mavis', SUBCOMMAND.SETUP, '-h']):
             try:
                 returncode = main()
             except SystemExit as err:
-                self.assertEqual(0, err.code)
+                assert err.code == 0
             else:
-                self.assertEqual(0, returncode)
+                assert returncode == 0
 
     def test_cluster(self):
         with patch.object(sys, 'argv', ['mavis', SUBCOMMAND.CLUSTER, '-h']):
             try:
                 returncode = main()
             except SystemExit as err:
-                self.assertEqual(0, err.code)
+                assert err.code == 0
             else:
-                self.assertEqual(0, returncode)
+                assert returncode == 0
 
     def test_validate(self):
         with patch.object(sys, 'argv', ['mavis', SUBCOMMAND.VALIDATE, '-h']):
             try:
                 returncode = main()
             except SystemExit as err:
-                self.assertEqual(0, err.code)
+                assert err.code == 0
             else:
-                self.assertEqual(0, returncode)
+                assert returncode == 0
 
     def test_annotate(self):
         with patch.object(sys, 'argv', ['mavis', SUBCOMMAND.ANNOTATE, '-h']):
             try:
                 returncode = main()
             except SystemExit as err:
-                self.assertEqual(0, err.code)
+                assert err.code == 0
             else:
-                self.assertEqual(0, returncode)
+                assert returncode == 0
 
     def test_pairing(self):
         with patch.object(sys, 'argv', ['mavis', SUBCOMMAND.PAIR, '-h']):
             try:
                 returncode = main()
             except SystemExit as err:
-                self.assertEqual(0, err.code)
+                assert err.code == 0
             else:
-                self.assertEqual(0, returncode)
+                assert returncode == 0
 
     def test_summary(self):
         with patch.object(sys, 'argv', ['mavis', SUBCOMMAND.SUMMARY, '-h']):
             try:
                 returncode = main()
             except SystemExit as err:
-                self.assertEqual(0, err.code)
+                assert err.code == 0
             else:
-                self.assertEqual(0, returncode)
+                assert returncode == 0
 
     def test_convert(self):
         with patch.object(sys, 'argv', ['mavis', SUBCOMMAND.CONVERT, '-h']):
             try:
                 returncode = main()
             except SystemExit as err:
-                self.assertEqual(0, err.code)
+                assert err.code == 0
             else:
-                self.assertEqual(0, returncode)
+                assert returncode == 0
 
     def test_overlay(self):
         with patch.object(sys, 'argv', ['mavis', SUBCOMMAND.OVERLAY, '-h']):
             try:
                 returncode = main()
             except SystemExit as err:
-                self.assertEqual(0, err.code)
+                assert err.code == 0
             else:
-                self.assertEqual(0, returncode)
+                assert returncode == 0
 
     def test_bad_option(self):
         with patch.object(sys, 'argv', ['mavis', SUBCOMMAND.SETUP, '--blargh']):
             try:
                 returncode = main()
             except SystemExit as err:
-                self.assertNotEqual(0, err.code)
+                assert err.code != 0
             else:
-                self.assertNotEqual(0, returncode)
+                assert returncode != 0
 
     def test_ref_alt_count(self):
         with patch.object(sys, 'argv', ['calculate_ref_alt_counts', '-h']):
             try:
                 returncode = main()
             except SystemExit as err:
-                self.assertEqual(0, err.code)
+                assert err.code == 0
             else:
-                self.assertEqual(0, returncode)
+                assert returncode == 0

--- a/tests/end_to_end/test_overlay.py
+++ b/tests/end_to_end/test_overlay.py
@@ -1,7 +1,6 @@
 import json
 import os
 import shutil
-import subprocess
 import sys
 import tempfile
 from unittest.mock import patch

--- a/tests/end_to_end/test_ref_alt_count.py
+++ b/tests/end_to_end/test_ref_alt_count.py
@@ -1,8 +1,8 @@
 import os
 import shutil
 import tempfile
-import unittest
 
+import pytest
 from mavis.annotate.file_io import load_reference_genome
 from mavis.breakpoint import Breakpoint, BreakpointPair
 from mavis.constants import ORIENT, SVTYPE
@@ -31,68 +31,60 @@ def print_file_tree(dirname):
             print('{}{}'.format(subindent, f))
 
 
-class TestFullCalculator(unittest.TestCase):
-    def setUp(self):
-        # create the temp output directory to store file outputs
-        self.temp_output = tempfile.mkdtemp()
-        print('output dir', self.temp_output)
+@pytest.fixture
+def calculator():
+    return RefAltCalculator(
+        [("TEST", get_data('mock_reads_for_events.sorted.bam'))],
+        REFERENCE_GENOME,
+        max_event_size=100,
+        buffer=20,
+    )
 
-        self.calculator = RefAltCalculator(
-            [("TEST", get_data('mock_reads_for_events.sorted.bam'))],
-            REFERENCE_GENOME,
-            max_event_size=100,
-            buffer=20,
-        )
 
-    def test_calculate_all_counts(self):
-        self.calculator.calculate_all_counts(
+@pytest.fixture
+def temp_output():
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d)
+
+
+class TestFullCalculator:
+    def test_calculate_all_counts(self, calculator, temp_output):
+        calculator.calculate_all_counts(
             [get_data("mavis_summary_all_mock-A36971_mock-A47933.tab")],
-            os.path.join(self.temp_output, "ref_alt_output.tab"),
+            os.path.join(temp_output, "ref_alt_output.tab"),
         )
-        self.assertTrue(glob_exists(self.temp_output, "ref_alt_output.tab"))
-
-    def tearDown(self):
-        # remove the temp directory and outputs
-        print_file_tree(self.temp_output)
-        shutil.rmtree(self.temp_output)
+        assert glob_exists(temp_output, "ref_alt_output.tab")
 
 
-class TestRefAltCalulator(unittest.TestCase):
-    def setUp(self):
-        self.calculator = RefAltCalculator(
-            [("TEST", get_data('mock_reads_for_events.sorted.bam'))],
-            REFERENCE_GENOME,
-            max_event_size=100,
-            buffer=20,
-        )
-
-    def test_calculate_count(self):
+class TestRefAltCalulator:
+    def test_calculate_count(self, calculator):
         ev1 = BreakpointPair(
             Breakpoint('reference11', 5999, orient=ORIENT.LEFT),
             Breakpoint('reference11', 6003, orient=ORIENT.RIGHT),
             opposing_strands=False,
             event_type=SVTYPE.DEL,
         )
-        bpp = self.calculator.calculate_ref_counts(ev1)
+        bpp = calculator.calculate_ref_counts(ev1)
         print(bpp.data)
-        self.assertEqual(27, bpp.data["TEST_ref_count"])
-        self.assertEqual(14, bpp.data["TEST_alt_count"])
-        self.assertEqual(188, bpp.data['TEST_ignored_count'])
+        assert bpp.data["TEST_ref_count"] == 27
+        assert bpp.data["TEST_alt_count"] == 14
+        assert bpp.data['TEST_ignored_count'] == 188
 
-    def test_calculate_count2(self):
+    def test_calculate_count2(self, calculator):
         ev1 = BreakpointPair(
             Breakpoint('reference11', 9999, orient=ORIENT.LEFT),
             Breakpoint('reference11', 10030, orient=ORIENT.RIGHT),
             opposing_strands=False,
             event_type=SVTYPE.DEL,
         )
-        bpp = self.calculator.calculate_ref_counts(ev1)
+        bpp = calculator.calculate_ref_counts(ev1)
         print(bpp.data)
-        self.assertEqual(0, bpp.data["TEST_ref_count"])
-        self.assertEqual(63, bpp.data["TEST_alt_count"])
-        self.assertEqual(197, bpp.data['TEST_ignored_count'])
+        assert bpp.data["TEST_ref_count"] == 0
+        assert bpp.data["TEST_alt_count"] == 63
+        assert bpp.data['TEST_ignored_count'] == 197
 
-    def test_calculate_count3(self):
+    def test_calculate_count3(self, calculator):
         ev1 = BreakpointPair(
             Breakpoint('reference1', 2002, orient=ORIENT.LEFT),
             Breakpoint('reference1', 2003, orient=ORIENT.RIGHT),
@@ -100,21 +92,21 @@ class TestRefAltCalulator(unittest.TestCase):
             event_type=SVTYPE.INS,
             untemplated_seq='TT',
         )
-        bpp = self.calculator.calculate_ref_counts(ev1)
+        bpp = calculator.calculate_ref_counts(ev1)
         print(bpp.data)
-        self.assertEqual(0, bpp.data["TEST_ref_count"])
-        self.assertEqual(23, bpp.data["TEST_alt_count"])
-        self.assertEqual(145, bpp.data['TEST_ignored_count'])
+        assert bpp.data["TEST_ref_count"] == 0
+        assert bpp.data["TEST_alt_count"] == 23
+        assert bpp.data['TEST_ignored_count'] == 145
 
-    def test_calculate_count4(self):
+    def test_calculate_count4(self, calculator):
         ev1 = BreakpointPair(
             Breakpoint('reference11', 1999, orient=ORIENT.LEFT),
             Breakpoint('reference11', 2001, orient=ORIENT.RIGHT),
             opposing_strands=False,
             event_type=SVTYPE.DEL,
         )
-        bpp = self.calculator.calculate_ref_counts(ev1)
+        bpp = calculator.calculate_ref_counts(ev1)
         print(bpp.data)
-        self.assertEqual(0, bpp.data["TEST_ref_count"])
-        self.assertEqual(50, bpp.data["TEST_alt_count"])
-        self.assertEqual(191, bpp.data['TEST_ignored_count'])
+        assert bpp.data["TEST_ref_count"] == 0
+        assert bpp.data["TEST_alt_count"] == 50
+        assert bpp.data['TEST_ignored_count'] == 191

--- a/tests/integration/test_align.py
+++ b/tests/integration/test_align.py
@@ -1,21 +1,21 @@
 import shutil
-import unittest
 from unittest import mock
 
 import mavis.bam.cigar as _cigar
+import pytest
 from mavis import align
 from mavis.annotate.file_io import load_reference_genome
 from mavis.assemble import Contig
 from mavis.bam.cache import BamCache
 from mavis.bam.read import SamRead
 from mavis.breakpoint import Breakpoint, BreakpointPair
-from mavis.constants import CIGAR, ORIENT, STRAND, SVTYPE, reverse_complement
+from mavis.constants import CIGAR, ORIENT, STRAND, reverse_complement
 from mavis.interval import Interval
 from mavis.schemas import DEFAULTS
 from mavis.validate.evidence import GenomeEvidence
 
 from ..util import get_data
-from . import MockBamFileHandle, MockLongString, MockObject, MockRead
+from . import MockLongString, MockObject, MockRead
 
 REFERENCE_GENOME = None
 
@@ -32,7 +32,7 @@ def setUpModule():
     BAM_CACHE = BamCache(get_data('mini_mock_reads_for_events.sorted.bam'))
 
 
-class TestCallReadEvents(unittest.TestCase):
+class TestCallReadEvents:
     def test_hardclipping(self):
         read = SamRead(reference_name='15')
         read.reference_start = 71491944
@@ -46,16 +46,13 @@ class TestCallReadEvents(unittest.TestCase):
             untemplated_seq='',
         )
         events = align.call_read_events(read, is_stranded=True)
-        self.assertEqual(1, len(events))
-        self.assertEqual(expected_bpp.break1, events[0].break1)
-        self.assertEqual(expected_bpp.break2, events[0].break2)
+        assert len(events) == 1
+        assert events[0].break1 == expected_bpp.break1
+        assert events[0].break2 == expected_bpp.break2
 
 
-class TestAlign(unittest.TestCase):
-    def setUp(self):
-        self.cache = BamCache(MockBamFileHandle({'Y': 23, 'fake': 0, 'reference3': 3}))
-
-    @unittest.skipIf(not shutil.which('blat'), 'missing the blat command')
+class TestAlign:
+    @pytest.mark.skipif(not shutil.which('blat'), reason='missing the blat command')
     def test_blat_contigs(self):
         ev = GenomeEvidence(
             Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
@@ -92,16 +89,16 @@ class TestAlign(unittest.TestCase):
         align.select_contig_alignments(ev, seq)
         print(ev.contigs[0].alignments)
         alignment = list(ev.contigs[0].alignments)[0]
-        self.assertEqual(1, alignment.read1.reference_id)
-        self.assertEqual(1, alignment.read2.reference_id)
-        self.assertEqual(Interval(125, 244), align.query_coverage_interval(alignment.read1))
-        self.assertEqual(Interval(117, 244), align.query_coverage_interval(alignment.read2))
-        self.assertEqual(1114, alignment.read1.reference_start)
-        self.assertEqual(2187, alignment.read2.reference_start)
-        self.assertEqual([(CIGAR.S, 125), (CIGAR.EQ, 120)], alignment.read1.cigar)
-        self.assertEqual([(CIGAR.S, 117), (CIGAR.EQ, 128)], alignment.read2.cigar)
+        assert alignment.read1.reference_id == 1
+        assert alignment.read2.reference_id == 1
+        assert align.query_coverage_interval(alignment.read1) == Interval(125, 244)
+        assert align.query_coverage_interval(alignment.read2) == Interval(117, 244)
+        assert alignment.read1.reference_start == 1114
+        assert alignment.read2.reference_start == 2187
+        assert alignment.read1.cigar == [(CIGAR.S, 125), (CIGAR.EQ, 120)]
+        assert alignment.read2.cigar == [(CIGAR.S, 117), (CIGAR.EQ, 128)]
 
-    @unittest.skipIf(not shutil.which('bwa'), 'missing the command')
+    @pytest.mark.skipif(not shutil.which('bwa'), reason='missing the command')
     def test_bwa_contigs(self):
         ev = GenomeEvidence(
             Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
@@ -139,21 +136,19 @@ class TestAlign(unittest.TestCase):
         align.select_contig_alignments(ev, seq)
         print(ev.contigs[0].alignments)
         alignment = list(ev.contigs[0].alignments)[0]
-        self.assertEqual(
-            reverse_complement(alignment.read1.query_sequence), alignment.read2.query_sequence
-        )
-        self.assertEqual('reference3', alignment.read1.reference_name)
-        self.assertEqual('reference3', alignment.read2.reference_name)
-        self.assertEqual(1, alignment.read1.reference_id)
-        self.assertEqual(1, alignment.read2.reference_id)
-        self.assertEqual(Interval(125, 244), align.query_coverage_interval(alignment.read1))
-        self.assertEqual(Interval(117, 244), align.query_coverage_interval(alignment.read2))
-        self.assertEqual(1114, alignment.read1.reference_start)
-        self.assertEqual(2187, alignment.read2.reference_start)
-        self.assertEqual([(CIGAR.S, 125), (CIGAR.EQ, 120)], alignment.read1.cigar)
-        self.assertEqual([(CIGAR.S, 117), (CIGAR.EQ, 128)], alignment.read2.cigar)
+        assert alignment.read2.query_sequence == reverse_complement(alignment.read1.query_sequence)
+        assert alignment.read1.reference_name == 'reference3'
+        assert alignment.read2.reference_name == 'reference3'
+        assert alignment.read1.reference_id == 1
+        assert alignment.read2.reference_id == 1
+        assert align.query_coverage_interval(alignment.read1) == Interval(125, 244)
+        assert align.query_coverage_interval(alignment.read2) == Interval(117, 244)
+        assert alignment.read1.reference_start == 1114
+        assert alignment.read2.reference_start == 2187
+        assert alignment.read1.cigar == [(CIGAR.S, 125), (CIGAR.EQ, 120)]
+        assert alignment.read2.cigar == [(CIGAR.S, 117), (CIGAR.EQ, 128)]
 
-    @unittest.skipIf(not shutil.which('blat'), 'missing the blat command')
+    @pytest.mark.skipif(not shutil.which('blat'), reason='missing the blat command')
     def test_blat_contigs_deletion(self):
         ev = GenomeEvidence(
             Breakpoint('fake', 1714, orient=ORIENT.LEFT),
@@ -188,20 +183,16 @@ class TestAlign(unittest.TestCase):
         print('alignments:')
         for aln in alignments:
             print(aln, repr(aln.read1), repr(aln.read2))
-        self.assertEqual(1, len(alignments))
+        assert len(alignments) == 1
         alignment = alignments[0]
-        self.assertTrue(alignment.read2 is None)
-        self.assertEqual(0, alignment.read1.reference_id)
-        self.assertTrue(not alignment.read1.is_reverse)
-        self.assertEqual(Interval(0, 175), align.query_coverage_interval(alignment.read1))
-        self.assertEqual(1612, alignment.read1.reference_start)
-        self.assertEqual([(CIGAR.EQ, 102), (CIGAR.D, 1253), (CIGAR.EQ, 74)], alignment.read1.cigar)
+        assert alignment.read2 is None
+        assert alignment.read1.reference_id == 0
+        assert not alignment.read1.is_reverse
+        assert align.query_coverage_interval(alignment.read1) == Interval(0, 175)
+        assert alignment.read1.reference_start == 1612
+        assert alignment.read1.cigar == [(CIGAR.EQ, 102), (CIGAR.D, 1253), (CIGAR.EQ, 74)]
 
-    @unittest.skipIf(not shutil.which('blat'), 'missing the blat command')
-    def test_blat_contigs_inversion(self):
-        raise unittest.SkipTest('TODO')
-
-    @unittest.skipIf(not shutil.which('blat'), 'missing the blat command')
+    @pytest.mark.skipif(not shutil.which('blat'), reason='missing the blat command')
     def test_blat_contigs_deletion_revcomp(self):
         ev = GenomeEvidence(
             Breakpoint('fake', 1714, orient=ORIENT.LEFT),
@@ -231,33 +222,32 @@ class TestAlign(unittest.TestCase):
         print('alignments:', ev.contigs[0].alignments)
         alignment = list(ev.contigs[0].alignments)[0]
         print(alignment)
-        self.assertTrue(alignment.read2 is None)
-        self.assertEqual(0, alignment.read1.reference_id)
-        self.assertTrue(alignment.read1.is_reverse)
-        self.assertEqual(seq, alignment.read1.query_sequence)
-        self.assertEqual(Interval(0, 175), align.query_coverage_interval(alignment.read1))
-        self.assertEqual(1612, alignment.read1.reference_start)
-        self.assertEqual([(CIGAR.EQ, 102), (CIGAR.D, 1253), (CIGAR.EQ, 74)], alignment.read1.cigar)
+        assert alignment.read2 is None
+        assert alignment.read1.reference_id == 0
+        assert alignment.read1.is_reverse
+        assert alignment.read1.query_sequence == seq
+        assert align.query_coverage_interval(alignment.read1) == Interval(0, 175)
+        assert alignment.read1.reference_start == 1612
+        assert alignment.read1.cigar == [(CIGAR.EQ, 102), (CIGAR.D, 1253), (CIGAR.EQ, 74)]
 
 
-class TestBreakpointContigRemappedDepth(unittest.TestCase):
-    def setUp(self):
-        self.contig = Contig(' ' * 60, None)
-        self.contig.add_mapped_sequence(MockObject(reference_start=0, reference_end=10))
-        self.contig.add_mapped_sequence(MockObject(reference_start=0, reference_end=20))
-        self.contig.add_mapped_sequence(MockObject(reference_start=50, reference_end=60))
-
+class TestBreakpointContigRemappedDepth:
     def test_break_left_deletion(self):
+        contig = Contig(' ' * 60, None)
+        contig.add_mapped_sequence(MockObject(reference_start=0, reference_end=10))
+        contig.add_mapped_sequence(MockObject(reference_start=0, reference_end=20))
+        contig.add_mapped_sequence(MockObject(reference_start=50, reference_end=60))
+
         b = Breakpoint('10', 1030, 1030, orient=ORIENT.LEFT)
         read = MockRead(
             cigar=_cigar.convert_string_to_cigar('35M10D5I20M'),
             reference_start=999,
             reference_name='10',
         )
-        align.SplitAlignment.breakpoint_contig_remapped_depth(b, self.contig, read)
+        align.SplitAlignment.breakpoint_contig_remapped_depth(b, contig, read)
 
 
-class TestSplitEvents(unittest.TestCase):
+class TestSplitEvents:
     def test_read_with_exons(self):
         contig = MockRead(
             query_sequence='CTTGAAGGAAACTGAATTCAAAAAGATCAAAGTGCTGGGCTCCGGTGCGTTCGGCACGGTGTATAAGGGACTCTGGATCCCAGAAGGTGAGAAAGTTAAAATTCCCGTCGCTATCAAGACATCTCCGAAAGCCAACAAGGAAATCCTCGATGAAGCCTACGTGATGGCCAGCGTGGACAACCCCCACGTGTGCCGCCTGCTGGGCATCTGCCTCACCTCCACCGTGCAGCTCATCATGCAGCTCATGCCCTTCGGCTGCCTCCTGGACTATGTCCGGGAACACAAAGACAATATTGGCTCCCAGTACCTGCTCAACTGGTGTGTGCAGATCGCAAAGGGCATGAACTACTTGGAGGACCGTCGCTTGGTGCACCGCGACCTGGCAGCCAGGAACGTACTGGTGAAAACACCGCAGCATGTCAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCGGAAGAGAAAGAATACCATGCAGAAGGAGGCAAAGTGCCTATCAAGTGGATGGCATTGGAATCAATTTTACACAGAATCTATACCCACCAGAGTGATGTCTGGAGCTACGGGGTGACCGTTTGGGAGTTGATGACCTTTGGATCCAA',
@@ -268,10 +258,10 @@ class TestSplitEvents(unittest.TestCase):
             reference_id=6,
             reference_start=55241669,
         )
-        self.assertEqual(6, len(align.call_read_events(contig)))
+        assert len(align.call_read_events(contig)) == 6
 
 
-class TestCallBreakpointPair(unittest.TestCase):
+class TestCallBreakpointPair:
     def test_single_one_event(self):
         r = MockRead(
             reference_id=0,
@@ -281,14 +271,14 @@ class TestCallBreakpointPair(unittest.TestCase):
             query_sequence='ACTGAATCGTGGGTAGCTGCTAG',
         )
         bpps = align.call_read_events(r)
-        self.assertEqual(1, len(bpps))
+        assert len(bpps) == 1
         bpp = bpps[0]
-        self.assertEqual(False, bpp.opposing_strands)
-        self.assertEqual(10, bpp.break1.start)
-        self.assertEqual(10, bpp.break1.end)
-        self.assertEqual(18, bpp.break2.start)
-        self.assertEqual(18, bpp.break2.end)
-        self.assertEqual('GGG', bpp.untemplated_seq)
+        assert bpp.opposing_strands is False
+        assert bpp.break1.start == 10
+        assert bpp.break1.end == 10
+        assert bpp.break2.start == 18
+        assert bpp.break2.end == 18
+        assert bpp.untemplated_seq == 'GGG'
 
     def test_ins_and_del(self):
         r = MockRead(
@@ -300,20 +290,20 @@ class TestCallBreakpointPair(unittest.TestCase):
         )
         # only report the major del event for now
         bpps = align.call_read_events(r)
-        self.assertEqual(2, len(bpps))
+        assert len(bpps) == 2
         bpp = bpps[0]
-        self.assertEqual(False, bpp.opposing_strands)
-        self.assertEqual(10, bpp.break1.start)
-        self.assertEqual(10, bpp.break1.end)
-        self.assertEqual(11, bpp.break2.start)
-        self.assertEqual(11, bpp.break2.end)
-        self.assertEqual('GGG', bpp.untemplated_seq)
+        assert bpp.opposing_strands is False
+        assert bpp.break1.start == 10
+        assert bpp.break1.end == 10
+        assert bpp.break2.start == 11
+        assert bpp.break2.end == 11
+        assert bpp.untemplated_seq == 'GGG'
         bpp = bpps[1]
-        self.assertEqual(False, bpp.opposing_strands)
-        self.assertEqual(15, bpp.break1.start)
-        self.assertEqual(15, bpp.break1.end)
-        self.assertEqual(23, bpp.break2.start)
-        self.assertEqual(23, bpp.break2.end)
+        assert bpp.opposing_strands is False
+        assert bpp.break1.start == 15
+        assert bpp.break1.end == 15
+        assert bpp.break2.start == 23
+        assert bpp.break2.end == 23
 
     def test_single_insertion(self):
         r = MockRead(
@@ -324,12 +314,12 @@ class TestCallBreakpointPair(unittest.TestCase):
             query_sequence='ACTGAATCGTGGGTAGCTGCTAG',
         )
         bpp = align.call_read_events(r)[0]
-        self.assertEqual(False, bpp.opposing_strands)
-        self.assertEqual(10, bpp.break1.start)
-        self.assertEqual(10, bpp.break1.end)
-        self.assertEqual(11, bpp.break2.start)
-        self.assertEqual(11, bpp.break2.end)
-        self.assertEqual('GGGTAGCT', bpp.untemplated_seq)
+        assert bpp.opposing_strands is False
+        assert bpp.break1.start == 10
+        assert bpp.break1.end == 10
+        assert bpp.break2.start == 11
+        assert bpp.break2.end == 11
+        assert bpp.untemplated_seq == 'GGGTAGCT'
 
     def test_single_duplication(self):
         r = MockRead(
@@ -341,9 +331,9 @@ class TestCallBreakpointPair(unittest.TestCase):
             'GACAGACTCTAGTAGTGTC',
         )
         bpp = align.call_read_events(r)[0]
-        self.assertEqual(27220, bpp.break1.start)
-        self.assertEqual(27316, bpp.break2.start)
-        self.assertEqual('AGACTT', bpp.untemplated_seq)
+        assert bpp.break1.start == 27220
+        assert bpp.break2.start == 27316
+        assert bpp.untemplated_seq == 'AGACTT'
 
     def test_single_duplication_with_leading_untemp(self):
         r = MockRead(
@@ -360,11 +350,9 @@ class TestCallBreakpointPair(unittest.TestCase):
             is_reverse=False,
         )
         bpp = align.call_read_events(r)[0]
-        self.assertEqual(
-            'AGGTTCCATGGGCTCCGTAGGTTCCATGGGCTCCGTAGGTTCCATCGGCTCCGT', bpp.untemplated_seq
-        )
-        self.assertEqual(ORIENT.LEFT, bpp.break1.orient)
-        self.assertEqual(ORIENT.RIGHT, bpp.break2.orient)
+        assert bpp.untemplated_seq == 'AGGTTCCATGGGCTCCGTAGGTTCCATGGGCTCCGTAGGTTCCATCGGCTCCGT'
+        assert bpp.break1.orient == ORIENT.LEFT
+        assert bpp.break2.orient == ORIENT.RIGHT
 
     def test_single_duplication_with_no_untemp(self):
         r = MockRead(
@@ -381,11 +369,11 @@ class TestCallBreakpointPair(unittest.TestCase):
         )
         # repeat: GATTTTGCTGTTGTTTTTGTTC
         bpp = align.convert_to_duplication(align.call_read_events(r)[0], REFERENCE_GENOME)
-        self.assertEqual('', bpp.untemplated_seq)
-        self.assertEqual(ORIENT.RIGHT, bpp.break1.orient)
-        self.assertEqual(ORIENT.LEFT, bpp.break2.orient)
-        self.assertEqual(bpp.break2.start, 1548)
-        self.assertEqual(bpp.break1.start, 1527)
+        assert bpp.untemplated_seq == ''
+        assert bpp.break1.orient == ORIENT.RIGHT
+        assert bpp.break2.orient == ORIENT.LEFT
+        assert 1548 == bpp.break2.start
+        assert 1527 == bpp.break1.start
 
     def test_single_duplication_with_trailing_untemp(self):
         r = MockRead(
@@ -411,11 +399,11 @@ class TestCallBreakpointPair(unittest.TestCase):
         print(bpp)
         bpp = align.convert_to_duplication(bpp, REFERENCE_GENOME)
         print(bpp)
-        self.assertEqual('GTCAA', bpp.untemplated_seq)
-        self.assertEqual(ORIENT.RIGHT, bpp.break1.orient)
-        self.assertEqual(ORIENT.LEFT, bpp.break2.orient)
-        self.assertEqual(bpp.break2.start, 1548)
-        self.assertEqual(bpp.break1.start, 1527)
+        assert bpp.untemplated_seq == 'GTCAA'
+        assert bpp.break1.orient == ORIENT.RIGHT
+        assert bpp.break2.orient == ORIENT.LEFT
+        assert 1548 == bpp.break2.start
+        assert 1527 == bpp.break1.start
 
     def test_read_pair_indel(self):
         # seq AAATTTCCCGGGAATTCCGGATCGATCGAT 1-30     1-?
@@ -441,15 +429,15 @@ class TestCallBreakpointPair(unittest.TestCase):
             is_reverse=False,
         )
         bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
-        self.assertEqual(STRAND.POS, bpp.break1.strand)
-        self.assertEqual(STRAND.POS, bpp.break2.strand)
-        self.assertEqual(ORIENT.LEFT, bpp.break1.orient)
-        self.assertEqual(ORIENT.RIGHT, bpp.break2.orient)
-        self.assertEqual('GGGAATTCCGGA', bpp.untemplated_seq)
-        self.assertEqual(9, bpp.break1.start)
-        self.assertEqual(100, bpp.break2.start)
-        self.assertEqual('AAATTTCCC', bpp.break1.seq)
-        self.assertEqual('TCGATCGAT', bpp.break2.seq)
+        assert bpp.break1.strand == STRAND.POS
+        assert bpp.break2.strand == STRAND.POS
+        assert bpp.break1.orient == ORIENT.LEFT
+        assert bpp.break2.orient == ORIENT.RIGHT
+        assert bpp.untemplated_seq == 'GGGAATTCCGGA'
+        assert bpp.break1.start == 9
+        assert bpp.break2.start == 100
+        assert bpp.break1.seq == 'AAATTTCCC'
+        assert bpp.break2.seq == 'TCGATCGAT'
 
     def test_read_pair_deletion(self):
         # seq AAATTTCCCGGGAATTCCGGATCGATCGAT
@@ -474,13 +462,13 @@ class TestCallBreakpointPair(unittest.TestCase):
             is_reverse=False,
         )
         bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
-        self.assertEqual(STRAND.POS, bpp.break1.strand)
-        self.assertEqual(STRAND.POS, bpp.break2.strand)
-        self.assertEqual(ORIENT.LEFT, bpp.break1.orient)
-        self.assertEqual(ORIENT.RIGHT, bpp.break2.orient)
-        self.assertEqual('', bpp.untemplated_seq)
-        self.assertEqual(21, bpp.break1.start)
-        self.assertEqual(100, bpp.break2.start)
+        assert bpp.break1.strand == STRAND.POS
+        assert bpp.break2.strand == STRAND.POS
+        assert bpp.break1.orient == ORIENT.LEFT
+        assert bpp.break2.orient == ORIENT.RIGHT
+        assert bpp.untemplated_seq == ''
+        assert bpp.break1.start == 21
+        assert bpp.break2.start == 100
 
     def test_read_pair_translocation(self):
         # seq AAATTTCCCGGGAATTCCGGATCGATCGAT
@@ -505,13 +493,13 @@ class TestCallBreakpointPair(unittest.TestCase):
             is_reverse=False,
         )
         bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
-        self.assertEqual(STRAND.POS, bpp.break1.strand)
-        self.assertEqual(STRAND.POS, bpp.break2.strand)
-        self.assertEqual(ORIENT.RIGHT, bpp.break1.orient)
-        self.assertEqual(ORIENT.LEFT, bpp.break2.orient)
-        self.assertEqual('1', bpp.break1.chr)
-        self.assertEqual('2', bpp.break2.chr)
-        self.assertEqual('', bpp.untemplated_seq)
+        assert bpp.break1.strand == STRAND.POS
+        assert bpp.break2.strand == STRAND.POS
+        assert bpp.break1.orient == ORIENT.RIGHT
+        assert bpp.break2.orient == ORIENT.LEFT
+        assert bpp.break1.chr == '1'
+        assert bpp.break2.chr == '2'
+        assert bpp.untemplated_seq == ''
 
     def test_read_pair_deletion_overlapping_query_coverage(self):
         # seq AAATTTCCCGGGAATTCCGGATCGATCGAT
@@ -536,17 +524,17 @@ class TestCallBreakpointPair(unittest.TestCase):
             query_sequence=seq,
             is_reverse=False,
         )
-        self.assertEqual(21, r1.reference_end)
+        assert r1.reference_end == 21
         bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
-        self.assertEqual(STRAND.POS, bpp.break1.strand)
-        self.assertEqual(STRAND.POS, bpp.break2.strand)
-        self.assertEqual(ORIENT.LEFT, bpp.break1.orient)
-        self.assertEqual(ORIENT.RIGHT, bpp.break2.orient)
-        self.assertEqual('', bpp.untemplated_seq)
-        self.assertEqual(21, bpp.break1.start)
-        self.assertEqual(103, bpp.break2.start)
-        self.assertEqual('AAATTTCCCGGGAATTCCGGA', bpp.break1.seq)
-        self.assertEqual('TCGATCGAT', bpp.break2.seq)
+        assert bpp.break1.strand == STRAND.POS
+        assert bpp.break2.strand == STRAND.POS
+        assert bpp.break1.orient == ORIENT.LEFT
+        assert bpp.break2.orient == ORIENT.RIGHT
+        assert bpp.untemplated_seq == ''
+        assert bpp.break1.start == 21
+        assert bpp.break2.start == 103
+        assert bpp.break1.seq == 'AAATTTCCCGGGAATTCCGGA'
+        assert bpp.break2.seq == 'TCGATCGAT'
 
     def test_read_pair_inversion_overlapping_query_coverage(self):
         # seq AAATTTCCCGGGAATTCCGGATCGATCGAT
@@ -573,15 +561,15 @@ class TestCallBreakpointPair(unittest.TestCase):
             is_reverse=True,
         )
         bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
-        self.assertEqual(STRAND.POS, bpp.break1.strand)
-        self.assertEqual(STRAND.NEG, bpp.break2.strand)
-        self.assertEqual(ORIENT.LEFT, bpp.break1.orient)
-        self.assertEqual(ORIENT.LEFT, bpp.break2.orient)
-        self.assertEqual('', bpp.untemplated_seq)
-        self.assertEqual(21, bpp.break1.start)
-        self.assertEqual(108, bpp.break2.start)
-        self.assertEqual('AAATTTCCCGGGAATTCCGGA', bpp.break1.seq)
-        self.assertEqual(reverse_complement('TCGATCGAT'), bpp.break2.seq)
+        assert bpp.break1.strand == STRAND.POS
+        assert bpp.break2.strand == STRAND.NEG
+        assert bpp.break1.orient == ORIENT.LEFT
+        assert bpp.break2.orient == ORIENT.LEFT
+        assert bpp.untemplated_seq == ''
+        assert bpp.break1.start == 21
+        assert bpp.break2.start == 108
+        assert bpp.break1.seq == 'AAATTTCCCGGGAATTCCGGA'
+        assert bpp.break2.seq == reverse_complement('TCGATCGAT')
 
     def test_read_pair_large_inversion_overlapping_query_coverage(self):
         s = 'CTGAGCATGAAAGCCCTGTAAACACAGAATTTGGATTCTTTCCTGTTTGGTTCCTGGTCGTGAGTGGCAGGTGCCATCATGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTGGTTATGAAATTTCAGGGTTTTCATTTCTGTATGTTAAT'
@@ -601,24 +589,22 @@ class TestCallBreakpointPair(unittest.TestCase):
             is_reverse=True,
         )
         bpp = align.call_paired_read_event(read1, read2, is_stranded=True)
-        self.assertEqual(STRAND.POS, bpp.break1.strand)
-        self.assertEqual(STRAND.NEG, bpp.break2.strand)
-        self.assertEqual(ORIENT.RIGHT, bpp.break1.orient)
-        self.assertEqual(ORIENT.RIGHT, bpp.break2.orient)
-        self.assertEqual('', bpp.untemplated_seq)
-        self.assertEqual(1115, bpp.break1.start)
-        self.assertEqual(2188 + 3, bpp.break2.start)
+        assert bpp.break1.strand == STRAND.POS
+        assert bpp.break2.strand == STRAND.NEG
+        assert bpp.break1.orient == ORIENT.RIGHT
+        assert bpp.break2.orient == ORIENT.RIGHT
+        assert bpp.untemplated_seq == ''
+        assert bpp.break1.start == 1115
+        assert bpp.break2.start == 2188 + 3
         print(bpp.break1.seq)
         print(bpp.break2.seq)
-        self.assertEqual(
-            'TCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTGGTTATGAAATTTCAG'
-            'GGTTTTCATTTCTGTATGTTAAT',
-            bpp.break1.seq,
+        assert (
+            bpp.break1.seq
+            == 'TCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTGGTTATGAAATTTCAGGGTTTTCATTTCTGTATGTTAAT'
         )
-        self.assertEqual(
-            'GCAGAGCTATATATTTAGGTAGACTGCTCTCAGGCAGAATGAAACATGATGGCACCTGCCACTCACGACCAGGAACCAAACAGGAAAGAATCCA'
-            'AATTCTGTGTTTACAGGGCTTTCATGCTCAG',
-            bpp.break2.seq,
+        assert (
+            bpp.break2.seq
+            == 'GCAGAGCTATATATTTAGGTAGACTGCTCTCAGGCAGAATGAAACATGATGGCACCTGCCACTCACGACCAGGAACCAAACAGGAAAGAATCCAAATTCTGTGTTTACAGGGCTTTCATGCTCAG'
         )
 
     def test_read_pair_inversion_gap_in_query_coverage(self):
@@ -646,18 +632,18 @@ class TestCallBreakpointPair(unittest.TestCase):
             is_reverse=True,
         )
         bpp = align.call_paired_read_event(r1, r2, is_stranded=True)
-        self.assertEqual(STRAND.POS, bpp.break1.strand)
-        self.assertEqual(STRAND.NEG, bpp.break2.strand)
-        self.assertEqual(ORIENT.LEFT, bpp.break1.orient)
-        self.assertEqual(ORIENT.LEFT, bpp.break2.orient)
-        self.assertEqual('CC', bpp.untemplated_seq)
-        self.assertEqual(16, bpp.break1.start)
-        self.assertEqual(111, bpp.break2.start)
-        self.assertEqual('AAATTTCCCGGGAATT', bpp.break1.seq)
-        self.assertEqual(reverse_complement('GGATCGATCGAT'), bpp.break2.seq)
+        assert bpp.break1.strand == STRAND.POS
+        assert bpp.break2.strand == STRAND.NEG
+        assert bpp.break1.orient == ORIENT.LEFT
+        assert bpp.break2.orient == ORIENT.LEFT
+        assert bpp.untemplated_seq == 'CC'
+        assert bpp.break1.start == 16
+        assert bpp.break2.start == 111
+        assert bpp.break1.seq == 'AAATTTCCCGGGAATT'
+        assert bpp.break2.seq == reverse_complement('GGATCGATCGAT')
 
 
-class TestConvertToDuplication(unittest.TestCase):
+class TestConvertToDuplication:
     def test_insertion_to_duplication(self):
         # BPP(Breakpoint(3:60204611L), Breakpoint(3:60204612R), opposing=False, seq='CATACATACATACATACATACATACATACATA')
         # insertion contig [seq2] contig_alignment_score: 0.99, contig_alignment_mq: Interval(255, 255)
@@ -681,13 +667,13 @@ class TestConvertToDuplication(unittest.TestCase):
         setattr(bpp, 'read2', None)
         event = align.convert_to_duplication(bpp, reference_genome)
         print(event)
-        self.assertEqual(ORIENT.RIGHT, event.break1.orient)
-        self.assertEqual(60204588, event.break1.start)
-        self.assertEqual(ORIENT.LEFT, event.break2.orient)
-        self.assertEqual(60204611, event.break2.start)
+        assert event.break1.orient == ORIENT.RIGHT
+        assert event.break1.start == 60204588
+        assert event.break2.orient == ORIENT.LEFT
+        assert event.break2.start == 60204611
         # CATACATACATACATACATACATACATACATA
         # ........................********
-        self.assertEqual('CATACATA', event.untemplated_seq)
+        assert event.untemplated_seq == 'CATACATA'
 
     def test_single_bp_insertion(self):
         bpp = BreakpointPair(
@@ -704,14 +690,14 @@ class TestConvertToDuplication(unittest.TestCase):
         setattr(bpp, 'read2', None)
         event = align.convert_to_duplication(bpp, reference_genome)
         print(event)
-        self.assertEqual(ORIENT.RIGHT, event.break1.orient)
-        self.assertEqual(121, event.break1.start)
-        self.assertEqual(ORIENT.LEFT, event.break2.orient)
-        self.assertEqual(121, event.break2.start)
-        self.assertEqual('', event.untemplated_seq)
+        assert event.break1.orient == ORIENT.RIGHT
+        assert event.break1.start == 121
+        assert event.break2.orient == ORIENT.LEFT
+        assert event.break2.start == 121
+        assert event.untemplated_seq == ''
 
 
-class TestSelectContigAlignments(unittest.TestCase):
+class TestSelectContigAlignments:
     def test_inversion_and_deletion(self):
         s = 'CTGAGCATGAAAGCCCTGTAAACACAGAATTTGGATTCTTTCCTGTTTGGTTCCTGGTCGTGAGTGGCAGGTGCCATCATGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTGGTTATGAAATTTCAGGGTTTTCATTTCTGTATGTTAAT'
         evidence = MockObject(
@@ -756,34 +742,30 @@ class TestSelectContigAlignments(unittest.TestCase):
         raw_alignments = {s: [read1, read2]}
         align.select_contig_alignments(evidence, raw_alignments)
         alignments = list(evidence.contigs[0].alignments)
-        self.assertEqual(2, len(alignments))
+        assert len(alignments) == 2
 
 
-class TestGetAlignerVersion(unittest.TestCase):
+class TestGetAlignerVersion:
     def test_get_blat_36x2(self):
         content = 'blat - Standalone BLAT v. 36x2 fast sequence search command line tool\n'
         with mock.patch('subprocess.getoutput', mock.Mock(return_value=content)):
-            self.assertEqual('36x2', align.get_aligner_version(align.SUPPORTED_ALIGNER.BLAT))
+            assert align.get_aligner_version(align.SUPPORTED_ALIGNER.BLAT) == '36x2'
 
     def test_get_blat_36(self):
         content = "blat - Standalone BLAT v. 36 fast sequence search command line tool"
         with mock.patch('subprocess.getoutput', mock.Mock(return_value=content)):
-            self.assertEqual('36', align.get_aligner_version(align.SUPPORTED_ALIGNER.BLAT))
+            assert align.get_aligner_version(align.SUPPORTED_ALIGNER.BLAT) == '36'
 
     def test_get_bwa_0_7_15(self):
         content = (
             "\nProgram: bwa (alignment via Burrows-Wheeler transformation)\nVersion: 0.7.15-r1140"
         )
         with mock.patch('subprocess.getoutput', mock.Mock(return_value=content)):
-            self.assertEqual(
-                '0.7.15-r1140', align.get_aligner_version(align.SUPPORTED_ALIGNER.BWA_MEM)
-            )
+            assert align.get_aligner_version(align.SUPPORTED_ALIGNER.BWA_MEM) == '0.7.15-r1140'
 
     def test_get_bwa_0_7_12(self):
         content = (
             "\nProgram: bwa (alignment via Burrows-Wheeler transformation)\nVersion: 0.7.12-r1039"
         )
         with mock.patch('subprocess.getoutput', mock.Mock(return_value=content)):
-            self.assertEqual(
-                '0.7.12-r1039', align.get_aligner_version(align.SUPPORTED_ALIGNER.BWA_MEM)
-            )
+            assert align.get_aligner_version(align.SUPPORTED_ALIGNER.BWA_MEM) == '0.7.12-r1039'

--- a/tests/integration/test_align.py
+++ b/tests/integration/test_align.py
@@ -14,7 +14,7 @@ from mavis.interval import Interval
 from mavis.schemas import DEFAULTS
 from mavis.validate.evidence import GenomeEvidence
 
-from ..util import get_data
+from ..util import blat_only, bwa_only, get_data
 from . import MockLongString, MockObject, MockRead
 
 REFERENCE_GENOME = None
@@ -52,7 +52,7 @@ class TestCallReadEvents:
 
 
 class TestAlign:
-    @pytest.mark.skipif(not shutil.which('blat'), reason='missing the blat command')
+    @blat_only
     def test_blat_contigs(self):
         ev = GenomeEvidence(
             Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
@@ -98,7 +98,7 @@ class TestAlign:
         assert alignment.read1.cigar == [(CIGAR.S, 125), (CIGAR.EQ, 120)]
         assert alignment.read2.cigar == [(CIGAR.S, 117), (CIGAR.EQ, 128)]
 
-    @pytest.mark.skipif(not shutil.which('bwa'), reason='missing the command')
+    @bwa_only
     def test_bwa_contigs(self):
         ev = GenomeEvidence(
             Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
@@ -148,7 +148,7 @@ class TestAlign:
         assert alignment.read1.cigar == [(CIGAR.S, 125), (CIGAR.EQ, 120)]
         assert alignment.read2.cigar == [(CIGAR.S, 117), (CIGAR.EQ, 128)]
 
-    @pytest.mark.skipif(not shutil.which('blat'), reason='missing the blat command')
+    @blat_only
     def test_blat_contigs_deletion(self):
         ev = GenomeEvidence(
             Breakpoint('fake', 1714, orient=ORIENT.LEFT),
@@ -192,7 +192,7 @@ class TestAlign:
         assert alignment.read1.reference_start == 1612
         assert alignment.read1.cigar == [(CIGAR.EQ, 102), (CIGAR.D, 1253), (CIGAR.EQ, 74)]
 
-    @pytest.mark.skipif(not shutil.which('blat'), reason='missing the blat command')
+    @blat_only
     def test_blat_contigs_deletion_revcomp(self):
         ev = GenomeEvidence(
             Breakpoint('fake', 1714, orient=ORIENT.LEFT),

--- a/tests/integration/test_annotate.py
+++ b/tests/integration/test_annotate.py
@@ -1,6 +1,7 @@
-import os
+import argparse
 import unittest
 
+import pytest
 from mavis.annotate.base import BioInterval, ReferenceName
 from mavis.annotate.file_io import load_annotations, load_reference_genome
 from mavis.annotate.fusion import FusionTranscript, determine_prime
@@ -11,16 +12,15 @@ from mavis.annotate.variant import (
     _gather_annotations,
     _gather_breakpoint_annotations,
     annotate_events,
-    flatten_fusion_transcript,
     overlapping_transcripts,
 )
 from mavis.breakpoint import Breakpoint, BreakpointPair
-from mavis.constants import ORIENT, PRIME, PROTOCOL, SPLICE_TYPE, STRAND, SVTYPE, reverse_complement
+from mavis.constants import ORIENT, PRIME, PROTOCOL, STRAND, SVTYPE, reverse_complement
 from mavis.error import NotSpecifiedError
 from mavis.interval import Interval
 
 from ..util import get_data
-from . import MockLongString, MockObject, get_example_genes
+from . import MockObject, get_example_genes
 
 REFERENCE_ANNOTATIONS = None
 REFERENCE_GENOME = None
@@ -40,129 +40,156 @@ def setUpModule():
     print('loaded the reference genome', get_data('mock_reference_genome.fa'))
 
 
-class TestTemplate(unittest.TestCase):
+class TestTemplate:
     def test_template_hashing(self):
         t = Template('1', 1, 10)
         d = {'1': 1, '2': 2, 1: '5'}
-        self.assertEqual('1', t.name)
-        self.assertEqual(1, d[t.name])
-        self.assertEqual(1, d[t])
+        assert t.name == '1'
+        assert d[t.name] == 1
+        assert d[t] == 1
 
 
-class TestFusionTranscript(unittest.TestCase):
-    def setUp(self):
-        self.x = Interval(100, 199)  # C
-        self.y = Interval(500, 599)  # G
-        self.z = Interval(1200, 1299)  # T
-        self.w = Interval(1500, 1599)  # C
-        self.s = Interval(1700, 1799)  # G
-        # introns: 99, 300, 600, 200, 100, ...
-        reference_sequence = 'A' * 99 + 'C' * 100 + 'A' * 300 + 'G' * 100
-        reference_sequence += 'A' * 600 + 'T' * 100 + 'A' * 200 + 'C' * 100
-        reference_sequence += 'A' * 100 + 'G' * 100 + 'A' * 200 + 'T' * 100
+@pytest.fixture
+def intervals():
+    n = argparse.Namespace()
+    n.x = Interval(100, 199)  # C
+    n.y = Interval(500, 599)  # G
+    n.z = Interval(1200, 1299)  # T
+    n.w = Interval(1500, 1599)  # C
+    n.s = Interval(1700, 1799)  # G
+    # introns: 99, 300, 600, 200, 100, ...
+    reference_sequence = 'A' * 99 + 'C' * 100 + 'A' * 300 + 'G' * 100
+    reference_sequence += 'A' * 600 + 'T' * 100 + 'A' * 200 + 'C' * 100
+    reference_sequence += 'A' * 100 + 'G' * 100 + 'A' * 200 + 'T' * 100
 
-        self.a = Interval(2000, 2099)  # T
-        self.b = Interval(2600, 2699)  # C
-        self.c = Interval(3000, 3099)  # G
-        self.d = Interval(3300, 3399)  # T
-        reference_sequence += 'A' * 500 + 'C' * 100 + 'A' * 300 + 'G' * 100
-        reference_sequence += 'A' * 200 + 'T' * 100 + 'A' * 200
-        self.reference_sequence = reference_sequence
+    n.a = Interval(2000, 2099)  # T
+    n.b = Interval(2600, 2699)  # C
+    n.c = Interval(3000, 3099)  # G
+    n.d = Interval(3300, 3399)  # T
+    reference_sequence += 'A' * 500 + 'C' * 100 + 'A' * 300 + 'G' * 100
+    reference_sequence += 'A' * 200 + 'T' * 100 + 'A' * 200
+    n.reference_sequence = reference_sequence
 
-        self.b1 = Interval(600, 699)  # A
-        self.b2 = Interval(800, 899)  # G
-        self.b3 = Interval(1100, 1199)  # T
-        self.b4 = Interval(1400, 1499)  # A
-        self.b5 = Interval(1700, 1799)  # G
-        self.b6 = Interval(2100, 2199)  # A
-        alternate_sequence = 'C' * 599 + 'A' * 100 + 'C' * 100 + 'G' * 100
-        alternate_sequence += 'C' * 200 + 'T' * 100 + 'C' * 200 + 'A' * 100
-        alternate_sequence += 'C' * 200 + 'G' * 100 + 'C' * 300 + 'A' * 100
-        alternate_sequence += 'C' * 200
-        self.alternate_sequence = alternate_sequence
+    n.b1 = Interval(600, 699)  # A
+    n.b2 = Interval(800, 899)  # G
+    n.b3 = Interval(1100, 1199)  # T
+    n.b4 = Interval(1400, 1499)  # A
+    n.b5 = Interval(1700, 1799)  # G
+    n.b6 = Interval(2100, 2199)  # A
+    alternate_sequence = 'C' * 599 + 'A' * 100 + 'C' * 100 + 'G' * 100
+    alternate_sequence += 'C' * 200 + 'T' * 100 + 'C' * 200 + 'A' * 100
+    alternate_sequence += 'C' * 200 + 'G' * 100 + 'C' * 300 + 'A' * 100
+    alternate_sequence += 'C' * 200
+    n.alternate_sequence = alternate_sequence
+    return n
 
-    def test__pull_exons_left_pos_intronic(self):
+
+class TestFusionTranscript:
+    def test__pull_exons_left_pos_intronic(self, intervals):
         # 100-199, 500-599, 1200-1299, 1500-1599, 1700-1799
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b = Breakpoint(REF_CHR, 700, orient=ORIENT.LEFT)
-        seq, new_exons = FusionTranscript._pull_exons(t, b, self.reference_sequence)
-        expt = 'C' * len(self.x) + 'A' * (499 - 200 + 1) + 'G' * len(self.y) + 'A' * (700 - 600 + 1)
-        self.assertEqual(expt, seq)
-        self.assertEqual(2, len(new_exons))
+        seq, new_exons = FusionTranscript._pull_exons(t, b, intervals.reference_sequence)
+        expt = (
+            'C' * len(intervals.x)
+            + 'A' * (499 - 200 + 1)
+            + 'G' * len(intervals.y)
+            + 'A' * (700 - 600 + 1)
+        )
+        assert seq == expt
+        assert len(new_exons) == 2
         e = new_exons[0][0]
-        self.assertEqual(1, e.start)
-        self.assertEqual(100, e.end)
-        self.assertEqual(True, e.start_splice_site.intact)
-        self.assertEqual(True, e.end_splice_site.intact)
+        assert e.start == 1
+        assert e.end == 100
+        assert e.start_splice_site.intact is True
+        assert e.end_splice_site.intact is True
 
-    def test__pull_exons_left_pos_intronic_splice(self):
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+    def test__pull_exons_left_pos_intronic_splice(self, intervals):
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b = Breakpoint(REF_CHR, 201, orient=ORIENT.LEFT)
-        seq, new_exons = FusionTranscript._pull_exons(t, b, self.reference_sequence)
+        seq, new_exons = FusionTranscript._pull_exons(t, b, intervals.reference_sequence)
         expt = 'C' * 100 + 'A' * 2
-        self.assertEqual(expt, seq)
-        self.assertEqual(1, len(new_exons))
+        assert seq == expt
+        assert len(new_exons) == 1
         e = new_exons[0][0]
-        self.assertEqual(1, e.start)
-        self.assertEqual(100, e.end)
-        self.assertEqual(True, e.start_splice_site.intact)
-        self.assertEqual(False, e.end_splice_site.intact)
+        assert e.start == 1
+        assert e.end == 100
+        assert e.start_splice_site.intact is True
+        assert e.end_splice_site.intact is False
 
-    def test__pull_exons_left_pos_exonic(self):
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+    def test__pull_exons_left_pos_exonic(self, intervals):
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         print('transcriptt exons:', t.exons)
         b = Breakpoint(REF_CHR, 199, orient=ORIENT.LEFT)
-        seq, new_exons = FusionTranscript._pull_exons(t, b, self.reference_sequence)
+        seq, new_exons = FusionTranscript._pull_exons(t, b, intervals.reference_sequence)
         expt = 'C' * 100
-        self.assertEqual(expt, seq)
-        self.assertEqual(1, len(new_exons))
+        assert seq == expt
+        assert len(new_exons) == 1
         e = new_exons[0][0]
-        self.assertEqual(1, e.start)
-        self.assertEqual(100, e.end)
-        self.assertEqual(True, e.start_splice_site.intact)
-        self.assertEqual(False, e.end_splice_site.intact)
+        assert e.start == 1
+        assert e.end == 100
+        assert e.start_splice_site.intact is True
+        assert e.end_splice_site.intact is False
 
-    def test__pull_exons_left_pos_exonic_splice(self):
+    def test__pull_exons_left_pos_exonic_splice(self, intervals):
         # 100-199, 500-599, 1200-1299, 1500-1599, 1700-1799
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b = Breakpoint(REF_CHR, 101, orient=ORIENT.LEFT)
-        seq, new_exons = FusionTranscript._pull_exons(t, b, self.reference_sequence)
+        seq, new_exons = FusionTranscript._pull_exons(t, b, intervals.reference_sequence)
         expt = 'C' * 2
-        self.assertEqual(expt, seq)
-        self.assertEqual(1, len(new_exons))
+        assert seq == expt
+        assert len(new_exons) == 1
         e = new_exons[0][0]
-        self.assertEqual(1, e.start)
-        self.assertEqual(2, e.end)
-        self.assertEqual(False, e.start_splice_site.intact)
-        self.assertEqual(False, e.end_splice_site.intact)
+        assert e.start == 1
+        assert e.end == 2
+        assert e.start_splice_site.intact is False
+        assert e.end_splice_site.intact is False
 
-    def test__pull_exons_right_pos_intronic(self):
+    def test__pull_exons_right_pos_intronic(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b = Breakpoint(REF_CHR, 1600, orient=ORIENT.RIGHT)
-        seq, new_exons = FusionTranscript._pull_exons(t, b, self.reference_sequence)
-        expt = 'A' * (1699 - 1600 + 1) + 'G' * len(self.s)
-        self.assertEqual(expt, seq)
-        self.assertEqual(1, len(new_exons))
+        seq, new_exons = FusionTranscript._pull_exons(t, b, intervals.reference_sequence)
+        expt = 'A' * (1699 - 1600 + 1) + 'G' * len(intervals.s)
+        assert seq == expt
+        assert len(new_exons) == 1
 
         b = Breakpoint(REF_CHR, 300, orient=ORIENT.RIGHT)
-        seq, new_exons = FusionTranscript._pull_exons(t, b, self.reference_sequence)
+        seq, new_exons = FusionTranscript._pull_exons(t, b, intervals.reference_sequence)
         expt = 'A' * (499 - 300 + 1) + 'G' * 100 + 'A' * (1199 - 600 + 1) + 'T' * 100
         expt += 'A' * (1499 - 1300 + 1) + 'C' * 100 + 'A' * (1699 - 1600 + 1) + 'G' * 100
 
-        self.assertEqual(expt, seq)
-        self.assertEqual(4, len(new_exons))
+        assert seq == expt
+        assert len(new_exons) == 4
         e = new_exons[0][0]
-        self.assertEqual(201, e.start)
-        self.assertEqual(300, e.end)
-        self.assertEqual(True, e.start_splice_site.intact)
-        self.assertEqual(True, e.end_splice_site.intact)
+        assert e.start == 201
+        assert e.end == 300
+        assert e.start_splice_site.intact is True
+        assert e.end_splice_site.intact is True
 
-    def test__pull_exons_right_pos_intronic_splice(self):
+    def test__pull_exons_right_pos_intronic_splice(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b = Breakpoint(REF_CHR, 1198, orient=ORIENT.RIGHT)
-        seq, new_exons = FusionTranscript._pull_exons(t, b, self.reference_sequence)
+        seq, new_exons = FusionTranscript._pull_exons(t, b, intervals.reference_sequence)
         expt = (
             'AA'
             + 'T' * 100
@@ -171,64 +198,76 @@ class TestFusionTranscript(unittest.TestCase):
             + 'A' * (1699 - 1600 + 1)
             + 'G' * 100
         )
-        self.assertEqual(expt, seq)
-        self.assertEqual(3, len(new_exons))
+        assert seq == expt
+        assert len(new_exons) == 3
         e = new_exons[0][0]
-        self.assertEqual(False, e.start_splice_site.intact)
-        self.assertEqual(True, e.end_splice_site.intact)
+        assert e.start_splice_site.intact is False
+        assert e.end_splice_site.intact is True
 
-    def test__pull_exons_right_pos_exonic(self):
+    def test__pull_exons_right_pos_exonic(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b = Breakpoint(REF_CHR, 1201, orient=ORIENT.RIGHT)
-        seq, new_exons = FusionTranscript._pull_exons(t, b, self.reference_sequence)
+        seq, new_exons = FusionTranscript._pull_exons(t, b, intervals.reference_sequence)
         expt = 'T' * 99 + 'A' * (1499 - 1300 + 1) + 'C' * 100 + 'A' * (1699 - 1600 + 1) + 'G' * 100
-        self.assertEqual(expt, seq)
-        self.assertEqual(3, len(new_exons))
+        assert seq == expt
+        assert len(new_exons) == 3
         e = new_exons[0][0]
-        self.assertEqual(False, e.start_splice_site.intact)
-        self.assertEqual(True, e.end_splice_site.intact)
+        assert e.start_splice_site.intact is False
+        assert e.end_splice_site.intact is True
 
-    def test__pull_exons_right_pos_exonic_splice(self):
+    def test__pull_exons_right_pos_exonic_splice(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b = Breakpoint(REF_CHR, 1298, orient=ORIENT.RIGHT)
-        seq, new_exons = FusionTranscript._pull_exons(t, b, self.reference_sequence)
+        seq, new_exons = FusionTranscript._pull_exons(t, b, intervals.reference_sequence)
         expt = 'TT' + 'A' * (1499 - 1300 + 1) + 'C' * 100 + 'A' * (1699 - 1600 + 1) + 'G' * 100
-        self.assertEqual(expt, seq)
-        self.assertEqual(3, len(new_exons))
+        assert seq == expt
+        assert len(new_exons) == 3
         e = new_exons[0][0]
-        self.assertEqual(False, e.start_splice_site.intact)
-        self.assertEqual(False, e.end_splice_site.intact)
+        assert e.start_splice_site.intact is False
+        assert e.end_splice_site.intact is False
 
-    def test__pull_exons_right_neg_intronic(self):
+    def test__pull_exons_right_neg_intronic(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.NEG)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.NEG,
+        )
         b = Breakpoint(REF_CHR, 700, orient=ORIENT.RIGHT)
-        seq, new_exons = FusionTranscript._pull_exons(t, b, self.reference_sequence)
+        seq, new_exons = FusionTranscript._pull_exons(t, b, intervals.reference_sequence)
         expt = 'A' * (1199 - 700 + 1) + 'T' * 100 + 'A' * (1499 - 1300 + 1) + 'C' * 100
         expt += 'A' * (1699 - 1600 + 1) + 'G' * 100
         expt = reverse_complement(expt)
-        self.assertEqual(expt, seq)
-        self.assertEqual(3, len(new_exons))
+        assert seq == expt
+        assert len(new_exons) == 3
         e = new_exons[0][0]
-        self.assertEqual(True, e.start_splice_site.intact)
-        self.assertEqual(True, e.end_splice_site.intact)
-        self.assertEqual(1, e.start)
-        self.assertEqual(100, e.end)
-        self.assertEqual('C' * 100, seq[e.start - 1 : e.end])
+        assert e.start_splice_site.intact is True
+        assert e.end_splice_site.intact is True
+        assert e.start == 1
+        assert e.end == 100
+        assert seq[e.start - 1 : e.end] == 'C' * 100
         e = new_exons[1][0]
-        self.assertEqual(True, e.start_splice_site.intact)
-        self.assertEqual(True, e.end_splice_site.intact)
-        self.assertEqual(201, e.start)
-        self.assertEqual(300, e.end)
-        self.assertEqual('G' * 100, seq[e.start - 1 : e.end])
+        assert e.start_splice_site.intact is True
+        assert e.end_splice_site.intact is True
+        assert e.start == 201
+        assert e.end == 300
+        assert seq[e.start - 1 : e.end] == 'G' * 100
 
-    def test__pull_exons_right_neg_intronic_splice(self):
+    def test__pull_exons_right_neg_intronic_splice(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.NEG)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.NEG,
+        )
         b = Breakpoint(REF_CHR, 1198, orient=ORIENT.RIGHT)
-        seq, new_exons = FusionTranscript._pull_exons(t, b, self.reference_sequence)
+        seq, new_exons = FusionTranscript._pull_exons(t, b, intervals.reference_sequence)
         expt = (
             'AA'
             + 'T' * 100
@@ -238,63 +277,66 @@ class TestFusionTranscript(unittest.TestCase):
             + 'G' * 100
         )
         expt = reverse_complement(expt)
-        self.assertEqual(expt, seq)
-        self.assertEqual(3, len(new_exons))
+        assert seq == expt
+        assert len(new_exons) == 3
         e = new_exons[0][0]
-        self.assertEqual(True, e.start_splice_site.intact)
-        self.assertEqual(True, e.end_splice_site.intact)
-        self.assertEqual(1, e.start)
-        self.assertEqual(100, e.end)
-        self.assertEqual('C' * 100, seq[e.start - 1 : e.end])
+        assert e.start_splice_site.intact is True
+        assert e.end_splice_site.intact is True
+        assert e.start == 1
+        assert e.end == 100
+        assert seq[e.start - 1 : e.end] == 'C' * 100
         e = new_exons[1][0]
-        self.assertEqual(True, e.start_splice_site.intact)
-        self.assertEqual(True, e.end_splice_site.intact)
-        self.assertEqual(201, e.start)
-        self.assertEqual(300, e.end)
-        self.assertEqual('G' * 100, seq[e.start - 1 : e.end])
+        assert e.start_splice_site.intact is True
+        assert e.end_splice_site.intact is True
+        assert e.start == 201
+        assert e.end == 300
+        assert seq[e.start - 1 : e.end] == 'G' * 100
         e = new_exons[2][0]
-        self.assertEqual(True, e.start_splice_site.intact)
-        self.assertEqual(False, e.end_splice_site.intact)
-        self.assertEqual(501, e.start)
-        self.assertEqual(600, e.end)
-        self.assertEqual('A' * 100, seq[e.start - 1 : e.end])
+        assert e.start_splice_site.intact is True
+        assert e.end_splice_site.intact is False
+        assert e.start == 501
+        assert e.end == 600
+        assert seq[e.start - 1 : e.end] == 'A' * 100
 
-    def test_build_single_transcript_indel(self):
+    def test_build_single_transcript_indel(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b1 = Breakpoint(REF_CHR, 599, orient=ORIENT.LEFT)
         b2 = Breakpoint(REF_CHR, 1200, orient=ORIENT.RIGHT)
         bpp = BreakpointPair(b1, b2, opposing_strands=False, untemplated_seq='ATCGATCG')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t, transcript2=t, event_type=SVTYPE.DEL, protocol=PROTOCOL.GENOME
         )
         ft = FusionTranscript.build(ann, ref)
 
         expt = (
-            'C' * len(self.x)
+            'C' * len(intervals.x)
             + 'A' * (499 - 200 + 1)
-            + 'G' * len(self.y)
+            + 'G' * len(intervals.y)
             + 'ATCGATCG'
-            + 'T' * len(self.z)
+            + 'T' * len(intervals.z)
         )
         expt += (
             'A' * (1499 - 1300 + 1)
-            + 'C' * len(self.w)
+            + 'C' * len(intervals.w)
             + 'A' * (1699 - 1600 + 1)
-            + 'G' * len(self.s)
+            + 'G' * len(intervals.s)
         )
 
-        self.assertEqual(expt, ft.seq)
-        self.assertEqual(5, len(ft.exons))
+        assert ft.seq == expt
+        assert len(ft.exons) == 5
 
         for i, ex in enumerate(t.exons):
             n = ft.exons[i]
-            self.assertEqual(ex, ft.exon_mapping[n.position])
+            assert ft.exon_mapping[n.position] == ex
 
-        self.assertEqual(1, ft.exons[0].start)
-        self.assertEqual(100, ft.exons[0].end)
+        assert ft.exons[0].start == 1
+        assert ft.exons[0].end == 100
 
         splice_pattern = [(True, True), (True, False), (False, True), (True, True), (True, True)]
         char_pattern = [x * 100 for x in ['C', 'G', 'T', 'C', 'G']]
@@ -302,60 +344,72 @@ class TestFusionTranscript(unittest.TestCase):
         for i in range(0, len(splice_pattern)):
             s, t = splice_pattern[i]
             ex = ft.exons[i]
-            self.assertEqual(s, ex.start_splice_site.intact)
-            self.assertEqual(t, ex.end_splice_site.intact)
-            self.assertEqual(char_pattern[i], ft.seq[ex.start - 1 : ex.end])
+            assert ex.start_splice_site.intact == s
+            assert ex.end_splice_site.intact == t
+            assert ft.seq[ex.start - 1 : ex.end] == char_pattern[i]
 
-    def test_build_single_transcript_inversion(self):
+    def test_build_single_transcript_inversion(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b1 = Breakpoint(REF_CHR, 1199, orient=ORIENT.LEFT)
         b2 = Breakpoint(REF_CHR, 1299, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2, opposing_strands=True, untemplated_seq='ATCGTC')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t, transcript2=t, event_type=SVTYPE.INV, protocol=PROTOCOL.GENOME
         )
         ft = FusionTranscript.build(ann, ref)
         expt = (
-            'C' * len(self.x) + 'A' * (499 - 200 + 1) + 'G' * len(self.y) + 'A' * (1199 - 600 + 1)
+            'C' * len(intervals.x)
+            + 'A' * (499 - 200 + 1)
+            + 'G' * len(intervals.y)
+            + 'A' * (1199 - 600 + 1)
         )
-        expt += 'ATCGTC' + 'A' * len(self.z)
+        expt += 'ATCGTC' + 'A' * len(intervals.z)
         expt += (
             'A' * (1499 - 1300 + 1)
-            + 'C' * len(self.w)
+            + 'C' * len(intervals.w)
             + 'A' * (1699 - 1600 + 1)
-            + 'G' * len(self.s)
+            + 'G' * len(intervals.s)
         )
         exons = [(1, 100), (401, 500), (1407, 1506), (1607, 1706)]
         for i in range(len(exons)):
-            self.assertEqual(exons[i][0], ft.exons[i].start)
-            self.assertEqual(exons[i][1], ft.exons[i].end)
-        self.assertEqual(expt, ft.seq)
-        self.assertEqual(4, len(ft.exons))
+            assert ft.exons[i].start == exons[i][0]
+            assert ft.exons[i].end == exons[i][1]
+        assert ft.seq == expt
+        assert len(ft.exons) == 4
 
-    def test_build_single_transcript_inversion_transcriptome(self):
+    def test_build_single_transcript_inversion_transcriptome(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b1 = Breakpoint(REF_CHR, 1199, orient=ORIENT.LEFT)
         b2 = Breakpoint(REF_CHR, 1299, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2, opposing_strands=True, untemplated_seq='ATCGTC')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t, transcript2=t, event_type=SVTYPE.INV, protocol=PROTOCOL.TRANS
         )
         ft = FusionTranscript.build(ann, ref)
         expt = (
-            'C' * len(self.x) + 'A' * (499 - 200 + 1) + 'G' * len(self.y) + 'A' * (1199 - 600 + 1)
+            'C' * len(intervals.x)
+            + 'A' * (499 - 200 + 1)
+            + 'G' * len(intervals.y)
+            + 'A' * (1199 - 600 + 1)
         )
-        expt += 'ATCGTC' + 'A' * len(self.z)
+        expt += 'ATCGTC' + 'A' * len(intervals.z)
         expt += (
             'A' * (1499 - 1300 + 1)
-            + 'C' * len(self.w)
+            + 'C' * len(intervals.w)
             + 'A' * (1699 - 1600 + 1)
-            + 'G' * len(self.s)
+            + 'G' * len(intervals.s)
         )
         exons = [
             Exon(1, 100, strand=STRAND.POS),
@@ -366,106 +420,119 @@ class TestFusionTranscript(unittest.TestCase):
         ]
         print(ft.exons)
         for i in range(len(exons)):
-            self.assertEqual(exons[i].start, ft.exons[i].start)
-            self.assertEqual(exons[i].end, ft.exons[i].end)
-            self.assertEqual(
-                exons[i].start_splice_site.intact, ft.exons[i].start_splice_site.intact
-            )
-            self.assertEqual(exons[i].end_splice_site.intact, ft.exons[i].end_splice_site.intact)
-        self.assertEqual(expt, ft.seq)
-        self.assertEqual(5, len(ft.exons))
+            assert ft.exons[i].start == exons[i].start
+            assert ft.exons[i].end == exons[i].end
+            assert ft.exons[i].start_splice_site.intact == exons[i].start_splice_site.intact
+            assert ft.exons[i].end_splice_site.intact == exons[i].end_splice_site.intact
+        assert ft.seq == expt
+        assert len(ft.exons) == 5
 
-    def test_build_single_transcript_inversion_neg(self):
+    def test_build_single_transcript_inversion_neg(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.NEG)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.NEG,
+        )
         b1 = Breakpoint(REF_CHR, 1300, orient=ORIENT.RIGHT)
         b2 = Breakpoint(REF_CHR, 1200, orient=ORIENT.RIGHT)
         bpp = BreakpointPair(b1, b2, opposing_strands=True, untemplated_seq='ATCGTC')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t, transcript2=t, event_type=SVTYPE.INV, protocol=PROTOCOL.GENOME
         )
         ft = FusionTranscript.build(ann, ref)
 
         expt = (
-            'C' * len(self.s)
+            'C' * len(intervals.s)
             + 'T' * (1699 - 1600 + 1)
-            + 'G' * len(self.w)
+            + 'G' * len(intervals.w)
             + 'T' * (1499 - 1300 + 1)
         )
-        expt += 'T' * len(self.z) + 'GACGAT' + 'T' * (1199 - 600 + 1) + 'C' * len(self.y)
-        expt += 'T' * (499 - 200 + 1) + 'G' * len(self.x)
+        expt += 'T' * len(intervals.z) + 'GACGAT' + 'T' * (1199 - 600 + 1) + 'C' * len(intervals.y)
+        expt += 'T' * (499 - 200 + 1) + 'G' * len(intervals.x)
 
         exons = [(1, 100), (201, 300), (1207, 1306), (1607, 1706)]
 
         for i in range(len(exons)):
-            self.assertEqual(exons[i][0], ft.exons[i].start)
-            self.assertEqual(exons[i][1], ft.exons[i].end)
-        self.assertEqual(expt, ft.seq)
-        self.assertEqual(4, len(ft.exons))
+            assert ft.exons[i].start == exons[i][0]
+            assert ft.exons[i].end == exons[i][1]
+        assert ft.seq == expt
+        assert len(ft.exons) == 4
 
-    def test_build_single_transcript_duplication_pos(self):
+    def test_build_single_transcript_duplication_pos(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b1 = Breakpoint(REF_CHR, 1200, orient=ORIENT.RIGHT)
         b2 = Breakpoint(REF_CHR, 1299, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2, opposing_strands=False, untemplated_seq='ATCGATCG')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t, transcript2=t, event_type=SVTYPE.DUP, protocol=PROTOCOL.GENOME
         )
         ft = FusionTranscript.build(ann, ref)
-        self.assertEqual(STRAND.POS, ft.get_strand())
+        assert ft.get_strand() == STRAND.POS
 
         expt = (
-            'C' * len(self.x) + 'A' * (499 - 200 + 1) + 'G' * len(self.y) + 'A' * (1199 - 600 + 1)
+            'C' * len(intervals.x)
+            + 'A' * (499 - 200 + 1)
+            + 'G' * len(intervals.y)
+            + 'A' * (1199 - 600 + 1)
         )
-        expt += 'T' * len(self.z) + 'ATCGATCG' + 'T' * len(self.z)
+        expt += 'T' * len(intervals.z) + 'ATCGATCG' + 'T' * len(intervals.z)
         expt += (
             'A' * (1499 - 1300 + 1)
-            + 'C' * len(self.w)
+            + 'C' * len(intervals.w)
             + 'A' * (1699 - 1600 + 1)
-            + 'G' * len(self.s)
+            + 'G' * len(intervals.s)
         )
-        self.assertEqual(expt, ft.seq)
+        assert ft.seq == expt
         exons = [(1, 100), (401, 500), (1101, 1200), (1209, 1308), (1509, 1608), (1709, 1808)]
         for i in range(len(exons)):
-            self.assertEqual(exons[i][0], ft.exons[i].start)
-            self.assertEqual(exons[i][1], ft.exons[i].end)
+            assert ft.exons[i].start == exons[i][0]
+            assert ft.exons[i].end == exons[i][1]
 
-        self.assertEqual(6, len(ft.exons))
-        self.assertTrue(ft.exons[2].start_splice_site.intact)
-        self.assertTrue(ft.exons[3].end_splice_site.intact)
-        self.assertFalse(ft.exons[2].end_splice_site.intact)
-        self.assertFalse(ft.exons[3].start_splice_site.intact)
+        assert len(ft.exons) == 6
+        assert ft.exons[2].start_splice_site.intact
+        assert ft.exons[3].end_splice_site.intact
+        assert not ft.exons[2].end_splice_site.intact
+        assert not ft.exons[3].start_splice_site.intact
 
-    def test_build_single_transcript_duplication_pos_transcriptome(self):
+    def test_build_single_transcript_duplication_pos_transcriptome(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         b1 = Breakpoint(REF_CHR, 1200, orient=ORIENT.RIGHT)
         b2 = Breakpoint(REF_CHR, 1299, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2, opposing_strands=False, untemplated_seq='ATCGATCG')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t, transcript2=t, event_type=SVTYPE.DUP, protocol=PROTOCOL.TRANS
         )
         ft = FusionTranscript.build(ann, ref)
-        self.assertEqual(STRAND.POS, ft.get_strand())
+        assert ft.get_strand() == STRAND.POS
 
         expt = (
-            'C' * len(self.x) + 'A' * (499 - 200 + 1) + 'G' * len(self.y) + 'A' * (1199 - 600 + 1)
+            'C' * len(intervals.x)
+            + 'A' * (499 - 200 + 1)
+            + 'G' * len(intervals.y)
+            + 'A' * (1199 - 600 + 1)
         )
-        expt += 'T' * len(self.z) + 'ATCGATCG' + 'T' * len(self.z)
+        expt += 'T' * len(intervals.z) + 'ATCGATCG' + 'T' * len(intervals.z)
         expt += (
             'A' * (1499 - 1300 + 1)
-            + 'C' * len(self.w)
+            + 'C' * len(intervals.w)
             + 'A' * (1699 - 1600 + 1)
-            + 'G' * len(self.s)
+            + 'G' * len(intervals.s)
         )
-        self.assertEqual(expt, ft.seq)
+        assert ft.seq == expt
         exons = [
             Exon(1, 100, strand=STRAND.POS),
             Exon(401, 500, strand=STRAND.POS),
@@ -477,241 +544,290 @@ class TestFusionTranscript(unittest.TestCase):
         ]
         print(ft.exons)
         for i in range(len(exons)):
-            self.assertEqual(exons[i].start, ft.exons[i].start)
-            self.assertEqual(exons[i].end, ft.exons[i].end)
-            self.assertEqual(
-                exons[i].start_splice_site.intact, ft.exons[i].start_splice_site.intact
-            )
-            self.assertEqual(exons[i].end_splice_site.intact, ft.exons[i].end_splice_site.intact)
+            assert ft.exons[i].start == exons[i].start
+            assert ft.exons[i].end == exons[i].end
+            assert ft.exons[i].start_splice_site.intact == exons[i].start_splice_site.intact
+            assert ft.exons[i].end_splice_site.intact == exons[i].end_splice_site.intact
 
-        self.assertEqual(7, len(ft.exons))
+        assert len(ft.exons) == 7
 
-    def test_build_single_transcript_duplication_neg(self):
+    def test_build_single_transcript_duplication_neg(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
-        t = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.NEG)
+        t = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.NEG,
+        )
         b1 = Breakpoint(REF_CHR, 1200, orient=ORIENT.RIGHT)
         b2 = Breakpoint(REF_CHR, 1299, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2, opposing_strands=False, untemplated_seq='ATCGATCG')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t, transcript2=t, event_type=SVTYPE.DUP, protocol=PROTOCOL.GENOME
         )
         ft = FusionTranscript.build(ann, ref)
 
         expt = (
-            'C' * len(self.x) + 'A' * (499 - 200 + 1) + 'G' * len(self.y) + 'A' * (1199 - 600 + 1)
+            'C' * len(intervals.x)
+            + 'A' * (499 - 200 + 1)
+            + 'G' * len(intervals.y)
+            + 'A' * (1199 - 600 + 1)
         )
-        expt += 'T' * len(self.z) + 'ATCGATCG' + 'T' * len(self.z)
+        expt += 'T' * len(intervals.z) + 'ATCGATCG' + 'T' * len(intervals.z)
         expt += (
             'A' * (1499 - 1300 + 1)
-            + 'C' * len(self.w)
+            + 'C' * len(intervals.w)
             + 'A' * (1699 - 1600 + 1)
-            + 'G' * len(self.s)
+            + 'G' * len(intervals.s)
         )
         expt = reverse_complement(expt)
-        self.assertEqual(expt, ft.seq)
+        assert ft.seq == expt
 
         exons = [(1, 100), (201, 300), (501, 600), (609, 708), (1309, 1408), (1709, 1808)]
 
         for i in range(len(exons)):
-            self.assertEqual(exons[i][0], ft.exons[i].start)
-            self.assertEqual(exons[i][1], ft.exons[i].end)
+            assert ft.exons[i].start == exons[i][0]
+            assert ft.exons[i].end == exons[i][1]
 
-        self.assertEqual(6, len(ft.exons))
-        self.assertTrue(ft.exons[2].start_splice_site.intact)
-        self.assertTrue(ft.exons[3].end_splice_site.intact)
-        self.assertFalse(ft.exons[2].end_splice_site.intact)
-        self.assertFalse(ft.exons[3].start_splice_site.intact)
-        self.assertEqual(3, ft.exon_number(ft.exons[2]))
-        self.assertEqual(3, ft.exon_number(ft.exons[3]))
+        assert len(ft.exons) == 6
+        assert ft.exons[2].start_splice_site.intact
+        assert ft.exons[3].end_splice_site.intact
+        assert not ft.exons[2].end_splice_site.intact
+        assert not ft.exons[3].start_splice_site.intact
+        assert ft.exon_number(ft.exons[2]) == 3
+        assert ft.exon_number(ft.exons[3]) == 3
 
-    def test_build_two_transcript_inversion_5prime_pos(self):
+    def test_build_two_transcript_inversion_5prime_pos(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
         # a:2000-2099, b:2600-2699, c:3000-3099, d:3300-3399
         #   TTTTTTTTT    CCCCCCCCC    GGGGGGGGG    TTTTTTTTT
-        t1 = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
-        t2 = PreTranscript(exons=[self.a, self.b, self.c, self.d], strand=STRAND.NEG)
+        t1 = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
+        t2 = PreTranscript(
+            exons=[intervals.a, intervals.b, intervals.c, intervals.d], strand=STRAND.NEG
+        )
         b1 = Breakpoint(REF_CHR, 1199, orient=ORIENT.LEFT)
         b2 = Breakpoint(REF_CHR, 2699, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2, opposing_strands=True, untemplated_seq='ATCGACTC')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t1, transcript2=t2, event_type=SVTYPE.INV, protocol=PROTOCOL.GENOME
         )
         ft = FusionTranscript.build(ann, ref)
         expt = (
-            'C' * len(self.x) + 'A' * (499 - 200 + 1) + 'G' * len(self.y) + 'A' * (1199 - 600 + 1)
+            'C' * len(intervals.x)
+            + 'A' * (499 - 200 + 1)
+            + 'G' * len(intervals.y)
+            + 'A' * (1199 - 600 + 1)
         )
-        expt += 'ATCGACTC' + 'G' * len(self.b) + 'T' * (2599 - 2100 + 1) + 'A' * len(self.a)
-        self.assertEqual(expt, ft.seq)
-        self.assertEqual(4, len(ft.exons))
-        self.assertTrue(ft.exons[3].end_splice_site.intact)
-        self.assertFalse(ft.exons[2].start_splice_site.intact)
-        self.assertTrue(ft.exons[2].end_splice_site.intact)
-        self.assertEqual(2, ft.exon_number(ft.exons[1]))
-        self.assertEqual(3, ft.exon_number(ft.exons[2]))
-
-    def test_build_two_transcript_inversion_5prime_neg(self):
-        # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
-        #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
-        # a:2000-2099, b:2600-2699, c:3000-3099, d:3300-3399
-        #   TTTTTTTTT    CCCCCCCCC    GGGGGGGGG    TTTTTTTTT
-        t1 = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.NEG)
-        t2 = PreTranscript(exons=[self.a, self.b, self.c, self.d], strand=STRAND.POS)
-        b1 = Breakpoint(REF_CHR, 1199, orient=ORIENT.LEFT)
-        b2 = Breakpoint(REF_CHR, 2699, orient=ORIENT.LEFT)
-        bpp = BreakpointPair(b1, b2, opposing_strands=True, untemplated_seq='ATCGACTC')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
-        ann = Annotation(
-            bpp, transcript1=t1, transcript2=t2, event_type=SVTYPE.INV, protocol=PROTOCOL.GENOME
-        )
-        ft = FusionTranscript.build(ann, ref)
-        expt = 'T' * len(self.a) + 'A' * (2599 - 2100 + 1) + 'C' * len(self.b) + 'ATCGACTC'
         expt += (
-            'T' * (1199 - 600 + 1) + 'C' * len(self.y) + 'T' * (499 - 200 + 1) + 'G' * len(self.x)
+            'ATCGACTC' + 'G' * len(intervals.b) + 'T' * (2599 - 2100 + 1) + 'A' * len(intervals.a)
         )
+        assert ft.seq == expt
+        assert len(ft.exons) == 4
+        assert ft.exons[3].end_splice_site.intact
+        assert not ft.exons[2].start_splice_site.intact
+        assert ft.exons[2].end_splice_site.intact
+        assert ft.exon_number(ft.exons[1]) == 2
+        assert ft.exon_number(ft.exons[2]) == 3
 
-        self.assertEqual(4, len(ft.exons))
-        self.assertEqual(2, ft.exon_number(ft.exons[1]))
-        self.assertEqual(4, ft.exon_number(ft.exons[2]))
-        self.assertEqual(expt, ft.seq)
-
-    def test_build_two_transcript_duplication_pos(self):
+    def test_build_two_transcript_inversion_5prime_neg(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
         # a:2000-2099, b:2600-2699, c:3000-3099, d:3300-3399
         #   TTTTTTTTT    CCCCCCCCC    GGGGGGGGG    TTTTTTTTT
-        t1 = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
-        t2 = PreTranscript(exons=[self.a, self.b, self.c, self.d], strand=STRAND.POS)
+        t1 = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.NEG,
+        )
+        t2 = PreTranscript(
+            exons=[intervals.a, intervals.b, intervals.c, intervals.d], strand=STRAND.POS
+        )
+        b1 = Breakpoint(REF_CHR, 1199, orient=ORIENT.LEFT)
+        b2 = Breakpoint(REF_CHR, 2699, orient=ORIENT.LEFT)
+        bpp = BreakpointPair(b1, b2, opposing_strands=True, untemplated_seq='ATCGACTC')
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
+        ann = Annotation(
+            bpp, transcript1=t1, transcript2=t2, event_type=SVTYPE.INV, protocol=PROTOCOL.GENOME
+        )
+        ft = FusionTranscript.build(ann, ref)
+        expt = (
+            'T' * len(intervals.a) + 'A' * (2599 - 2100 + 1) + 'C' * len(intervals.b) + 'ATCGACTC'
+        )
+        expt += (
+            'T' * (1199 - 600 + 1)
+            + 'C' * len(intervals.y)
+            + 'T' * (499 - 200 + 1)
+            + 'G' * len(intervals.x)
+        )
+
+        assert len(ft.exons) == 4
+        assert ft.exon_number(ft.exons[1]) == 2
+        assert ft.exon_number(ft.exons[2]) == 4
+        assert ft.seq == expt
+
+    def test_build_two_transcript_duplication_pos(self, intervals):
+        # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
+        #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
+        # a:2000-2099, b:2600-2699, c:3000-3099, d:3300-3399
+        #   TTTTTTTTT    CCCCCCCCC    GGGGGGGGG    TTTTTTTTT
+        t1 = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
+        t2 = PreTranscript(
+            exons=[intervals.a, intervals.b, intervals.c, intervals.d], strand=STRAND.POS
+        )
         b1 = Breakpoint(REF_CHR, 1200, orient=ORIENT.RIGHT)
         b2 = Breakpoint(REF_CHR, 2699, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2, opposing_strands=False, untemplated_seq='ATCGAC')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t1, transcript2=t2, event_type=SVTYPE.DUP, protocol=PROTOCOL.GENOME
         )
         ft = FusionTranscript.build(ann, ref)
-        expt = 'T' * len(self.a) + 'A' * (2599 - 2100 + 1) + 'C' * len(self.b) + 'ATCGAC'
-        expt += 'T' * len(self.z) + 'A' * (1499 - 1300 + 1) + 'C' * len(self.w)
-        expt += 'A' * (1699 - 1600 + 1) + 'G' * len(self.s)
+        expt = 'T' * len(intervals.a) + 'A' * (2599 - 2100 + 1) + 'C' * len(intervals.b) + 'ATCGAC'
+        expt += 'T' * len(intervals.z) + 'A' * (1499 - 1300 + 1) + 'C' * len(intervals.w)
+        expt += 'A' * (1699 - 1600 + 1) + 'G' * len(intervals.s)
 
-        self.assertEqual(5, len(ft.exons))
-        self.assertEqual(2, ft.exon_number(ft.exons[1]))
-        self.assertEqual(3, ft.exon_number(ft.exons[2]))
-        self.assertEqual(expt, ft.seq)
+        assert len(ft.exons) == 5
+        assert ft.exon_number(ft.exons[1]) == 2
+        assert ft.exon_number(ft.exons[2]) == 3
+        assert ft.seq == expt
 
-    def test_build_two_transcript_duplication_neg(self):
+    def test_build_two_transcript_duplication_neg(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
         # a:2000-2099, b:2600-2699, c:3000-3099, d:3300-3399
         #   TTTTTTTTT    CCCCCCCCC    GGGGGGGGG    TTTTTTTTT
-        t1 = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.NEG)
-        t2 = PreTranscript(exons=[self.a, self.b, self.c, self.d], strand=STRAND.NEG)
+        t1 = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.NEG,
+        )
+        t2 = PreTranscript(
+            exons=[intervals.a, intervals.b, intervals.c, intervals.d], strand=STRAND.NEG
+        )
         b1 = Breakpoint(REF_CHR, 1200, orient=ORIENT.RIGHT)
         b2 = Breakpoint(REF_CHR, 2699, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2, opposing_strands=False, untemplated_seq='ATCGAC')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t1, transcript2=t2, event_type=SVTYPE.DUP, protocol=PROTOCOL.GENOME
         )
         ft = FusionTranscript.build(ann, ref)
 
         expt = (
-            'C' * len(self.s)
+            'C' * len(intervals.s)
             + 'T' * (1699 - 1600 + 1)
-            + 'G' * len(self.w)
+            + 'G' * len(intervals.w)
             + 'T' * (1499 - 1300 + 1)
         )
-        expt += 'A' * len(self.z) + 'GTCGAT' + 'G' * len(self.b) + 'T' * (2599 - 2100 + 1)
-        expt += 'A' * len(self.a)
+        expt += 'A' * len(intervals.z) + 'GTCGAT' + 'G' * len(intervals.b) + 'T' * (2599 - 2100 + 1)
+        expt += 'A' * len(intervals.a)
 
-        self.assertEqual(5, len(ft.exons))
-        self.assertEqual(2, ft.exon_number(ft.exons[1]))
-        self.assertEqual(3, ft.exon_number(ft.exons[2]))
-        self.assertEqual(expt, ft.seq)
+        assert len(ft.exons) == 5
+        assert ft.exon_number(ft.exons[1]) == 2
+        assert ft.exon_number(ft.exons[2]) == 3
+        assert ft.seq == expt
 
-    def test_build_two_transcript_deletion_pos(self):
+    def test_build_two_transcript_deletion_pos(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
         # a:2000-2099, b:2600-2699, c:3000-3099, d:3300-3399
         #   TTTTTTTTT    CCCCCCCCC    GGGGGGGGG    TTTTTTTTT
-        t1 = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
-        t2 = PreTranscript(exons=[self.a, self.b, self.c, self.d], strand=STRAND.POS)
+        t1 = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
+        t2 = PreTranscript(
+            exons=[intervals.a, intervals.b, intervals.c, intervals.d], strand=STRAND.POS
+        )
         b1 = Breakpoint(REF_CHR, 1199, orient=ORIENT.LEFT)
         b2 = Breakpoint(REF_CHR, 2700, orient=ORIENT.RIGHT)
         bpp = BreakpointPair(b1, b2, opposing_strands=False, untemplated_seq='AACGTGT')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t1, transcript2=t2, event_type=SVTYPE.DEL, protocol=PROTOCOL.GENOME
         )
         ft = FusionTranscript.build(ann, ref)
 
         expt = (
-            'C' * len(self.x)
+            'C' * len(intervals.x)
             + 'A' * (499 - 200 + 1)
-            + 'G' * len(self.y)
+            + 'G' * len(intervals.y)
             + 'A' * (1199 - 600 + 1)
             + 'AACGTGT'
         )
         expt += (
             'A' * (2999 - 2700 + 1)
-            + 'G' * len(self.c)
+            + 'G' * len(intervals.c)
             + 'A' * (3299 - 3100 + 1)
-            + 'T' * len(self.d)
+            + 'T' * len(intervals.d)
         )
 
-        self.assertEqual(expt, ft.seq)
-        self.assertTrue(4, len(ft.exons))
+        assert ft.seq == expt
+        assert 4, len(ft.exons)
 
-    def test_build_two_transcript_deletion_pos_transcriptome(self):
+    def test_build_two_transcript_deletion_pos_transcriptome(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
         # a:2000-2099, b:2600-2699, c:3000-3099, d:3300-3399
         #   TTTTTTTTT    CCCCCCCCC    GGGGGGGGG    TTTTTTTTT
-        t1 = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
-        t2 = PreTranscript(exons=[self.a, self.b, self.c, self.d], strand=STRAND.POS)
+        t1 = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
+        t2 = PreTranscript(
+            exons=[intervals.a, intervals.b, intervals.c, intervals.d], strand=STRAND.POS
+        )
         b1 = Breakpoint(REF_CHR, 1199, orient=ORIENT.LEFT)
         b2 = Breakpoint(REF_CHR, 2700, orient=ORIENT.RIGHT)
         bpp = BreakpointPair(b1, b2, opposing_strands=False, untemplated_seq='AACGTGT')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t1, transcript2=t2, event_type=SVTYPE.DEL, protocol=PROTOCOL.TRANS
         )
         ft = FusionTranscript.build(ann, ref)
 
         expt = (
-            'C' * len(self.x)
+            'C' * len(intervals.x)
             + 'A' * (499 - 200 + 1)
-            + 'G' * len(self.y)
+            + 'G' * len(intervals.y)
             + 'A' * (1199 - 600 + 1)
             + 'AACGTGT'
         )
         expt += (
             'A' * (2999 - 2700 + 1)
-            + 'G' * len(self.c)
+            + 'G' * len(intervals.c)
             + 'A' * (3299 - 3100 + 1)
-            + 'T' * len(self.d)
+            + 'T' * len(intervals.d)
         )
 
-        self.assertEqual(expt, ft.seq)
-        self.assertTrue(5, len(ft.exons))
+        assert ft.seq == expt
+        assert 5, len(ft.exons)
 
-    def test_build_two_transcript_deletion_neg(self):
+    def test_build_two_transcript_deletion_neg(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
         # a:2000-2099, b:2600-2699, c:3000-3099, d:3300-3399
         #   TTTTTTTTT    CCCCCCCCC    GGGGGGGGG    TTTTTTTTT
-        t1 = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.NEG)
+        t1 = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.NEG,
+        )
 
-        t2 = PreTranscript(exons=[self.a, self.b, self.c, self.d], strand=STRAND.NEG)
+        t2 = PreTranscript(
+            exons=[intervals.a, intervals.b, intervals.c, intervals.d], strand=STRAND.NEG
+        )
         print('t1 exons', t1.exons)
         print('t2 exons', t2.exons)
         b1 = Breakpoint(REF_CHR, 1200, orient=ORIENT.RIGHT)
         b2 = Breakpoint(REF_CHR, 2699, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2, opposing_strands=False, untemplated_seq='AACGAGTGT')
-        ref = {REF_CHR: MockObject(seq=self.reference_sequence)}
+        ref = {REF_CHR: MockObject(seq=intervals.reference_sequence)}
         ann = Annotation(
             bpp, transcript1=t1, transcript2=t2, event_type=SVTYPE.DEL, protocol=PROTOCOL.GENOME
         )
@@ -719,456 +835,521 @@ class TestFusionTranscript(unittest.TestCase):
         ft = FusionTranscript.build(ann, ref)
 
         expt = (
-            'C' * len(self.s)
+            'C' * len(intervals.s)
             + 'T' * (1699 - 1600 + 1)
-            + 'G' * len(self.w)
+            + 'G' * len(intervals.w)
             + 'T' * (1499 - 1300 + 1)
         )
-        expt += 'A' * len(self.z) + 'ACACTCGTT' + 'G' * len(self.b) + 'T' * (2599 - 2100 + 1)
-        expt += 'A' * len(self.a)
+        expt += (
+            'A' * len(intervals.z) + 'ACACTCGTT' + 'G' * len(intervals.b) + 'T' * (2599 - 2100 + 1)
+        )
+        expt += 'A' * len(intervals.a)
 
-        self.assertEqual(expt, ft.seq)
-        self.assertTrue(5, len(ft.exons))
-        self.assertEqual(3, ft.exon_number(ft.exons[2]))
-        self.assertEqual(3, ft.exon_number(ft.exons[3]))
+        assert ft.seq == expt
+        assert 5, len(ft.exons)
+        assert ft.exon_number(ft.exons[2]) == 3
+        assert ft.exon_number(ft.exons[3]) == 3
 
-    def test_build_two_transcript_translocation(self):
+    def test_build_two_transcript_translocation(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
         # 1:600-699, 2:800-899, 3:1100-1199, 4:1400-1499, 5:1700-1799 6:2100-2199
         #   AAAAAAA    GGGGGGG,   TTTTTTTTT,   AAAAAAAAA,   GGGGGGGGG   AAAAAAAAA
-        t1 = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.POS)
+        t1 = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.POS,
+        )
         t2 = PreTranscript(
-            exons=[self.b1, self.b2, self.b3, self.b4, self.b5, self.b6], strand=STRAND.POS
+            exons=[
+                intervals.b1,
+                intervals.b2,
+                intervals.b3,
+                intervals.b4,
+                intervals.b5,
+                intervals.b6,
+            ],
+            strand=STRAND.POS,
         )
         b1 = Breakpoint(REF_CHR, 1199, orient=ORIENT.LEFT)
         b2 = Breakpoint('ref2', 1200, orient=ORIENT.RIGHT)
         bpp = BreakpointPair(b1, b2, opposing_strands=False, untemplated_seq='GCAACATAT')
         ref = {
-            REF_CHR: MockObject(seq=self.reference_sequence),
-            'ref2': MockObject(seq=self.alternate_sequence),
+            REF_CHR: MockObject(seq=intervals.reference_sequence),
+            'ref2': MockObject(seq=intervals.alternate_sequence),
         }
         ann = Annotation(
             bpp, transcript1=t1, transcript2=t2, event_type=SVTYPE.TRANS, protocol=PROTOCOL.GENOME
         )
-        self.assertEqual(b1, ann.break1)
+        assert ann.break1 == b1
         ft = FusionTranscript.build(ann, ref)
 
         expt = (
-            'C' * len(self.x) + 'A' * (499 - 200 + 1) + 'G' * len(self.y) + 'A' * (1199 - 600 + 1)
+            'C' * len(intervals.x)
+            + 'A' * (499 - 200 + 1)
+            + 'G' * len(intervals.y)
+            + 'A' * (1199 - 600 + 1)
         )
-        expt += 'GCAACATAT' + 'C' * (1399 - 1200 + 1) + 'A' * len(self.b4) + 'C' * (1699 - 1500 + 1)
-        expt += 'G' * len(self.b5) + 'C' * (2099 - 1800 + 1) + 'A' * len(self.b6)
+        expt += (
+            'GCAACATAT'
+            + 'C' * (1399 - 1200 + 1)
+            + 'A' * len(intervals.b4)
+            + 'C' * (1699 - 1500 + 1)
+        )
+        expt += 'G' * len(intervals.b5) + 'C' * (2099 - 1800 + 1) + 'A' * len(intervals.b6)
 
-        self.assertEqual(expt, ft.seq)
-        self.assertTrue(5, len(ft.exons))
-        self.assertTrue(2, ft.exon_number(ft.exons[1]))
-        self.assertTrue(4, ft.exon_number(ft.exons[2]))
+        assert ft.seq == expt
+        assert 5, len(ft.exons)
+        assert 2, ft.exon_number(ft.exons[1])
+        assert 4, ft.exon_number(ft.exons[2])
 
-    def test_build_two_transcript_translocation_neg(self):
+    def test_build_two_transcript_translocation_neg(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
         # 1:600-699, 2:800-899, 3:1100-1199, 4:1400-1499, 5:1700-1799 6:2100-2199
         #   AAAAAAA    GGGGGGG,   TTTTTTTTT,   AAAAAAAAA,   GGGGGGGGG   AAAAAAAAA
-        t1 = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.NEG)
+        t1 = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.NEG,
+        )
         t2 = PreTranscript(
-            exons=[self.b1, self.b2, self.b3, self.b4, self.b5, self.b6], strand=STRAND.NEG
+            exons=[
+                intervals.b1,
+                intervals.b2,
+                intervals.b3,
+                intervals.b4,
+                intervals.b5,
+                intervals.b6,
+            ],
+            strand=STRAND.NEG,
         )
         b1 = Breakpoint(REF_CHR, 1200, orient=ORIENT.RIGHT)
         b2 = Breakpoint(ALT_REF_CHR, 1199, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2, opposing_strands=False, untemplated_seq='TCTACATAT')
         ref = {
-            REF_CHR: MockObject(seq=self.reference_sequence),
-            ALT_REF_CHR: MockObject(seq=self.alternate_sequence),
+            REF_CHR: MockObject(seq=intervals.reference_sequence),
+            ALT_REF_CHR: MockObject(seq=intervals.alternate_sequence),
         }
         ann = Annotation(
             bpp, transcript1=t1, transcript2=t2, event_type=SVTYPE.TRANS, protocol=PROTOCOL.GENOME
         )
-        self.assertEqual(b1, ann.break1)
-        self.assertEqual(b2, ann.break2)
+        assert ann.break1 == b1
+        assert ann.break2 == b2
         ft = FusionTranscript.build(ann, ref)
 
         expt = (
-            'C' * len(self.s)
+            'C' * len(intervals.s)
             + 'T' * (1699 - 1600 + 1)
-            + 'G' * len(self.w)
+            + 'G' * len(intervals.w)
             + 'T' * (1499 - 1300 + 1)
         )
-        expt += 'A' * len(self.z) + 'ATATGTAGA' + 'A' * len(self.b3) + 'G' * (1099 - 900 + 1)
-        expt += 'C' * len(self.b2) + 'G' * (799 - 700 + 1) + 'T' * len(self.b1)
+        expt += (
+            'A' * len(intervals.z) + 'ATATGTAGA' + 'A' * len(intervals.b3) + 'G' * (1099 - 900 + 1)
+        )
+        expt += 'C' * len(intervals.b2) + 'G' * (799 - 700 + 1) + 'T' * len(intervals.b1)
 
-        self.assertEqual(expt, ft.seq)
-        self.assertEqual(6, len(ft.exons))
-        self.assertTrue(3, ft.exon_number(ft.exons[2]))
-        self.assertTrue(3, ft.exon_number(ft.exons[3]))
+        assert ft.seq == expt
+        assert len(ft.exons) == 6
+        assert 3, ft.exon_number(ft.exons[2])
+        assert 3, ft.exon_number(ft.exons[3])
 
-    def test_build_two_transcript_inverted_translocation(self):
+    def test_build_two_transcript_inverted_translocation(self, intervals):
         # x:100-199, y:500-599, z:1200-1299, w:1500-1599, s:1700-1799
         #   CCCCCCC    GGGGGGG    TTTTTTTTT    CCCCCCCCC    GGGGGGGGG
         # 1:600-699, 2:800-899, 3:1100-1199, 4:1400-1499, 5:1700-1799 6:2100-2199
         #   AAAAAAA    GGGGGGG,   TTTTTTTTT,   AAAAAAAAA,   GGGGGGGGG   AAAAAAAAA
-        t1 = PreTranscript(exons=[self.x, self.y, self.z, self.w, self.s], strand=STRAND.NEG)
+        t1 = PreTranscript(
+            exons=[intervals.x, intervals.y, intervals.z, intervals.w, intervals.s],
+            strand=STRAND.NEG,
+        )
         t2 = PreTranscript(
-            exons=[self.b1, self.b2, self.b3, self.b4, self.b5, self.b6], strand=STRAND.POS
+            exons=[
+                intervals.b1,
+                intervals.b2,
+                intervals.b3,
+                intervals.b4,
+                intervals.b5,
+                intervals.b6,
+            ],
+            strand=STRAND.POS,
         )
         b1 = Breakpoint(REF_CHR, 1200, orient=ORIENT.RIGHT)
         b2 = Breakpoint(ALT_REF_CHR, 1200, orient=ORIENT.RIGHT)
         bpp = BreakpointPair(b1, b2, opposing_strands=True, untemplated_seq='GATACATAT')
         ref = {
-            REF_CHR: MockObject(seq=self.reference_sequence),
-            ALT_REF_CHR: MockObject(seq=self.alternate_sequence),
+            REF_CHR: MockObject(seq=intervals.reference_sequence),
+            ALT_REF_CHR: MockObject(seq=intervals.alternate_sequence),
         }
         ann = Annotation(
             bpp, transcript1=t1, transcript2=t2, event_type=SVTYPE.TRANS, protocol=PROTOCOL.GENOME
         )
-        self.assertEqual(b1, ann.break1)
-        self.assertEqual(b2, ann.break2)
+        assert ann.break1 == b1
+        assert ann.break2 == b2
         ft = FusionTranscript.build(ann, ref)
 
         expt = (
-            'C' * len(self.s)
+            'C' * len(intervals.s)
             + 'T' * (1699 - 1600 + 1)
-            + 'G' * len(self.w)
+            + 'G' * len(intervals.w)
             + 'T' * (1499 - 1300 + 1)
         )
-        expt += 'A' * len(self.z) + 'ATATGTATC' + 'C' * (1399 - 1200 + 1) + 'A' * len(self.b4)
+        expt += (
+            'A' * len(intervals.z) + 'ATATGTATC' + 'C' * (1399 - 1200 + 1) + 'A' * len(intervals.b4)
+        )
         expt += (
             'C' * (1699 - 1500 + 1)
-            + 'G' * len(self.b5)
+            + 'G' * len(intervals.b5)
             + 'C' * (2099 - 1800 + 1)
-            + 'A' * len(self.b6)
+            + 'A' * len(intervals.b6)
         )
 
-        self.assertEqual(expt, ft.seq)
-        self.assertEqual(6, len(ft.exons))
-        self.assertTrue(3, ft.exon_number(ft.exons[2]))
-        self.assertTrue(4, ft.exon_number(ft.exons[3]))
+        assert ft.seq == expt
+        assert len(ft.exons) == 6
+        assert 3, ft.exon_number(ft.exons[2])
+        assert 4, ft.exon_number(ft.exons[3])
 
 
-class TestSequenceFetching(unittest.TestCase):
-    def setUp(self):
-        self.gene = Gene(REF_CHR, 1, 900, strand=STRAND.POS)
+@pytest.fixture
+def mock_ann_obj():
+    n = argparse.Namespace()
+    n.gene = Gene(REF_CHR, 1, 900, strand=STRAND.POS)
 
-        self.pre_transcript = PreTranscript(
-            exons=[(101, 200), (301, 400), (501, 600), (701, 800)], gene=self.gene
-        )
-        self.gene.transcripts.append(self.pre_transcript)
+    n.pre_transcript = PreTranscript(
+        exons=[(101, 200), (301, 400), (501, 600), (701, 800)], gene=n.gene
+    )
+    n.gene.transcripts.append(n.pre_transcript)
 
-        self.transcript = Transcript(
-            self.pre_transcript, self.pre_transcript.generate_splicing_patterns()[0]
-        )
-        self.pre_transcript.transcripts.append(self.transcript)
+    n.transcript = Transcript(n.pre_transcript, n.pre_transcript.generate_splicing_patterns()[0])
+    n.pre_transcript.transcripts.append(n.transcript)
 
-        self.translation = Translation(51, 350, self.transcript)
-        self.transcript.translations.append(self.translation)
+    n.translation = Translation(51, 350, n.transcript)
+    n.transcript.translations.append(n.translation)
 
-        self.spliced_seq = (
-            'GGTGAATTTCTAGTTTGCCTTTTCAGCTAGGGATTAGCTTTTTAGGGGTCCCAATG'
-            'CCTAGGGAGATTTCTAGGTCCTCTGTTCCTTGCTGACCTCCAATAATCAGAAAATGCTGTGAAGGAAAAAC'
-            'AAAATGAAATTGCATTGTTTCTACCGGCCCTTTATCAAGCCCTGGCCACCATGATAGTCATGAATTCCAAT'
-            'TGTGTTGAAATCACTTCAATGTGTTTCTCTTCTTTCTGGGAGCTTACACACTCAAGTTCTGGATGCTTTGA'
-            'TTGCTATCAGAAGCCGTTAAATAGCTACTTATAAATAGCATTGAGTTATCAGTACTTTCATGTCTTGATAC'
-            'ATTTCTTCTTGAAAATGTTCATGCTTGCTGATTTGTCTGTTTGTTGAGAGGAGAATGTTC'
-        )
+    n.spliced_seq = (
+        'GGTGAATTTCTAGTTTGCCTTTTCAGCTAGGGATTAGCTTTTTAGGGGTCCCAATG'
+        'CCTAGGGAGATTTCTAGGTCCTCTGTTCCTTGCTGACCTCCAATAATCAGAAAATGCTGTGAAGGAAAAAC'
+        'AAAATGAAATTGCATTGTTTCTACCGGCCCTTTATCAAGCCCTGGCCACCATGATAGTCATGAATTCCAAT'
+        'TGTGTTGAAATCACTTCAATGTGTTTCTCTTCTTTCTGGGAGCTTACACACTCAAGTTCTGGATGCTTTGA'
+        'TTGCTATCAGAAGCCGTTAAATAGCTACTTATAAATAGCATTGAGTTATCAGTACTTTCATGTCTTGATAC'
+        'ATTTCTTCTTGAAAATGTTCATGCTTGCTGATTTGTCTGTTTGTTGAGAGGAGAATGTTC'
+    )
 
-        self.domain = Domain(
-            name=REF_CHR, regions=[(11, 20), (51, 60)], translation=self.translation
-        )
-        self.translation.domains.append(self.domain)
+    n.domain = Domain(name=REF_CHR, regions=[(11, 20), (51, 60)], translation=n.translation)
+    n.translation.domains.append(n.domain)
+    return n
 
-    def test_fetch_gene_seq_from_ref(self):
+
+class TestSequenceFetching:
+    def test_fetch_gene_seq_from_ref(self, mock_ann_obj):
         expt = str(REFERENCE_GENOME[REF_CHR][0:900].seq).upper()
-        self.assertEqual(expt, self.gene.get_seq(REFERENCE_GENOME))
+        assert mock_ann_obj.gene.get_seq(REFERENCE_GENOME) == expt
         # gene seq should be the same if gene in on reverse strand b/c gene seq always given on pos
-        self.gene.strand = STRAND.NEG
-        self.assertEqual(expt, self.gene.get_seq(REFERENCE_GENOME))
+        mock_ann_obj.gene.strand = STRAND.NEG
+        assert mock_ann_obj.gene.get_seq(REFERENCE_GENOME) == expt
 
-    def test_fetch_gene_seq_from_stored(self):
+    def test_fetch_gene_seq_from_stored(self, mock_ann_obj):
         expt = 'AAA'
-        self.gene.seq = expt
-        self.assertEqual(expt, self.gene.get_seq(REFERENCE_GENOME))
+        mock_ann_obj.gene.seq = expt
+        assert mock_ann_obj.gene.get_seq(REFERENCE_GENOME) == expt
 
-    def test_fetch_gene_seq_force_uncached(self):
+    def test_fetch_gene_seq_force_uncached(self, mock_ann_obj):
         expt = str(REFERENCE_GENOME[REF_CHR][0:900].seq).upper()
-        self.gene.seq = 'AAA'
-        self.assertEqual(expt, self.gene.get_seq(REFERENCE_GENOME, ignore_cache=True))
+        mock_ann_obj.gene.seq = 'AAA'
+        assert mock_ann_obj.gene.get_seq(REFERENCE_GENOME, ignore_cache=True) == expt
 
-    def test_fetch_us_transcript_seq_from_ref(self):
+    def test_fetch_us_transcript_seq_from_ref(self, mock_ann_obj):
         expt = str(REFERENCE_GENOME[REF_CHR][100:800].seq).upper()
-        self.assertEqual(expt, self.pre_transcript.get_seq(REFERENCE_GENOME))
+        assert mock_ann_obj.pre_transcript.get_seq(REFERENCE_GENOME) == expt
 
-    def test_fetch_us_transcript_seq_from_ref_revcomp(self):
-        self.gene.strand = STRAND.NEG
+    def test_fetch_us_transcript_seq_from_ref_revcomp(self, mock_ann_obj):
+        mock_ann_obj.gene.strand = STRAND.NEG
         expt = reverse_complement(str(REFERENCE_GENOME[REF_CHR][100:800].seq).upper())
-        self.assertEqual(expt, self.pre_transcript.get_seq(REFERENCE_GENOME))
+        assert mock_ann_obj.pre_transcript.get_seq(REFERENCE_GENOME) == expt
 
-    def test_fetch_us_transcript_seq_from_stored(self):
+    def test_fetch_us_transcript_seq_from_stored(self, mock_ann_obj):
         expt = 'AAA'
-        self.pre_transcript.seq = expt
-        self.assertEqual(expt, self.pre_transcript.get_seq(REFERENCE_GENOME))
+        mock_ann_obj.pre_transcript.seq = expt
+        assert mock_ann_obj.pre_transcript.get_seq(REFERENCE_GENOME) == expt
 
-    def test_fetch_us_transcript_seq_from_parent_gene(self):
-        self.gene.seq = 'A' * len(self.gene)
-        self.assertEqual('A' * len(self.pre_transcript), self.pre_transcript.get_seq())
+    def test_fetch_us_transcript_seq_from_parent_gene(self, mock_ann_obj):
+        mock_ann_obj.gene.seq = 'A' * len(mock_ann_obj.gene)
+        assert mock_ann_obj.pre_transcript.get_seq() == 'A' * len(mock_ann_obj.pre_transcript)
 
-    def test_fetch_us_transcript_seq_from_parent_gene_revcomp(self):
-        self.gene.seq = 'A' * len(self.gene)
-        self.gene.strand = STRAND.NEG
-        self.assertEqual('T' * len(self.pre_transcript), self.pre_transcript.get_seq())
+    def test_fetch_us_transcript_seq_from_parent_gene_revcomp(self, mock_ann_obj):
+        mock_ann_obj.gene.seq = 'A' * len(mock_ann_obj.gene)
+        mock_ann_obj.gene.strand = STRAND.NEG
+        assert mock_ann_obj.pre_transcript.get_seq() == 'T' * len(mock_ann_obj.pre_transcript)
 
-    def test_fetch_us_transcript_seq_force_uncached(self):
+    def test_fetch_us_transcript_seq_force_uncached(self, mock_ann_obj):
         expt = str(REFERENCE_GENOME[REF_CHR][100:800].seq).upper()
-        self.pre_transcript.seq = 'AAA'
-        self.assertEqual(expt, self.pre_transcript.get_seq(REFERENCE_GENOME, ignore_cache=True))
+        mock_ann_obj.pre_transcript.seq = 'AAA'
+        assert mock_ann_obj.pre_transcript.get_seq(REFERENCE_GENOME, ignore_cache=True) == expt
 
-    def test_fetch_transcript_seq_from_ref(self):
-        self.assertEqual(self.spliced_seq, self.transcript.get_seq(REFERENCE_GENOME))
+    def test_fetch_transcript_seq_from_ref(self, mock_ann_obj):
+        assert mock_ann_obj.transcript.get_seq(REFERENCE_GENOME) == mock_ann_obj.spliced_seq
 
-    def test_fetch_transcript_seq_from_ref_revcomp(self):
-        self.gene.strand = STRAND.NEG
-        self.assertEqual(
-            reverse_complement(self.spliced_seq), self.transcript.get_seq(REFERENCE_GENOME)
+    def test_fetch_transcript_seq_from_ref_revcomp(self, mock_ann_obj):
+        mock_ann_obj.gene.strand = STRAND.NEG
+        assert mock_ann_obj.transcript.get_seq(REFERENCE_GENOME) == reverse_complement(
+            mock_ann_obj.spliced_seq
         )
 
-    def test_fetch_transcript_seq_from_stored(self):
+    def test_fetch_transcript_seq_from_stored(self, mock_ann_obj):
         expt = 'AAA'
-        self.transcript.seq = expt
-        self.assertEqual(expt, self.transcript.get_seq(REFERENCE_GENOME))
+        mock_ann_obj.transcript.seq = expt
+        assert mock_ann_obj.transcript.get_seq(REFERENCE_GENOME) == expt
 
-    def test_fetch_transcript_seq_from_parent_ust(self):
-        self.pre_transcript.seq = 'A' * len(self.pre_transcript)
-        self.assertEqual('A' * len(self.transcript), self.transcript.get_seq())
+    def test_fetch_transcript_seq_from_parent_ust(self, mock_ann_obj):
+        mock_ann_obj.pre_transcript.seq = 'A' * len(mock_ann_obj.pre_transcript)
+        assert mock_ann_obj.transcript.get_seq() == 'A' * len(mock_ann_obj.transcript)
 
-    def test_fetch_transcript_seq_from_parent_gene(self):
-        self.gene.seq = 'A' * len(self.gene)
-        self.assertEqual('A' * len(self.transcript), self.transcript.get_seq())
+    def test_fetch_transcript_seq_from_parent_gene(self, mock_ann_obj):
+        mock_ann_obj.gene.seq = 'A' * len(mock_ann_obj.gene)
+        assert mock_ann_obj.transcript.get_seq() == 'A' * len(mock_ann_obj.transcript)
 
-    def test_fetch_transcript_seq_force_uncached(self):
-        self.transcript.seq = 'AAA'
-        self.assertEqual(
-            self.spliced_seq, self.transcript.get_seq(REFERENCE_GENOME, ignore_cache=True)
+    def test_fetch_transcript_seq_force_uncached(self, mock_ann_obj):
+        mock_ann_obj.transcript.seq = 'AAA'
+        assert (
+            mock_ann_obj.transcript.get_seq(REFERENCE_GENOME, ignore_cache=True)
+            == mock_ann_obj.spliced_seq
         )
 
-    def test_fetch_translation_aa_seq_from_ref(self):
-        cds = self.spliced_seq[self.translation.start - 1 : self.translation.end]
-        self.assertEqual(translate(cds), self.translation.get_aa_seq(REFERENCE_GENOME))
+    def test_fetch_translation_aa_seq_from_ref(self, mock_ann_obj):
+        cds = mock_ann_obj.spliced_seq[
+            mock_ann_obj.translation.start - 1 : mock_ann_obj.translation.end
+        ]
+        assert mock_ann_obj.translation.get_aa_seq(REFERENCE_GENOME) == translate(cds)
 
-    def test_fetch_translation_cds_seq_from_ref(self):
-        cds = self.spliced_seq[self.translation.start - 1 : self.translation.end]
-        self.assertEqual(cds, self.translation.get_seq(REFERENCE_GENOME))
+    def test_fetch_translation_cds_seq_from_ref(self, mock_ann_obj):
+        cds = mock_ann_obj.spliced_seq[
+            mock_ann_obj.translation.start - 1 : mock_ann_obj.translation.end
+        ]
+        assert mock_ann_obj.translation.get_seq(REFERENCE_GENOME) == cds
 
-    def test_fetch_translation_cds_seq_from_ref_revcomp(self):
-        self.gene.strand = STRAND.NEG
-        cdna = reverse_complement(self.spliced_seq)
-        cds = cdna[self.translation.start - 1 : self.translation.end]
-        self.assertEqual(cds, self.translation.get_seq(REFERENCE_GENOME))
+    def test_fetch_translation_cds_seq_from_ref_revcomp(self, mock_ann_obj):
+        mock_ann_obj.gene.strand = STRAND.NEG
+        cdna = reverse_complement(mock_ann_obj.spliced_seq)
+        cds = cdna[mock_ann_obj.translation.start - 1 : mock_ann_obj.translation.end]
+        assert mock_ann_obj.translation.get_seq(REFERENCE_GENOME) == cds
 
-    def test_fetch_translation_cds_seq_from_stored(self):
+    def test_fetch_translation_cds_seq_from_stored(self, mock_ann_obj):
         expt = 'AAA'
-        self.translation.seq = expt
-        self.assertEqual(expt, self.translation.get_seq(REFERENCE_GENOME))
+        mock_ann_obj.translation.seq = expt
+        assert mock_ann_obj.translation.get_seq(REFERENCE_GENOME) == expt
 
-    def test_fetch_translation_cds_seq_from_parent_transcript(self):
-        self.transcript.seq = 'A' * len(self.transcript)
-        self.assertEqual('A' * len(self.translation), self.translation.get_seq(REFERENCE_GENOME))
+    def test_fetch_translation_cds_seq_from_parent_transcript(self, mock_ann_obj):
+        mock_ann_obj.transcript.seq = 'A' * len(mock_ann_obj.transcript)
+        assert mock_ann_obj.translation.get_seq(REFERENCE_GENOME) == 'A' * len(
+            mock_ann_obj.translation
+        )
 
-    def test_fetch_translation_cds_seq_from_parent_ust(self):
-        self.pre_transcript.seq = 'A' * len(self.pre_transcript)
-        self.assertEqual('A' * len(self.translation), self.translation.get_seq(REFERENCE_GENOME))
+    def test_fetch_translation_cds_seq_from_parent_ust(self, mock_ann_obj):
+        mock_ann_obj.pre_transcript.seq = 'A' * len(mock_ann_obj.pre_transcript)
+        assert mock_ann_obj.translation.get_seq(REFERENCE_GENOME) == 'A' * len(
+            mock_ann_obj.translation
+        )
 
-    def test_fetch_translation_cds_seq_from_parent_gene(self):
-        self.gene.seq = 'A' * len(self.gene)
-        self.assertEqual('A' * len(self.translation), self.translation.get_seq(REFERENCE_GENOME))
+    def test_fetch_translation_cds_seq_from_parent_gene(self, mock_ann_obj):
+        mock_ann_obj.gene.seq = 'A' * len(mock_ann_obj.gene)
+        assert mock_ann_obj.translation.get_seq(REFERENCE_GENOME) == 'A' * len(
+            mock_ann_obj.translation
+        )
 
-    def test_fetch_translation_cds_seq_force_uncached(self):
-        self.translation.seq = 'AAA'
-        cds = self.spliced_seq[self.translation.start - 1 : self.translation.end]
-        self.assertEqual(cds, self.translation.get_seq(REFERENCE_GENOME, ignore_cache=True))
+    def test_fetch_translation_cds_seq_force_uncached(self, mock_ann_obj):
+        mock_ann_obj.translation.seq = 'AAA'
+        cds = mock_ann_obj.spliced_seq[
+            mock_ann_obj.translation.start - 1 : mock_ann_obj.translation.end
+        ]
+        assert mock_ann_obj.translation.get_seq(REFERENCE_GENOME, ignore_cache=True) == cds
 
-    def test_fetch_domain_seq_from_ref(self):
+    def test_fetch_domain_seq_from_ref(self, mock_ann_obj):
         seqs = ['VPC*PPIIRK', 'C*NHFNVFLF']
-        self.assertEqual(seqs, self.domain.get_seqs(REFERENCE_GENOME))
+        assert mock_ann_obj.domain.get_seqs(REFERENCE_GENOME) == seqs
 
 
-class TestStrandInheritance(unittest.TestCase):
-    def setUp(self):
-        self.gene = Gene('1', 1, 500, strand=STRAND.POS)
-        pre_transcript = PreTranscript(gene=self.gene, exons=[(1, 100), (200, 300), (400, 500)])
-        self.gene.unspliced_transcripts.append(pre_transcript)
-        for spl in pre_transcript.generate_splicing_patterns():
-            t = Transcript(pre_transcript, spl)
-            pre_transcript.spliced_transcripts.append(t)
-            tl = Translation(51, 250, t)
-            t.translations.append(tl)
-
-    def test_strand_gene(self):
-        self.assertEqual(STRAND.POS, self.gene.get_strand())
-
-    def test_strand_us_transcript(self):
-        self.assertEqual(STRAND.POS, self.gene.unspliced_transcripts[0].get_strand())
-
-    def test_strand_spl_transcript(self):
-        self.assertEqual(STRAND.POS, self.gene.spliced_transcripts[0].get_strand())
-
-    def test_strand_translation(self):
-        self.assertEqual(STRAND.POS, self.gene.spliced_transcripts[0].translations[0].get_strand())
+@pytest.fixture
+def unstranded_gene():
+    gene = Gene('1', 1, 500, strand=STRAND.POS)
+    pre_transcript = PreTranscript(gene=gene, exons=[(1, 100), (200, 300), (400, 500)])
+    gene.unspliced_transcripts.append(pre_transcript)
+    for spl in pre_transcript.generate_splicing_patterns():
+        t = Transcript(pre_transcript, spl)
+        pre_transcript.spliced_transcripts.append(t)
+        tl = Translation(51, 250, t)
+        t.translations.append(tl)
+    return gene
 
 
-class TestCoordinateCoversion(unittest.TestCase):
-    def setUp(self):
-        self.gene = Gene('1', 15, 700, strand=STRAND.POS)
+class TestStrandInheritance:
+    def test_strand_gene(self, unstranded_gene):
+        assert unstranded_gene.get_strand() == STRAND.POS
 
-        self.pre_transcript = PreTranscript(
-            gene=self.gene, exons=[(101, 200), (301, 400), (501, 600)]
-        )
-        self.gene.unspliced_transcripts.append(self.pre_transcript)
-        assert 1 == len(self.pre_transcript.generate_splicing_patterns())
+    def test_strand_us_transcript(self, unstranded_gene):
+        assert unstranded_gene.unspliced_transcripts[0].get_strand() == STRAND.POS
 
-        spl = self.pre_transcript.generate_splicing_patterns()[0]
-        self.transcript = Transcript(self.pre_transcript, spl)
-        self.pre_transcript.spliced_transcripts.append(self.transcript)
+    def test_strand_spl_transcript(self, unstranded_gene):
+        assert unstranded_gene.spliced_transcripts[0].get_strand() == STRAND.POS
 
-        self.translation = Translation(51, 251, self.transcript)
-        self.transcript.translations.append(self.translation)
-
-        self.rev_gene = Gene('1', 15, 700, strand=STRAND.NEG)
-        self.rev_ust = PreTranscript(gene=self.rev_gene, exons=[(101, 200), (301, 400), (501, 600)])
-        self.gene.unspliced_transcripts.append(self.rev_ust)
-        assert 1 == len(self.rev_ust.generate_splicing_patterns())
-
-        spl = self.rev_ust.generate_splicing_patterns()[0]
-        self.rev_transcript = Transcript(self.rev_ust, spl)
-        self.rev_ust.spliced_transcripts.append(self.rev_transcript)
-
-        self.rev_translation = Translation(51, 251, self.rev_transcript)
-        self.rev_transcript.translations.append(self.rev_translation)
-
-    def test_cdna_to_genomic(self):
-        self.assertEqual(150, self.transcript.convert_cdna_to_genomic(50))
-        self.assertEqual(550, self.transcript.convert_cdna_to_genomic(250))
-
-    def test_cdna_to_genomic_before(self):
-        self.assertEqual(100, self.transcript.convert_cdna_to_genomic(-1))
-        self.assertEqual(51, self.transcript.convert_cdna_to_genomic(-50))
-
-    def test_cdna_to_genomic_after(self):
-        self.assertEqual(650, self.transcript.convert_cdna_to_genomic(350))
-
-    def test_cdna_to_genomic_revcomp(self):
-        self.assertEqual(551, self.rev_transcript.convert_cdna_to_genomic(50))
-        self.assertEqual(151, self.rev_transcript.convert_cdna_to_genomic(250))
-
-    def test_genomic_to_cdna(self):
-        self.assertEqual(50, self.transcript.convert_genomic_to_cdna(150))
-        self.assertEqual(249, self.transcript.convert_genomic_to_cdna(549))
-
-    def test_genomic_to_cdna_before(self):
-        self.assertEqual((1, -1), self.transcript.convert_genomic_to_nearest_cdna(100))
-
-    def test_genomic_to_cdna_after(self):
-        self.assertEqual((300, 1), self.transcript.convert_genomic_to_nearest_cdna(601))
-
-    def test_genomic_to_cdna_revcomp(self):
-        self.assertEqual(50, self.rev_transcript.convert_genomic_to_cdna(551))
-        self.assertEqual(250, self.rev_transcript.convert_genomic_to_cdna(151))
-
-    def test_aa_to_cdna(self):
-        self.assertEqual(Interval(51, 53), self.translation.convert_aa_to_cdna(1))
-        self.assertEqual(Interval(249, 251), self.translation.convert_aa_to_cdna(67))
-
-    def test_cdna_to_aa(self):
-        self.assertEqual(1, self.translation.convert_cdna_to_aa(51))
-        self.assertEqual(67, self.translation.convert_cdna_to_aa(251))
-        with self.assertRaises(IndexError):
-            self.translation.convert_cdna_to_aa(50)
-        with self.assertRaises(IndexError):
-            self.translation.convert_cdna_to_aa(252)
-
-    def test_genomic_to_cds(self):
-        self.assertEqual(1, self.translation.convert_genomic_to_cds(151))
-        self.assertEqual(201, self.translation.convert_genomic_to_cds(551))
-
-    def test_genomic_to_cds_3prime_utr(self):
-        self.assertEqual(-1, self.translation.convert_genomic_to_cds(150))
-
-    def test_genomic_to_cds_5prime_utr(self):
-        self.assertEqual(202, self.translation.convert_genomic_to_cds(552))
-
-    def test_genomic_to_cds_notation(self):
-        self.assertEqual('1', self.translation.convert_genomic_to_cds_notation(151))
-        self.assertEqual('201', self.translation.convert_genomic_to_cds_notation(551))
-
-    def test_genomic_to_cds_notation_3prime_utr(self):
-        self.assertEqual('-1', self.translation.convert_genomic_to_cds_notation(150))
-
-    def test_genomic_to_cds_notation_5prime_utr(self):
-        self.assertEqual('*1', self.translation.convert_genomic_to_cds_notation(552))
-
-    def test_genomic_to_cds_notation_intronic_pos(self):
-        self.assertEqual('50+2', self.translation.convert_genomic_to_cds_notation(202))
-
-    def test_genomic_to_cds_notation_intronic_neg(self):
-        self.assertEqual('51-2', self.translation.convert_genomic_to_cds_notation(299))
-
-    def test_genomic_to_nearest_cdna_exonic(self):
-        self.assertEqual((1, 0), self.transcript.convert_genomic_to_nearest_cdna(101))
-        self.assertEqual((300, 0), self.transcript.convert_genomic_to_nearest_cdna(600))
-        self.assertEqual((101, 0), self.transcript.convert_genomic_to_nearest_cdna(301))
-
-    def test_genomic_to_nearest_cdna_intronic_pos(self):
-        self.assertEqual((100, 10), self.transcript.convert_genomic_to_nearest_cdna(210))
-
-    def test_genomic_to_nearest_cdna_intronic_neg(self):
-        self.assertEqual((101, -2), self.transcript.convert_genomic_to_nearest_cdna(299))
-
-    def test_genomic_to_nearest_cdna_rev_exonic(self):
-        self.assertEqual((300, 0), self.rev_transcript.convert_genomic_to_nearest_cdna(101))
-        self.assertEqual((1, 0), self.rev_transcript.convert_genomic_to_nearest_cdna(600))
-        self.assertEqual((101, 0), self.rev_transcript.convert_genomic_to_nearest_cdna(400))
-
-    def test_genomic_to_nearest_cdna_rev_intronic_pos(self):
-        self.assertEqual((201, -10), self.rev_transcript.convert_genomic_to_nearest_cdna(210))
-
-    def test_genomic_to_nearest_cdna_rev_intronic_neg(self):
-        self.assertEqual((200, 2), self.rev_transcript.convert_genomic_to_nearest_cdna(299))
+    def test_strand_translation(self, unstranded_gene):
+        assert unstranded_gene.spliced_transcripts[0].translations[0].get_strand() == STRAND.POS
 
 
-class TestUSTranscript(unittest.TestCase):
+@pytest.fixture
+def coord_conv_setup():
+    n = argparse.Namespace()
+    n.gene = Gene('1', 15, 700, strand=STRAND.POS)
+
+    n.pre_transcript = PreTranscript(gene=n.gene, exons=[(101, 200), (301, 400), (501, 600)])
+    n.gene.unspliced_transcripts.append(n.pre_transcript)
+    assert 1 == len(n.pre_transcript.generate_splicing_patterns())
+
+    spl = n.pre_transcript.generate_splicing_patterns()[0]
+    n.transcript = Transcript(n.pre_transcript, spl)
+    n.pre_transcript.spliced_transcripts.append(n.transcript)
+
+    n.translation = Translation(51, 251, n.transcript)
+    n.transcript.translations.append(n.translation)
+
+    n.rev_gene = Gene('1', 15, 700, strand=STRAND.NEG)
+    n.rev_ust = PreTranscript(gene=n.rev_gene, exons=[(101, 200), (301, 400), (501, 600)])
+    n.gene.unspliced_transcripts.append(n.rev_ust)
+    assert 1 == len(n.rev_ust.generate_splicing_patterns())
+
+    spl = n.rev_ust.generate_splicing_patterns()[0]
+    n.rev_transcript = Transcript(n.rev_ust, spl)
+    n.rev_ust.spliced_transcripts.append(n.rev_transcript)
+
+    n.rev_translation = Translation(51, 251, n.rev_transcript)
+    n.rev_transcript.translations.append(n.rev_translation)
+    return n
+
+
+class TestCoordinateCoversion:
+    def test_cdna_to_genomic(self, coord_conv_setup):
+        assert coord_conv_setup.transcript.convert_cdna_to_genomic(50) == 150
+        assert coord_conv_setup.transcript.convert_cdna_to_genomic(250) == 550
+
+    def test_cdna_to_genomic_before(self, coord_conv_setup):
+        assert coord_conv_setup.transcript.convert_cdna_to_genomic(-1) == 100
+        assert coord_conv_setup.transcript.convert_cdna_to_genomic(-50) == 51
+
+    def test_cdna_to_genomic_after(self, coord_conv_setup):
+        assert coord_conv_setup.transcript.convert_cdna_to_genomic(350) == 650
+
+    def test_cdna_to_genomic_revcomp(self, coord_conv_setup):
+        assert coord_conv_setup.rev_transcript.convert_cdna_to_genomic(50) == 551
+        assert coord_conv_setup.rev_transcript.convert_cdna_to_genomic(250) == 151
+
+    def test_genomic_to_cdna(self, coord_conv_setup):
+        assert coord_conv_setup.transcript.convert_genomic_to_cdna(150) == 50
+        assert coord_conv_setup.transcript.convert_genomic_to_cdna(549) == 249
+
+    def test_genomic_to_cdna_before(self, coord_conv_setup):
+        assert coord_conv_setup.transcript.convert_genomic_to_nearest_cdna(100) == (1, -1)
+
+    def test_genomic_to_cdna_after(self, coord_conv_setup):
+        assert coord_conv_setup.transcript.convert_genomic_to_nearest_cdna(601) == (300, 1)
+
+    def test_genomic_to_cdna_revcomp(self, coord_conv_setup):
+        assert coord_conv_setup.rev_transcript.convert_genomic_to_cdna(551) == 50
+        assert coord_conv_setup.rev_transcript.convert_genomic_to_cdna(151) == 250
+
+    def test_aa_to_cdna(self, coord_conv_setup):
+        assert coord_conv_setup.translation.convert_aa_to_cdna(1) == Interval(51, 53)
+        assert coord_conv_setup.translation.convert_aa_to_cdna(67) == Interval(249, 251)
+
+    def test_cdna_to_aa(self, coord_conv_setup):
+        assert coord_conv_setup.translation.convert_cdna_to_aa(51) == 1
+        assert coord_conv_setup.translation.convert_cdna_to_aa(251) == 67
+        with pytest.raises(IndexError):
+            coord_conv_setup.translation.convert_cdna_to_aa(50)
+        with pytest.raises(IndexError):
+            coord_conv_setup.translation.convert_cdna_to_aa(252)
+
+    def test_genomic_to_cds(self, coord_conv_setup):
+        assert coord_conv_setup.translation.convert_genomic_to_cds(151) == 1
+        assert coord_conv_setup.translation.convert_genomic_to_cds(551) == 201
+
+    def test_genomic_to_cds_3prime_utr(self, coord_conv_setup):
+        assert coord_conv_setup.translation.convert_genomic_to_cds(150) == -1
+
+    def test_genomic_to_cds_5prime_utr(self, coord_conv_setup):
+        assert coord_conv_setup.translation.convert_genomic_to_cds(552) == 202
+
+    def test_genomic_to_cds_notation(self, coord_conv_setup):
+        assert coord_conv_setup.translation.convert_genomic_to_cds_notation(151) == '1'
+        assert coord_conv_setup.translation.convert_genomic_to_cds_notation(551) == '201'
+
+    def test_genomic_to_cds_notation_3prime_utr(self, coord_conv_setup):
+        assert coord_conv_setup.translation.convert_genomic_to_cds_notation(150) == '-1'
+
+    def test_genomic_to_cds_notation_5prime_utr(self, coord_conv_setup):
+        assert coord_conv_setup.translation.convert_genomic_to_cds_notation(552) == '*1'
+
+    def test_genomic_to_cds_notation_intronic_pos(self, coord_conv_setup):
+        assert coord_conv_setup.translation.convert_genomic_to_cds_notation(202) == '50+2'
+
+    def test_genomic_to_cds_notation_intronic_neg(self, coord_conv_setup):
+        assert coord_conv_setup.translation.convert_genomic_to_cds_notation(299) == '51-2'
+
+    def test_genomic_to_nearest_cdna_exonic(self, coord_conv_setup):
+        assert coord_conv_setup.transcript.convert_genomic_to_nearest_cdna(101) == (1, 0)
+        assert coord_conv_setup.transcript.convert_genomic_to_nearest_cdna(600) == (300, 0)
+        assert coord_conv_setup.transcript.convert_genomic_to_nearest_cdna(301) == (101, 0)
+
+    def test_genomic_to_nearest_cdna_intronic_pos(self, coord_conv_setup):
+        assert coord_conv_setup.transcript.convert_genomic_to_nearest_cdna(210) == (100, 10)
+
+    def test_genomic_to_nearest_cdna_intronic_neg(self, coord_conv_setup):
+        assert coord_conv_setup.transcript.convert_genomic_to_nearest_cdna(299) == (101, -2)
+
+    def test_genomic_to_nearest_cdna_rev_exonic(self, coord_conv_setup):
+        assert coord_conv_setup.rev_transcript.convert_genomic_to_nearest_cdna(101) == (300, 0)
+        assert coord_conv_setup.rev_transcript.convert_genomic_to_nearest_cdna(600) == (1, 0)
+        assert coord_conv_setup.rev_transcript.convert_genomic_to_nearest_cdna(400) == (101, 0)
+
+    def test_genomic_to_nearest_cdna_rev_intronic_pos(self, coord_conv_setup):
+        assert coord_conv_setup.rev_transcript.convert_genomic_to_nearest_cdna(210) == (201, -10)
+
+    def test_genomic_to_nearest_cdna_rev_intronic_neg(self, coord_conv_setup):
+        assert coord_conv_setup.rev_transcript.convert_genomic_to_nearest_cdna(299) == (200, 2)
+
+
+class TestUSTranscript:
     def test___init__implicit_start(self):
         t = PreTranscript(gene=None, exons=[(1, 100), (200, 300), (400, 500)], strand=STRAND.POS)
-        self.assertEqual(1, t.start)
-        self.assertEqual(t.start, t.start)
-        self.assertEqual(500, t.end)
-        self.assertEqual(t.end, t.end)
-        self.assertEqual(1, t[0])
-        self.assertEqual(500, t[1])
-        self.assertFalse(Interval.overlaps((0, 0), t))
-        self.assertTrue(Interval.overlaps((1, 1), t))
-        self.assertTrue(Interval.overlaps((1, 50), t))
+        assert t.start == 1
+        assert t.start == t.start
+        assert t.end == 500
+        assert t.end == t.end
+        assert t[0] == 1
+        assert t[1] == 500
+        assert not Interval.overlaps((0, 0), t)
+        assert Interval.overlaps((1, 1), t)
+        assert Interval.overlaps((1, 50), t)
 
     def test___init__strand_mismatch(self):
         g = Gene('1', 1, 9999, name='KRAS', strand=STRAND.POS)
 
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             PreTranscript([(1, 100)], gene=g, strand=STRAND.NEG)
 
     def test___init__overlapping_exon_error(self):
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             PreTranscript(exons=[Exon(1, 15), Exon(10, 20)])
 
     def test_exon_number(self):
         t = PreTranscript(gene=None, exons=[(1, 99), (200, 299), (400, 499)], strand=STRAND.POS)
         for i, e in enumerate(t.exons):
-            self.assertEqual(i + 1, t.exon_number(e))
+            assert t.exon_number(e) == i + 1
 
         t = PreTranscript(gene=None, exons=[(1, 99), (200, 299), (400, 499)], strand=STRAND.NEG)
         for i, e in enumerate(sorted(t.exons, key=lambda x: x.start, reverse=True)):
-            self.assertEqual(i + 1, t.exon_number(e))
+            assert t.exon_number(e) == i + 1
 
 
-class TestDomain(unittest.TestCase):
+class TestDomain:
     def test___init__region_error(self):
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             Domain('name', [(1, 3), (4, 3)])
 
     def test_get_seq_from_ref(self):
@@ -1177,13 +1358,13 @@ class TestDomain(unittest.TestCase):
         t = PreTranscript(exons=[(2, 5), (7, 15)], gene=g)
         tl = Translation(4, 11, t, [])
         d = Domain('name', [(1, 2)], translation=tl)
-        self.assertEqual([translate('GGGGAT')], d.get_seqs(ref))
+        assert d.get_seqs(ref) == [translate('GGGGAT')]
 
     def test_get_seq_from_translation_seq(self):
         t = PreTranscript(exons=[(2, 5), (7, 15)], seq='CCCTAATCCCCTTT', strand=STRAND.NEG)
         tl = Translation(4, 11, t, [])
         d = Domain('name', [(1, 2)], translation=tl)
-        self.assertEqual([translate('TAATCC')], d.get_seqs())
+        assert d.get_seqs() == [translate('TAATCC')]
 
     def test_align_seq(self):
         regions = [
@@ -1213,15 +1394,15 @@ class TestDomain(unittest.TestCase):
         )
 
         d = Domain('name', regions)
-        self.assertTrue(len(refseq) >= 578)
+        assert len(refseq) >= 578
         match, total, temp = d.align_seq(refseq)
-        self.assertEqual(sum([len(d.seq) for d in regions]), total)
-        self.assertEqual(total, match)
-        self.assertEqual(len(regions), len(temp))
+        assert total == sum([len(d.seq) for d in regions])
+        assert match == total
+        assert len(temp) == len(regions)
         for dr1, dr2 in zip(temp, regions):
-            self.assertEqual(dr1.start, dr2.start)
-            self.assertEqual(dr1.end, dr2.end)
-            self.assertEqual(dr1.seq, dr2.seq)
+            assert dr2.start == dr1.start
+            assert dr2.end == dr1.end
+            assert dr2.seq == dr1.seq
 
         refseq = (
             'MHRPPRHMGNKAMEPMDSPLMSAIPRLRPLQPMGRPPMQLLMDSLPLVILLQLPPRHTASLSRGMALVLMIPPL'
@@ -1236,7 +1417,7 @@ class TestDomain(unittest.TestCase):
         )
 
         dom = Domain('name', [DomainRegion(1, len(d), d)])
-        with self.assertRaises(UserWarning):
+        with pytest.raises(UserWarning):
             dom.align_seq(refseq)
 
         seq = (
@@ -1251,42 +1432,42 @@ class TestDomain(unittest.TestCase):
         d = 'IYVQGLNDSVTLDDLADFFKQCGVVKMNKRTGQPMIHIYLDKETGKPKGDATVSYEDPPTAKAAVEWFDGKDFQGSKLK'
         dom = Domain('name', [DomainRegion(1, len(d), d)])
 
-        with self.assertRaises(UserWarning):
+        with pytest.raises(UserWarning):
             m, t, regions = dom.align_seq(seq)
 
 
-class TestBioInterval(unittest.TestCase):
+class TestBioInterval:
     def test___eq__(self):
         a = BioInterval(REF_CHR, 1, 2)
         b = BioInterval(REF_CHR, 1, 2)
         c = BioInterval('test2', 1, 2)
-        self.assertEqual(a, a)
-        self.assertEqual(a, b)
-        self.assertNotEqual(a, None)
-        self.assertNotEqual(a, c)
+        assert a == a
+        assert b == a
+        assert a is not None
+        assert c != a
 
 
-class TestGene(unittest.TestCase):
+class TestGene:
     def test___hash__(self):
         g1 = Gene(REF_CHR, 1, 2, 'name1', STRAND.POS)
         g2 = Gene(REF_CHR, 1, 2, 'name2', STRAND.POS)
         h = set([g1, g2])
-        self.assertEqual(2, len(h))
+        assert len(h) == 2
 
     def test___eq__(self):
         g1 = Gene(REF_CHR, 1, 2, 'name1', STRAND.POS)
         g2 = Gene(REF_CHR, 1, 2, 'name2', STRAND.POS)
-        self.assertNotEqual(g1, g2)
+        assert g2 != g1
         g3 = Gene('test2', 1, 2, 'name1', STRAND.POS)
-        self.assertNotEqual(g1, g3)
-        self.assertNotEqual(g3, g1)
-        self.assertNotEqual(g1, None)
-        self.assertNotEqual(None, g1)
+        assert g3 != g1
+        assert g1 != g3
+        assert None != g1  # noqa: E711
+        assert g1 != None  # noqa: E711
 
     def test_get_seq(self):
         ref = {'1': MockObject(seq='AACCCTTTGGG')}
         g = Gene('1', 3, 8, strand=STRAND.POS)
-        self.assertEqual('CCCTTT', g.get_seq(ref))
+        assert g.get_seq(ref) == 'CCCTTT'
         g = Gene(REF_CHR, 2836, 4144, strand=STRAND.POS)
         seq = (
             'GCAACTATATAATCTGTGGGAATATCTCCTTTTACACCTAGCCCTACTTCTGTCTGGCTACAGTCATTTATCTGGCTTTGGGAAATGTGACCACAGAATCAGATAT'
@@ -1303,16 +1484,16 @@ class TestGene(unittest.TestCase):
             'CATCGATAAACATCACAAAATGACTACTGGTAACCACTATGAAACTCTTTAAGCGGTAGGTCCTGTATGAATTTTACTCCTCATGATTTGAAGATTATGCATAAAT'
             'TCCTTCTTCCTGTTATTTTGTTTCCAATTTAGTCTTT'
         ).upper()
-        self.assertEqual(seq, g.get_seq(REFERENCE_GENOME))
+        assert g.get_seq(REFERENCE_GENOME) == seq
 
 
-class TestAnnotationGathering(unittest.TestCase):
+class TestAnnotationGathering:
     def test_overlapping_transcripts(self):
         b = Breakpoint('C', 1000, strand=STRAND.POS)
         g = Gene('C', 1, 9999, 'gene1', STRAND.POS)
         t = PreTranscript(exons=[(100, 199), (500, 699), (1200, 1300)], gene=g)
         g.transcripts.append(t)
-        self.assertTrue(Interval.overlaps(b, t))
+        assert Interval.overlaps(b, t)
         t = PreTranscript(exons=[(100, 199), (500, 699), (800, 900)], gene=g)
         g.transcripts.append(t)
         h = Gene('C', 1, 9999, 'gene1', STRAND.NEG)
@@ -1320,73 +1501,73 @@ class TestAnnotationGathering(unittest.TestCase):
         h.transcripts.append(t)
         d = {'C': [g, h]}
         tlist = overlapping_transcripts(d, b)
-        self.assertEqual(1, len(tlist))
+        assert len(tlist) == 1
 
     def test_breakpoint_within_gene(self):
         b = Breakpoint(REF_CHR, 150, 150)
         pos, neg = _gather_breakpoint_annotations(REFERENCE_ANNOTATIONS, b)
-        self.assertEqual(1, len(pos))
-        self.assertEqual(1, len(neg))
-        self.assertEqual(STRAND.POS, pos[0].get_strand())
-        self.assertEqual(b.start, neg[0].start)
-        self.assertEqual(b.end, neg[0].end)
-        self.assertEqual(STRAND.NEG, neg[0].get_strand())
+        assert len(pos) == 1
+        assert len(neg) == 1
+        assert pos[0].get_strand() == STRAND.POS
+        assert neg[0].start == b.start
+        assert neg[0].end == b.end
+        assert neg[0].get_strand() == STRAND.NEG
 
     def test_breakpoint_overlapping_gene(self):
         b = Breakpoint(REF_CHR, 150, 230)
         pos, neg = _gather_breakpoint_annotations(REFERENCE_ANNOTATIONS, b)
-        self.assertEqual(2, len(pos))
-        self.assertEqual(201, pos[1].start)
-        self.assertEqual(b.end, pos[1].end)
-        self.assertEqual(1, len(neg))
-        self.assertEqual(b.start, neg[0].start)
-        self.assertEqual(b.end, neg[0].end)
+        assert len(pos) == 2
+        assert pos[1].start == 201
+        assert pos[1].end == b.end
+        assert len(neg) == 1
+        assert neg[0].start == b.start
+        assert neg[0].end == b.end
 
         b = Breakpoint(REF_CHR, 150, 225, strand=STRAND.POS)
         pos, neg = _gather_breakpoint_annotations(REFERENCE_ANNOTATIONS, b)
-        self.assertEqual(2, len(pos))
-        self.assertEqual(100, pos[0].start)
-        self.assertEqual(200, pos[0].end)
-        self.assertEqual(201, pos[1].start)
-        self.assertEqual(b.end, pos[1].end)
-        self.assertEqual(1, len(neg))
-        self.assertEqual(b.start, neg[0].start)
-        self.assertEqual(b.end, neg[0].end)
+        assert len(pos) == 2
+        assert pos[0].start == 100
+        assert pos[0].end == 200
+        assert pos[1].start == 201
+        assert pos[1].end == b.end
+        assert len(neg) == 1
+        assert neg[0].start == b.start
+        assert neg[0].end == b.end
 
         b = Breakpoint(REF_CHR, 375, 425, strand=STRAND.POS)
         pos, neg = _gather_breakpoint_annotations(REFERENCE_ANNOTATIONS, b)
-        self.assertEqual(2, len(pos))
-        self.assertEqual(300, pos[0].start)
-        self.assertEqual(400, pos[0].end)
-        self.assertEqual(401, pos[1].start)
-        self.assertEqual(b.end, pos[1].end)
-        self.assertEqual(1, len(neg))
-        self.assertEqual(b.start, neg[0].start)
-        self.assertEqual(b.end, neg[0].end)
+        assert len(pos) == 2
+        assert pos[0].start == 300
+        assert pos[0].end == 400
+        assert pos[1].start == 401
+        assert pos[1].end == b.end
+        assert len(neg) == 1
+        assert neg[0].start == b.start
+        assert neg[0].end == b.end
 
     def test_breakpoint_overlapping_mutliple_genes_and_intergenic(self):
         b = Breakpoint(REF_CHR, 150, 275)
         pos, neg = _gather_breakpoint_annotations(REFERENCE_ANNOTATIONS, b)
-        self.assertEqual(2, len(pos))
-        self.assertEqual(201, pos[1].start)
-        self.assertEqual(b.end, pos[1].end)
-        self.assertEqual(2, len(neg))
-        self.assertEqual(b.start, neg[0].start)
-        self.assertEqual(249, neg[0].end)
+        assert len(pos) == 2
+        assert pos[1].start == 201
+        assert pos[1].end == b.end
+        assert len(neg) == 2
+        assert neg[0].start == b.start
+        assert neg[0].end == 249
 
     def test_breakpoint_overlapping_mutliple_pos_genes(self):
         b = Breakpoint(REF_CHR, 575, 625)
         pos, neg = _gather_breakpoint_annotations(REFERENCE_ANNOTATIONS, b)
-        self.assertEqual(2, len(pos))
-        self.assertEqual(1, len(neg))
-        self.assertEqual(b.start, neg[0].start)
-        self.assertEqual(b.end, neg[0].end)
+        assert len(pos) == 2
+        assert len(neg) == 1
+        assert neg[0].start == b.start
+        assert neg[0].end == b.end
 
     def test_breakpoint_overlapping_mutliple_genes(self):
         b = Breakpoint(REF_CHR, 300, 350)
         pos, neg = _gather_breakpoint_annotations(REFERENCE_ANNOTATIONS, b)
-        self.assertEqual(1, len(pos))
-        self.assertEqual(1, len(neg))
+        assert len(pos) == 1
+        assert len(neg) == 1
 
     def test_intrachromosomal(self):
         b1 = Breakpoint(REF_CHR, 150, 225, strand=STRAND.POS)
@@ -1395,16 +1576,16 @@ class TestAnnotationGathering(unittest.TestCase):
         ann_list = sorted(
             _gather_annotations(REFERENCE_ANNOTATIONS, bpp), key=lambda x: (x.break1, x.break2)
         )
-        self.assertEqual(5, len(ann_list))
+        assert len(ann_list) == 5
         first = ann_list[0]
-        self.assertEqual(1, len(first.encompassed_genes))
-        self.assertEqual(0, len(first.genes_proximal_to_break1))
-        self.assertEqual(1, len(first.genes_proximal_to_break2))
-        self.assertEqual(0, len(first.genes_overlapping_break1))
-        self.assertEqual(0, len(first.genes_overlapping_break2))
+        assert len(first.encompassed_genes) == 1
+        assert len(first.genes_proximal_to_break1) == 0
+        assert len(first.genes_proximal_to_break2) == 1
+        assert len(first.genes_overlapping_break1) == 0
+        assert len(first.genes_overlapping_break2) == 0
         near, dist = list(first.genes_proximal_to_break2)[0]
-        self.assertEqual(50, dist)
-        self.assertEqual(2, len(ann_list[1].encompassed_genes))
+        assert dist == 50
+        assert len(ann_list[1].encompassed_genes) == 2
 
     def test_interchromosomal(self):
         raise unittest.SkipTest('TODO')
@@ -1419,8 +1600,8 @@ class TestAnnotationGathering(unittest.TestCase):
         b2 = Breakpoint(REF_CHR, 2250, strand=STRAND.NEG)
         bpp = BreakpointPair(b1, b2)
         ann_list = sorted(_gather_annotations(ref, bpp), key=lambda x: (x.break1, x.break2))
-        self.assertEqual(1, len(ann_list))
-        self.assertEqual(ann_list[0].transcript1, ann_list[0].transcript2)
+        assert len(ann_list) == 1
+        assert ann_list[0].transcript2 == ann_list[0].transcript1
 
     def test_breakpoint_single_gene(self):
         g = Gene(REF_CHR, 1000, 3000, strand=STRAND.POS)
@@ -1431,40 +1612,40 @@ class TestAnnotationGathering(unittest.TestCase):
         b2 = Breakpoint(REF_CHR, 800, strand=STRAND.POS)
         bpp = BreakpointPair(b1, b2, event_type=SVTYPE.DEL, protocol=PROTOCOL.GENOME)
         ann_list = sorted(_gather_annotations(ref, bpp), key=lambda x: (x.break1, x.break2))
-        self.assertEqual(3, len(ann_list))
+        assert len(ann_list) == 3
         for ann in ann_list:
-            self.assertTrue(ann.break1.start in ann.transcript1.position)
-            self.assertTrue(ann.break1.end in ann.transcript1.position)
-            self.assertTrue(ann.break2.start in ann.transcript2.position)
-            self.assertTrue(ann.break2.end in ann.transcript2.position)
+            assert ann.break1.start in ann.transcript1.position
+            assert ann.break1.end in ann.transcript1.position
+            assert ann.break2.start in ann.transcript2.position
+            assert ann.break2.end in ann.transcript2.position
 
 
-class TestAnnotate(unittest.TestCase):
+class TestAnnotate:
     def test_reference_name_eq(self):
         first, second = ReferenceName('chr1'), ReferenceName('1')
-        self.assertEqual(first, second)
+        assert second == first
 
     def test_reference_name_set(self):
         first, second = ReferenceName('chr1'), ReferenceName('1')
         d = {first, second}
-        self.assertEqual(1, len(d))
+        assert len(d) == 1
 
     def test_reference_name_dict(self):
         first, second = ReferenceName('chr1'), ReferenceName('1')
         d = {first: 1}
         d[second] = 2
         print(d)
-        self.assertEqual(1, len(d))
+        assert len(d) == 1
         d = {first: 1, second: 2}
-        self.assertEqual(1, len(d))
+        assert len(d) == 1
 
     def test_loading_json_annotations(self):
         annotations = load_annotations(get_data('mock_reference_annotations.json'))
-        self.assertEqual(1, len(annotations.keys()))
-        self.assertEqual(1, len(list(annotations.values())[0]))
+        assert len(annotations.keys()) == 1
+        assert len(list(annotations.values())[0]) == 1
 
     def test_loading_annotations_not_found(self):
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             load_annotations('file.other')
 
     def test_determine_prime(self):
@@ -1473,22 +1654,22 @@ class TestAnnotate(unittest.TestCase):
         bleft = Breakpoint(REF_CHR, 1, 2, orient=ORIENT.LEFT)
         bright = Breakpoint(REF_CHR, 1, 2, orient=ORIENT.RIGHT)
         # positive left should be five prime
-        self.assertEqual(PRIME.FIVE, determine_prime(tpos, bleft))
+        assert determine_prime(tpos, bleft) == PRIME.FIVE
         # positive right should be three prime
-        self.assertEqual(PRIME.THREE, determine_prime(tpos, bright))
+        assert determine_prime(tpos, bright) == PRIME.THREE
         # negative left should be three prime
-        self.assertEqual(PRIME.THREE, determine_prime(tneg, bleft))
+        assert determine_prime(tneg, bleft) == PRIME.THREE
         # negative right should be five prime
-        self.assertEqual(PRIME.FIVE, determine_prime(tneg, bright))
+        assert determine_prime(tneg, bright) == PRIME.FIVE
 
-        with self.assertRaises(NotSpecifiedError):
+        with pytest.raises(NotSpecifiedError):
             bleft.orient = ORIENT.NS
             determine_prime(tpos, bleft)
 
-        with self.assertRaises(NotSpecifiedError):
+        with pytest.raises(NotSpecifiedError):
             determine_prime(tneg, bleft)
 
-        with self.assertRaises(NotSpecifiedError):
+        with pytest.raises(NotSpecifiedError):
             tpos.strand = STRAND.NS
             determine_prime(tpos, bright)
 
@@ -1520,11 +1701,11 @@ class TestAnnotate(unittest.TestCase):
         )
         orfs = calculate_orf(seq)
         for orf in orfs:
-            self.assertEqual('ATG', seq[orf.start - 1 : orf.start + 2])
+            assert seq[orf.start - 1 : orf.start + 2] == 'ATG'
         orfs = sorted(orfs)
-        self.assertEqual(2, len(orfs))
-        self.assertEqual(Interval(1, 894), orfs[0])
-        self.assertEqual(Interval(590, 724), orfs[1])
+        assert len(orfs) == 2
+        assert orfs[0] == Interval(1, 894)
+        assert orfs[1] == Interval(590, 724)
 
         seq = (
             'AAGGAGAGAAAATGGCGTCCACGGATTACAGTACCTATAGCCAAGCTGCAGCGCAGCAGGGCTACAGTGCTTACACCGCCCAGCCCACTCAAGGATATGC'
@@ -1551,10 +1732,10 @@ class TestAnnotate(unittest.TestCase):
 
         orfs = calculate_orf(seq)
         for orf in orfs:
-            self.assertEqual('ATG', seq[orf.start - 1 : orf.start + 2])
+            assert seq[orf.start - 1 : orf.start + 2] == 'ATG'
 
 
-class TestAnnotateEvents(unittest.TestCase):
+class TestAnnotateEvents:
     def test_annotate_events(self):
         reference_annotations = load_annotations(get_data('mock_reference_annotations.full.tsv'))
         b1 = Breakpoint('fakereference9', 658, orient=ORIENT.RIGHT, strand=STRAND.POS)
@@ -1570,14 +1751,14 @@ class TestAnnotateEvents(unittest.TestCase):
         annotations = annotate_events(
             [bpp], reference_genome=REFERENCE_GENOME, annotations=reference_annotations, filters=[]
         )
-        self.assertEqual(4, len(annotations))
-        self.assertEqual(STRAND.POS, annotations[0].transcript1.get_strand())
-        self.assertEqual(STRAND.NEG, annotations[0].transcript2.get_strand())
-        self.assertEqual('ENST00000375851', annotations[0].transcript1.name)
-        self.assertEqual(None, annotations[0].transcript2.name)
+        assert len(annotations) == 4
+        assert annotations[0].transcript1.get_strand() == STRAND.POS
+        assert annotations[0].transcript2.get_strand() == STRAND.NEG
+        assert annotations[0].transcript1.name == 'ENST00000375851'
+        assert annotations[0].transcript2.name is None
         for ann in annotations:
             print(ann.transcript1, ann.transcript2)
         annotations = annotate_events(
             [bpp], reference_genome=REFERENCE_GENOME, annotations=reference_annotations
         )
-        self.assertEqual(2, len(annotations))
+        assert len(annotations) == 2

--- a/tests/integration/test_annotate_examples.py
+++ b/tests/integration/test_annotate_examples.py
@@ -1,6 +1,3 @@
-import os
-import unittest
-
 from mavis.annotate.fusion import FusionTranscript
 from mavis.annotate.variant import (
     Annotation,
@@ -22,23 +19,20 @@ def get_best(gene):
     raise KeyError('no best transcript for gene', gene)
 
 
-class TestNDUFA12(unittest.TestCase):
-    def setUp(self):
-        print(get_example_genes().keys())
-        self.gene = get_example_genes()['NDUFA12']
-        self.reference_annotations = {self.gene.chr: [self.gene]}
-        self.reference_genome = {
-            self.gene.chr: MockObject(seq=MockLongString(self.gene.seq, offset=self.gene.start - 1))
-        }
-        self.best = get_best(self.gene)
-
+class TestNDUFA12:
     def test_annotate_events_synonymous(self):
-        for gene_list in self.reference_annotations.values():
+        gene = get_example_genes()['NDUFA12']
+        reference_annotations = {gene.chr: [gene]}
+        reference_genome = {
+            gene.chr: MockObject(seq=MockLongString(gene.seq, offset=gene.start - 1))
+        }
+
+        for gene_list in reference_annotations.values():
             for gene in gene_list:
                 for t in gene.transcripts:
                     print(t)
-        b1 = Breakpoint(self.gene.chr, 95344068, orient=ORIENT.LEFT, strand=STRAND.NS)
-        b2 = Breakpoint(self.gene.chr, 95344379, orient=ORIENT.RIGHT, strand=STRAND.NS)
+        b1 = Breakpoint(gene.chr, 95344068, orient=ORIENT.LEFT, strand=STRAND.NS)
+        b2 = Breakpoint(gene.chr, 95344379, orient=ORIENT.RIGHT, strand=STRAND.NS)
         bpp = BreakpointPair(
             b1,
             b2,
@@ -49,28 +43,27 @@ class TestNDUFA12(unittest.TestCase):
             untemplated_seq='',
         )
         annotations = annotate_events(
-            [bpp], reference_genome=self.reference_genome, annotations=self.reference_annotations
+            [bpp], reference_genome=reference_genome, annotations=reference_annotations
         )
         ann = annotations[0]
         for a in annotations:
             print(a, a.fusion, a.fusion.transcripts)
             print(a.transcript1, a.transcript1.transcripts)
         fseq = ann.fusion.transcripts[0].get_seq()
-        refseq = ann.transcript1.transcripts[0].get_seq(self.reference_genome)
-        self.assertEqual(refseq, fseq)
-        self.assertEqual(1, len(annotations))
+        refseq = ann.transcript1.transcripts[0].get_seq(reference_genome)
+        assert fseq == refseq
+        assert len(annotations) == 1
 
 
-class TestARID1B(unittest.TestCase):
-    def setUp(self):
-        self.gene = get_example_genes()['ARID1B']
-        self.reference_annotations = {self.gene.chr: [self.gene]}
-        self.reference_genome = {
-            self.gene.chr: MockObject(seq=MockLongString(self.gene.seq, offset=self.gene.start - 1))
-        }
-        self.best = get_best(self.gene)
-
+class TestARID1B:
     def test_small_duplication(self):
+        gene = get_example_genes()['ARID1B']
+        reference_annotations = {gene.chr: [gene]}
+        reference_genome = {
+            gene.chr: MockObject(seq=MockLongString(gene.seq, offset=gene.start - 1))
+        }
+        best = get_best(gene)
+
         bpp = BreakpointPair(
             Breakpoint('6', 157100005, strand='+', orient='R'),
             Breakpoint('6', 157100007, strand='+', orient='L'),
@@ -80,41 +73,40 @@ class TestARID1B(unittest.TestCase):
         )
         # annotate the breakpoint with the gene
         annotations = annotate_events(
-            [bpp], reference_genome=self.reference_genome, annotations=self.reference_annotations
+            [bpp], reference_genome=reference_genome, annotations=reference_annotations
         )
-        self.assertEqual(1, len(annotations))
+        assert len(annotations) == 1
 
-        ann = Annotation(bpp, transcript1=self.best, transcript2=self.best)
+        ann = Annotation(bpp, transcript1=best, transcript2=best)
         ft = FusionTranscript.build(
             ann,
-            self.reference_genome,
+            reference_genome,
             min_orf_size=300,
             max_orf_cap=10,
             min_domain_mapping_match=0.9,
         )
-        ref_tx = self.best.translations[0]
+        ref_tx = best.translations[0]
         fusion_tx = ft.translations[0]
 
         # compare the fusion translation to the refernece translation to create the protein notation
-        ref_aa_seq = ref_tx.get_aa_seq(self.reference_genome)
+        ref_aa_seq = ref_tx.get_aa_seq(reference_genome)
         call = IndelCall(ref_aa_seq, fusion_tx.get_aa_seq())
-        self.assertTrue(call.is_dup)
+        assert call.is_dup
 
-        notation = call_protein_indel(ref_tx, fusion_tx, self.reference_genome)
+        notation = call_protein_indel(ref_tx, fusion_tx, reference_genome)
         print(notation)
-        self.assertEqual('ENST00000346085:p.G319dupG', notation)
+        assert notation == 'ENST00000346085:p.G319dupG'
 
 
-class TestSVEP1(unittest.TestCase):
-    def setUp(self):
-        self.gene = get_example_genes()['SVEP1']
-        self.reference_annotations = {self.gene.chr: [self.gene]}
-        self.reference_genome = {
-            self.gene.chr: MockObject(seq=MockLongString(self.gene.seq, offset=self.gene.start - 1))
-        }
-        self.best = get_best(self.gene)
-
+class TestSVEP1:
     def test_annotate_small_intronic_inversion(self):
+        gene = get_example_genes()['SVEP1']
+        reference_annotations = {gene.chr: [gene]}
+        reference_genome = {
+            gene.chr: MockObject(seq=MockLongString(gene.seq, offset=gene.start - 1))
+        }
+        best = get_best(gene)
+
         bpp = BreakpointPair(
             Breakpoint('9', 113152627, 113152627, orient='L'),
             Breakpoint('9', 113152635, 113152635, orient='L'),
@@ -125,19 +117,25 @@ class TestSVEP1(unittest.TestCase):
             untemplated_seq='',
         )
         annotations = annotate_events(
-            [bpp], reference_genome=self.reference_genome, annotations=self.reference_annotations
+            [bpp], reference_genome=reference_genome, annotations=reference_annotations
         )
         for a in annotations:
             print(a, a.transcript1, a.transcript2)
-        self.assertEqual(1, len(annotations))
+        assert len(annotations) == 1
         ann = annotations[0]
-        self.assertEqual(self.best, ann.transcript1)
-        self.assertEqual(self.best, ann.transcript2)
-        refseq = self.best.transcripts[0].get_seq(self.reference_genome)
-        self.assertEqual(1, len(ann.fusion.transcripts))
-        self.assertEqual(refseq, ann.fusion.transcripts[0].get_seq())
+        assert ann.transcript1 == best
+        assert ann.transcript2 == best
+        refseq = best.transcripts[0].get_seq(reference_genome)
+        assert len(ann.fusion.transcripts) == 1
+        assert ann.fusion.transcripts[0].get_seq() == refseq
 
     def test_build_single_transcript_inversion(self):
+        gene = get_example_genes()['SVEP1']
+        reference_genome = {
+            gene.chr: MockObject(seq=MockLongString(gene.seq, offset=gene.start - 1))
+        }
+        best = get_best(gene)
+
         bpp = BreakpointPair(
             Breakpoint('9', 113152627, 113152627, orient='L'),
             Breakpoint('9', 113152635, 113152635, orient='L'),
@@ -147,29 +145,27 @@ class TestSVEP1(unittest.TestCase):
             protocol=PROTOCOL.GENOME,
             untemplated_seq='',
         )
-        ann = Annotation(bpp, transcript1=self.best, transcript2=self.best)
+        ann = Annotation(bpp, transcript1=best, transcript2=best)
         ft = FusionTranscript.build(
             ann,
-            self.reference_genome,
+            reference_genome,
             min_orf_size=300,
             max_orf_cap=10,
             min_domain_mapping_match=0.9,
         )
-        refseq = self.best.transcripts[0].get_seq(self.reference_genome)
-        self.assertEqual(1, len(ft.transcripts))
-        self.assertEqual(refseq, ft.transcripts[0].get_seq())
+        refseq = best.transcripts[0].get_seq(reference_genome)
+        assert len(ft.transcripts) == 1
+        assert ft.transcripts[0].get_seq() == refseq
 
 
-class TestPRKCB(unittest.TestCase):
-    def setUp(self):
-        self.gene = get_example_genes()['PRKCB']
-        self.reference_annotations = {self.gene.chr: [self.gene]}
-        self.reference_genome = {
-            self.gene.chr: MockObject(seq=MockLongString(self.gene.seq, offset=self.gene.start - 1))
-        }
-        self.best = get_best(self.gene)
-
+class TestPRKCB:
     def test_retained_intron(self):
+        gene = get_example_genes()['PRKCB']
+        reference_genome = {
+            gene.chr: MockObject(seq=MockLongString(gene.seq, offset=gene.start - 1))
+        }
+        best = get_best(gene)
+
         bpp = BreakpointPair(
             Breakpoint('16', 23957049, orient='L'),
             Breakpoint('16', 23957050, orient='R'),
@@ -179,31 +175,29 @@ class TestPRKCB(unittest.TestCase):
             protocol=PROTOCOL.TRANS,
             untemplated_seq='A',
         )
-        ann = Annotation(bpp, transcript1=self.best, transcript2=self.best)
+        ann = Annotation(bpp, transcript1=best, transcript2=best)
         ft = FusionTranscript.build(
             ann,
-            self.reference_genome,
+            reference_genome,
             min_orf_size=300,
             max_orf_cap=10,
             min_domain_mapping_match=0.9,
         )
-        self.assertEqual(1, len(ft.transcripts))
+        assert len(ft.transcripts) == 1
         print(ft.transcripts[0].splicing_pattern)
-        print(self.best.transcripts[0].splicing_pattern)
-        self.assertEqual(SPLICE_TYPE.RETAIN, ft.transcripts[0].splicing_pattern.splice_type)
+        print(best.transcripts[0].splicing_pattern)
+        assert ft.transcripts[0].splicing_pattern.splice_type == SPLICE_TYPE.RETAIN
 
 
-class TestDSTYK(unittest.TestCase):
-    def setUp(self):
-        print(get_example_genes().keys())
-        self.gene = get_example_genes()['DSTYK']
-        self.reference_annotations = {self.gene.chr: [self.gene]}
-        self.reference_genome = {
-            self.gene.chr: MockObject(seq=MockLongString(self.gene.seq, offset=self.gene.start - 1))
-        }
-        self.best = get_best(self.gene)
-
+class TestDSTYK:
     def test_build_single_transcript_inversion_reverse_strand(self):
+        print(get_example_genes().keys())
+        gene = get_example_genes()['DSTYK']
+        reference_genome = {
+            gene.chr: MockObject(seq=MockLongString(gene.seq, offset=gene.start - 1))
+        }
+        best = get_best(gene)
+
         # 1:205178631R 1:205178835R inversion
         bpp = BreakpointPair(
             Breakpoint('1', 205178631, orient='R'),
@@ -214,10 +208,10 @@ class TestDSTYK(unittest.TestCase):
             protocol=PROTOCOL.GENOME,
             untemplated_seq='',
         )
-        ann = Annotation(bpp, transcript1=self.best, transcript2=self.best)
+        ann = Annotation(bpp, transcript1=best, transcript2=best)
         ft = FusionTranscript.build(
             ann,
-            self.reference_genome,
+            reference_genome,
             min_orf_size=300,
             max_orf_cap=10,
             min_domain_mapping_match=0.9,
@@ -233,8 +227,8 @@ class TestDSTYK(unittest.TestCase):
                 len(ft.exon_mapping.get(ex.position, None)),
                 ft.exon_number(ex),
             )
-        # refseq = self.best.transcripts[0].get_seq(self.reference_genome)
-        self.assertEqual(1, len(ft.transcripts))
-        self.assertEqual(1860, ft.break1)
-        self.assertEqual(2065, ft.break2)
+        # refseq = best.transcripts[0].get_seq(reference_genome)
+        assert len(ft.transcripts) == 1
+        assert ft.break1 == 1860
+        assert ft.break2 == 2065
         flatten_fusion_transcript(ft.transcripts[0])  # test no error

--- a/tests/integration/test_annotate_fileio.py
+++ b/tests/integration/test_annotate_fileio.py
@@ -1,28 +1,24 @@
-import os
-import unittest
-
 from mavis.annotate.file_io import convert_tab_to_json, load_annotations
 
 from ..util import get_data
 
+TAB = get_data('annotations_subsample.tab')
+JSON = get_data('annotations_subsample.json')
 
-class TestAnnotationLoading(unittest.TestCase):
-    def setUp(self):
-        self.tab = get_data('annotations_subsample.tab')
-        self.json = get_data('annotations_subsample.json')
 
+class TestAnnotationLoading:
     def test_convert_tab_to_json(self):
-        json = convert_tab_to_json(self.tab, warn=print)
-        self.assertEqual(32, len(json['genes']))
+        json = convert_tab_to_json(TAB, warn=print)
+        assert len(json['genes']) == 32
 
     def test_tab_equivalent_to_json(self):
-        tab_result = load_annotations(self.tab, warn=print)
-        json_result = load_annotations(self.json, warn=print)
-        self.assertEqual(sorted(tab_result.keys()), sorted(json_result.keys()))
+        tab_result = load_annotations(TAB, warn=print)
+        json_result = load_annotations(JSON, warn=print)
+        assert sorted(json_result.keys()) == sorted(tab_result.keys())
 
     def test_load_tab(self):
-        result = load_annotations(self.tab, warn=print)
-        self.assertEqual(12, len(result.keys()))
+        result = load_annotations(TAB, warn=print)
+        assert len(result.keys()) == 12
         domains = []
         for gene in result['12']:
             for t in gene.spliced_transcripts:
@@ -35,10 +31,10 @@ class TestAnnotationLoading(unittest.TestCase):
                 break
         for d in domains:
             print(d.name, d.regions)
-        self.assertEqual(2, len(domains))
+        assert len(domains) == 2
         result = load_annotations(get_data('mock_reference_annotations.tsv'), warn=print)
-        self.assertEqual(1, len(result.keys()))
+        assert len(result.keys()) == 1
 
     def test_load_json(self):
-        result = load_annotations(self.json, warn=print)
-        self.assertEqual(12, len(result.keys()))
+        result = load_annotations(JSON, warn=print)
+        assert len(result.keys()) == 12

--- a/tests/integration/test_args.py
+++ b/tests/integration/test_args.py
@@ -1,6 +1,4 @@
-import argparse
 import json
-import os
 import sys
 import tempfile
 from unittest.mock import patch

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -1,7 +1,6 @@
-import os
 import time
-import unittest
 
+import pytest
 import timeout_decorator
 from mavis.assemble import Contig, assemble, filter_contigs
 from mavis.constants import reverse_complement
@@ -9,11 +8,11 @@ from mavis.interval import Interval
 from mavis.schemas import DEFAULTS
 from mavis.util import LOG
 
-from ..util import get_data
-from . import RUN_FULL, MockObject
+from ..util import get_data, long_running_test
+from . import MockObject
 
 
-class TestFilterContigs(unittest.TestCase):
+class TestFilterContigs:
     @timeout_decorator.timeout(30)
     def test_large_set(self):
         contigs = []
@@ -27,61 +26,66 @@ class TestFilterContigs(unittest.TestCase):
         print()
         for c in filtered:
             print(c.seq)
-        self.assertEqual(3, len(filtered))  # figure out amount later. need to optimize timing
+        assert len(filtered) == 3  # figure out amount later. need to optimize timing
 
 
-class TestContigRemap(unittest.TestCase):
-    def setUp(self):
-        self.contig = Contig(' ' * 60, None)
-        self.contig.add_mapped_sequence(MockObject(reference_start=0, reference_end=10))
-        self.contig.add_mapped_sequence(MockObject(reference_start=0, reference_end=20))
-        self.contig.add_mapped_sequence(MockObject(reference_start=50, reference_end=60))
-
-    def test_depth_even_coverage(self):
-        covg = self.contig.remap_depth(Interval(1, 10))
-        self.assertEqual(2, covg)
-
-    def test_depth_mixed_coverage(self):
-        covg = self.contig.remap_depth(Interval(1, 20))
-        self.assertEqual(1.5, covg)
-
-    def test_depth_no_coverage(self):
-        covg = self.contig.remap_depth(Interval(21, 49))
-        self.assertEqual(0, covg)
-
-    def test_depth_whole_contig_coverage(self):
-        self.assertAlmostEqual(40 / 60, self.contig.remap_depth())
-
-    def test_depth_weighted_read(self):
-        self.contig.add_mapped_sequence(MockObject(reference_start=0, reference_end=10), 5)
-        self.assertAlmostEqual(42 / 60, self.contig.remap_depth())
-
-    def test_depth_bad_query_range(self):
-        with self.assertRaises(ValueError):
-            self.contig.remap_depth(Interval(0, 10))
-        with self.assertRaises(ValueError):
-            self.contig.remap_depth(Interval(1, len(self.contig.seq) + 1))
-
-    def test_coverage(self):
-        self.assertEqual(0.5, self.contig.remap_coverage())
+@pytest.fixture
+def contig():
+    contig = Contig(' ' * 60, None)
+    contig.add_mapped_sequence(MockObject(reference_start=0, reference_end=10))
+    contig.add_mapped_sequence(MockObject(reference_start=0, reference_end=20))
+    contig.add_mapped_sequence(MockObject(reference_start=50, reference_end=60))
+    return contig
 
 
-class TestAssemble(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        # load files here so they do not count towar timeout checking
-        sequences = set()
-        with open(get_data('long_filter_assembly.txt'), 'r') as fh:
-            sequences.update([s.strip() for s in fh.readlines() if s])
-        cls.long_filter_seq = sequences
-        sequences = set()
-        with open(get_data('large_assembly.txt'), 'r') as fh:
-            sequences.update([line.strip() for line in fh.readlines()])
-        cls.large_assembly_seq = sequences
+class TestContigRemap:
+    def test_depth_even_coverage(self, contig):
+        covg = contig.remap_depth(Interval(1, 10))
+        assert covg == 2
 
-    def setUp(self):
-        self.log = lambda *x, **k: print(x, k)
+    def test_depth_mixed_coverage(self, contig):
+        covg = contig.remap_depth(Interval(1, 20))
+        assert covg == 1.5
 
+    def test_depth_no_coverage(self, contig):
+        covg = contig.remap_depth(Interval(21, 49))
+        assert covg == 0
+
+    def test_depth_whole_contig_coverage(self, contig):
+        assert pytest.approx(contig.remap_depth()) == 40 / 60
+
+    def test_depth_weighted_read(self, contig):
+        contig.add_mapped_sequence(MockObject(reference_start=0, reference_end=10), 5)
+        assert pytest.approx(contig.remap_depth()) == 42 / 60
+
+    def test_depth_bad_query_range(self, contig):
+        with pytest.raises(ValueError):
+            contig.remap_depth(Interval(0, 10))
+        with pytest.raises(ValueError):
+            contig.remap_depth(Interval(1, len(contig.seq) + 1))
+
+    def test_coverage(self, contig):
+        assert contig.remap_coverage() == 0.5
+
+
+@pytest.fixture
+def long_filter_seq():
+    # load files here so they do not count towar timeout checking
+    sequences = set()
+    with open(get_data('long_filter_assembly.txt'), 'r') as fh:
+        sequences.update([s.strip() for s in fh.readlines() if s])
+    return sequences
+
+
+@pytest.fixture
+def large_assembly_seq():
+    sequences = set()
+    with open(get_data('large_assembly.txt'), 'r') as fh:
+        sequences.update([line.strip() for line in fh.readlines()])
+    return sequences
+
+
+class TestAssemble:
     def test1(self):
         sequences = [
             'TCTTTTTCTTTCTTTCTTTCTTTCTTTCTATTCTATCTTCTTCCTGACTCTTCCTAGCTTAGTCTTACTGACAAGCATGTTACCTTCTTTTTATTTTTGTTTTTAAACCACATTGATCGTAAATCGCCGTGCTTGGTGCTTAATGTACTT',
@@ -177,11 +181,10 @@ class TestAssemble(unittest.TestCase):
             remap_min_exact_match=6,
             assembly_max_paths=20,
             assembly_min_uniq=0.01,
-            log=self.log,
         )
         for contig in assembly:
             print(contig.seq)
-        self.assertTrue(assembly)
+        assert assembly
 
     def test_assembly_low_center(self):
         sequences = {
@@ -245,11 +248,10 @@ class TestAssemble(unittest.TestCase):
             remap_min_exact_match=6,
             assembly_max_paths=20,
             assembly_min_uniq=0.01,
-            log=self.log,
         )
         for assembly in assemblies:
             print(assembly.seq)
-        self.assertEqual(2, len(assemblies))
+        assert len(assemblies) == 2
 
     def test_low_evidence(self):
         seqs = [
@@ -280,11 +282,10 @@ class TestAssemble(unittest.TestCase):
             remap_min_exact_match=6,
             assembly_max_paths=20,
             assembly_min_uniq=0.01,
-            log=self.log,
         )
         for assembly in assemblies:
             print(assembly.seq, assembly.remap_score())
-        self.assertEqual(2, len(assemblies))
+        assert len(assemblies) == 2
 
     def test_multiple_events(self):
         sequences = {
@@ -341,28 +342,23 @@ class TestAssemble(unittest.TestCase):
             remap_min_exact_match=DEFAULTS['validate.assembly_min_exact_match_to_remap'],
             assembly_max_paths=DEFAULTS['validate.assembly_max_paths'],
             assembly_min_uniq=0.01,
-            log=self.log,
         )
         print('assemblies', len(assemblies))
         for assembly in assemblies:
             print(assembly.seq, assembly.remap_score())
             print(reverse_complement(assembly.seq))
         expected = 'ACCAGGTCTTCGATATATAAAAACCCTAGGTCGGCCGGTCGGCCGTGTTAGTGAGACACACACACACACATGTATACCCGTGCGCGCCCGCGGGAGAGAGAGAGAGAGAGATATATATATAGCAGACCAGGAGAGCGAGAGCGAGAGAGATATAGAGAGATCGCGCGCGAGAGAGATAGGAGACC'
-        self.assertEqual(expected, assemblies[0].seq)
-        self.assertEqual(1, len(assemblies))
+        assert assemblies[0].seq == expected
+        assert len(assemblies) == 1
 
     @timeout_decorator.timeout(300)
-    @unittest.skipIf(
-        not RUN_FULL,
-        'slower tests will not be run unless the environment variable RUN_FULL is given',
-    )
-    def test_large_assembly(self):
+    @long_running_test
+    def test_large_assembly(self, large_assembly_seq):
         # simply testing that this will complete before the timeout
-        sequences = self.large_assembly_seq
         kmer_size = 150 * DEFAULTS['validate.assembly_kmer_size']
         print('read inputs')
         contigs = assemble(
-            sequences,
+            large_assembly_seq,
             kmer_size,
             min_edge_trim_weight=DEFAULTS['validate.assembly_min_edge_trim_weight'],
             assembly_max_paths=DEFAULTS['validate.assembly_max_paths'],
@@ -374,7 +370,7 @@ class TestAssemble(unittest.TestCase):
         for contig in contigs:
             print(len(contig.seq), contig.remap_score())
             print(contig.seq)
-        self.assertTrue(len(contigs))
+        assert len(contigs)
 
     def test_assemble_short_contig(self):
         sequences = {
@@ -626,16 +622,12 @@ class TestAssemble(unittest.TestCase):
         print('target', target)
         for contig in contigs:
             print(len(contig.seq), contig.remap_score(), contig.seq)
-        self.assertTrue({target, reverse_complement(target)} & {c.seq for c in contigs})
+        assert {target, reverse_complement(target)} & {c.seq for c in contigs}
 
     @timeout_decorator.timeout(120)
-    @unittest.skipIf(
-        not RUN_FULL,
-        'slower tests will not be run unless the environment variable RUN_FULL is given',
-    )
-    def test_long_filter_bug(self):
-        sequences = self.long_filter_seq
-        contigs = assemble(sequences, 111, 3, 8, 0.1, 0.1, log=LOG)
+    @long_running_test
+    def test_long_filter_bug(self, long_filter_seq):
+        contigs = assemble(long_filter_seq, 111, 3, 8, 0.1, 0.1, log=LOG)
         for c in contigs:
             print(c.seq, c.remap_score())
-        self.assertTrue(len(contigs))
+        assert len(contigs)

--- a/tests/integration/test_bam.py
+++ b/tests/integration/test_bam.py
@@ -1,9 +1,9 @@
+import argparse
 import logging
-import os
-import unittest
 import warnings
 from unittest import mock
 
+import pytest
 import timeout_decorator
 from mavis.annotate.file_io import load_annotations, load_reference_genome
 from mavis.bam import cigar as _cigar
@@ -16,15 +16,7 @@ from mavis.bam.read import (
     sequenced_strand,
 )
 from mavis.bam.stats import Histogram, compute_genome_bam_stats, compute_transcriptome_bam_stats
-from mavis.constants import (
-    CIGAR,
-    DNA_ALPHABET,
-    NA_MAPPING_QUALITY,
-    ORIENT,
-    READ_PAIR_TYPE,
-    STRAND,
-    SVTYPE,
-)
+from mavis.constants import CIGAR, DNA_ALPHABET, ORIENT, READ_PAIR_TYPE, STRAND, SVTYPE
 from mavis.interval import Interval
 
 from ..util import get_data
@@ -44,23 +36,23 @@ def setUpModule():
         raise AssertionError('fake genome file does not have the expected contents')
 
 
-class TestBamCache(unittest.TestCase):
+class TestBamCache:
     def test___init__(self):
         fh = MockBamFileHandle()
         b = BamCache(fh)
-        self.assertEqual(fh, b.fh)
+        assert b.fh == fh
 
     def test_add_read(self):
         fh = MockBamFileHandle()
         b = BamCache(fh)
         r = mock.MagicMock(query_name='name', query_sequence='')
         b.add_read(r)
-        self.assertEqual(1, len(b.cache.values()))
+        assert len(b.cache.values()) == 1
         b.add_read(r)
-        self.assertEqual(1, len(b.cache.values()))
+        assert len(b.cache.values()) == 1
         r.reference_start = 0
         b.add_read(r)
-        self.assertEqual(1, len(b.cache.values()))
+        assert len(b.cache.values()) == 1
 
     @mock.patch('mavis.util.LOG')
     def test_add_invalid_read(self, log_patcher):
@@ -69,7 +61,7 @@ class TestBamCache(unittest.TestCase):
         )
         cache = BamCache(MockBamFileHandle())
         cache.add_read(bad_read)
-        self.assertEqual(0, len(cache.cache))
+        assert len(cache.cache) == 0
         log_patcher.assert_called_with('ignoring invalid read', 'BAD_READ', level=logging.DEBUG)
 
     @mock.patch('mavis.util.LOG')
@@ -81,7 +73,7 @@ class TestBamCache(unittest.TestCase):
         fh.configure_mock(**{'fetch.return_value': [bad_read]})
         cache = BamCache(fh)
         cache.fetch('chr', 1, 10)
-        self.assertEqual(0, len(cache.cache))
+        assert len(cache.cache) == 0
         log_patcher.assert_called_with('ignoring invalid read', 'BAD_READ', level=logging.DEBUG)
 
     @mock.patch('mavis.util.LOG')
@@ -93,85 +85,88 @@ class TestBamCache(unittest.TestCase):
         fh.configure_mock(**{'fetch.return_value': [bad_read]})
         cache = BamCache(fh)
         cache.fetch_from_bins('chr', 1, 10)
-        self.assertEqual(0, len(cache.cache))
+        assert len(cache.cache) == 0
         log_patcher.assert_called_with('ignoring invalid read', 'BAD_READ', level=logging.DEBUG)
 
     def test_reference_id(self):
         fh = MockBamFileHandle({'1': 0})
         b = BamCache(fh)
-        self.assertEqual(0, b.reference_id('1'))
-        with self.assertRaises(KeyError):
+        assert b.reference_id('1') == 0
+        with pytest.raises(KeyError):
             b.reference_id('2')
 
     def test_get_read_reference_name(self):
         fh = MockBamFileHandle({'1': 0})
         b = BamCache(fh)
         r = MockRead('name', 0)
-        self.assertEqual('1', b.get_read_reference_name(r))
+        assert b.get_read_reference_name(r) == '1'
 
     def test_generate_fetch_bins_single(self):
-        self.assertEqual([(1, 100)], BamCache._generate_fetch_bins(1, 100, 1, 1))
+        assert BamCache._generate_fetch_bins(1, 100, 1, 1) == [(1, 100)]
 
     def test_generate_fetch_bins_multi(self):
-        self.assertEqual([(1, 50), (51, 100)], BamCache._generate_fetch_bins(1, 100, 2, 1))
-        self.assertEqual(
-            [(1, 20), (21, 40), (41, 60), (61, 80), (81, 100)],
-            BamCache._generate_fetch_bins(1, 100, 5, 1),
-        )
+        assert BamCache._generate_fetch_bins(1, 100, 2, 1) == [(1, 50), (51, 100)]
+        assert BamCache._generate_fetch_bins(1, 100, 5, 1) == [
+            (1, 20),
+            (21, 40),
+            (41, 60),
+            (61, 80),
+            (81, 100),
+        ]
 
     def test_generate_fetch_bins_large_min_size(self):
-        self.assertEqual([(1, 50), (51, 100)], BamCache._generate_fetch_bins(1, 100, 5, 50))
+        assert BamCache._generate_fetch_bins(1, 100, 5, 50) == [(1, 50), (51, 100)]
 
     def test_fetch_single_read(self):
         b = BamCache(get_data('mini_mock_reads_for_events.sorted.bam'))
         s = b.fetch_from_bins('reference3', 1382, 1383, read_limit=1, sample_bins=1)
-        self.assertEqual(1, len(s))
+        assert len(s) == 1
         r = list(s)[0]
-        self.assertEqual('HISEQX1_11:4:2122:14275:37717:split', r.qname)
+        assert r.qname == 'HISEQX1_11:4:2122:14275:37717:split'
         b.close()
 
     def test_get_mate(self):
         # dependant on fetch working
         b = BamCache(get_data('mini_mock_reads_for_events.sorted.bam'))
         s = b.fetch_from_bins('reference3', 1382, 1383, read_limit=1, sample_bins=1)
-        self.assertEqual(1, len(s))
+        assert len(s) == 1
         r = list(s)[0]
-        self.assertEqual('HISEQX1_11:4:2122:14275:37717:split', r.qname)
+        assert r.qname == 'HISEQX1_11:4:2122:14275:37717:split'
         o = b.get_mate(r, allow_file_access=True)
-        self.assertEqual(1, len(o))
-        self.assertEqual('HISEQX1_11:4:2122:14275:37717:split', o[0].qname)
+        assert len(o) == 1
+        assert o[0].qname == 'HISEQX1_11:4:2122:14275:37717:split'
 
 
-class TestModule(unittest.TestCase):
+class TestModule:
     """
     test class for functions in the validate namespace
     that are not associated with a class
     """
 
     def test_alphabet_matching(self):
-        self.assertTrue(DNA_ALPHABET.match('N', 'A'))
-        self.assertTrue(DNA_ALPHABET.match('A', 'N'))
+        assert DNA_ALPHABET.match('N', 'A')
+        assert DNA_ALPHABET.match('A', 'N')
 
     def test_breakpoint_pos(self):
         # ==========+++++++++>
         r = MockRead(reference_start=10, cigar=[(CIGAR.M, 10), (CIGAR.S, 10)])
-        self.assertEqual(19, _read.breakpoint_pos(r))
+        assert _read.breakpoint_pos(r) == 19
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             breakpoint_pos(r, ORIENT.RIGHT)
 
-        self.assertEqual(19, _read.breakpoint_pos(r, ORIENT.LEFT))
+        assert _read.breakpoint_pos(r, ORIENT.LEFT) == 19
 
         # ++++++++++=========>
         r = MockRead(reference_start=10, cigar=[(CIGAR.S, 10), (CIGAR.M, 10)])
-        self.assertEqual(10, _read.breakpoint_pos(r))
+        assert _read.breakpoint_pos(r) == 10
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             breakpoint_pos(r, ORIENT.LEFT)
 
-        self.assertEqual(10, _read.breakpoint_pos(r, ORIENT.RIGHT))
+        assert _read.breakpoint_pos(r, ORIENT.RIGHT) == 10
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             r = MockRead(reference_start=10, cigar=[(CIGAR.X, 10), (CIGAR.M, 10)])
             _read.breakpoint_pos(r, ORIENT.LEFT)
 
@@ -188,7 +183,7 @@ class TestModule(unittest.TestCase):
         # GATTCTTTCCTGTTTGGTTCCTGGTCGTGAGTGGCAGGTGCCATCATGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTG
 
 
-class TestNsbAlign(unittest.TestCase):
+class TestNsbAlign:
     def test_length_seq_le_ref(self):
         ref = (
             'GATTCTTTCCTGTTTGGTTCCTGGTCGTGAGTGGCAGGTGCCATCATGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAG'
@@ -199,9 +194,9 @@ class TestNsbAlign(unittest.TestCase):
             'TGCTCTCAGGCAGAATGAAACATGATGGCACCTGCCACTCACGACCAGGAAC'
         )
         alignment = _read.nsb_align(ref, seq)
-        self.assertEqual(1, len(alignment))
+        assert len(alignment) == 1
         alignment = _read.nsb_align(ref, seq, min_consecutive_match=20)
-        self.assertEqual(0, len(alignment))
+        assert len(alignment) == 0
 
     def test_length_ref_le_seq(self):
         pass
@@ -217,17 +212,17 @@ class TestNsbAlign(unittest.TestCase):
             'CGCAGCTACTCAGGAGATCGGAAG'
         )
         alignment = _read.nsb_align(ref, seq, min_consecutive_match=6)
-        self.assertEqual(1, len(alignment))
+        assert len(alignment) == 1
 
     def test_left_softclipping(self):
         ref = 'TAAGCTTCTTCCTTTTTCTATGCCACCTACATAGGCATTTTGCATGGTCAGATTGGAATTTACATAATGCATACATGCAAAGAAATATATAGAAGCCAGATATATAAGGTAGTACATTGGCAGGCTTCATATATATAGACTCCCCCATATTGTCTATATGCTAAAAAAGTATTTTAAATCCTTAAATTTTATTTTTGTTCTCTGCATTTGAAATCTTTATCAACTAGGTCATGAAAATAGCCAGTCGGTTCTCCTTTTGGTCTATTAGAATAAAATCTGGACTGCAACTGAGAAGCAGAAGGTAATGTCAGAATGTAT'
         seq = 'GCTAAAAAAGTATTTTAAATCCTTAAATGTTATTTTTGTTCTC'
         alignments = _read.nsb_align(ref, seq, min_consecutive_match=6)
-        self.assertEqual(1, len(alignments))
+        assert len(alignments) == 1
         print(alignments)
         seq = 'CTTATAAAGCTGGAGTATCTGCTGAGAGCATCAGGAATTGACATCTAGGATAATGAGAGAAGGCTGATCATGGACAACATATAGCCTTTCTAGTAGATGCAGCTGAGGCTAAAAAAGTATTTTAAATCCTTAAATGTTATTTTTGTTCTC'
         alignments = _read.nsb_align(ref, seq, min_consecutive_match=6, min_overlap_percent=0.5)
-        self.assertEqual(1, len(alignments))
+        assert len(alignments) == 1
 
     def test_min_overlap(self):
         ref = 'ATTACATTAAAGATTCAAACTCCTAGAGTTTTTTTGATTTTTAGTATGATCTTTAGATAAAAAAAAAGGAAGAAAAAGAAAAAAAAACAGAGTCTATTAAGGCATCTTCTATGGTCAGATATATCTATTTTTTTCTTTCTTTTTTTTACTTTCATTAAGTGCCACTAAAAAATTAGGTTCAATTAAACTTTATTAATCTCTTCTGAGTTTTGAT'
@@ -240,193 +235,201 @@ class TestNsbAlign(unittest.TestCase):
             min_overlap_percent=(len(seq) - 15) / len(seq),
         )
         print(alignments)
-        self.assertEqual(0, len(alignments))
+        assert len(alignments) == 0
 
 
-class TestReadPairStrand(unittest.TestCase):
-    def setUp(self):
-        self.read1_pos_neg = MockRead(is_reverse=False, is_read1=True, mate_is_reverse=True)
-        assert not self.read1_pos_neg.is_read2
-        self.read1_neg_pos = MockRead(is_reverse=True, is_read1=True, mate_is_reverse=False)
-        self.read1_pos_pos = MockRead(is_reverse=False, is_read1=True, mate_is_reverse=False)
-        self.read1_neg_neg = MockRead(is_reverse=True, is_read1=True, mate_is_reverse=True)
+@pytest.fixture
+def stranded_reads():
+    n = argparse.Namespace()
+    n.read1_pos_neg = MockRead(is_reverse=False, is_read1=True, mate_is_reverse=True)
+    assert not n.read1_pos_neg.is_read2
+    n.read1_neg_pos = MockRead(is_reverse=True, is_read1=True, mate_is_reverse=False)
+    n.read1_pos_pos = MockRead(is_reverse=False, is_read1=True, mate_is_reverse=False)
+    n.read1_neg_neg = MockRead(is_reverse=True, is_read1=True, mate_is_reverse=True)
 
-        self.read2_pos_neg = MockRead(is_reverse=True, is_read1=False, mate_is_reverse=True)
-        assert self.read2_pos_neg.is_read2
-        self.read2_neg_pos = MockRead(is_reverse=False, is_read1=False, mate_is_reverse=False)
-        self.read2_pos_pos = MockRead(is_reverse=False, is_read1=False, mate_is_reverse=False)
-        self.read2_neg_neg = MockRead(is_reverse=True, is_read1=False, mate_is_reverse=True)
+    n.read2_pos_neg = MockRead(is_reverse=True, is_read1=False, mate_is_reverse=True)
+    assert n.read2_pos_neg.is_read2
+    n.read2_neg_pos = MockRead(is_reverse=False, is_read1=False, mate_is_reverse=False)
+    n.read2_pos_pos = MockRead(is_reverse=False, is_read1=False, mate_is_reverse=False)
+    n.read2_neg_neg = MockRead(is_reverse=True, is_read1=False, mate_is_reverse=True)
 
-        self.unpaired_pos = MockRead(is_reverse=False, is_paired=False)
-        self.unpaired_neg = MockRead(is_reverse=True, is_paired=False)
+    n.unpaired_pos = MockRead(is_reverse=False, is_paired=False)
+    n.unpaired_neg = MockRead(is_reverse=True, is_paired=False)
+    return n
 
-    def test_read_pair_strand_det1_read1(self):
-        self.assertEqual(
-            STRAND.POS, sequenced_strand(self.read1_pos_neg, strand_determining_read=1)
-        )
-        self.assertEqual(
-            STRAND.NEG, sequenced_strand(self.read1_neg_pos, strand_determining_read=1)
-        )
-        self.assertEqual(
-            STRAND.POS, sequenced_strand(self.read1_pos_pos, strand_determining_read=1)
-        )
-        self.assertEqual(
-            STRAND.NEG, sequenced_strand(self.read1_neg_neg, strand_determining_read=1)
-        )
 
-    def test_read_pair_strand_det1_read2(self):
-        self.assertEqual(
-            STRAND.POS, sequenced_strand(self.read2_pos_neg, strand_determining_read=1)
+class TestReadPairStrand:
+    def test_read_pair_strand_det1_read1(self, stranded_reads):
+        assert (
+            sequenced_strand(stranded_reads.read1_pos_neg, strand_determining_read=1) == STRAND.POS
         )
-        self.assertEqual(
-            STRAND.NEG, sequenced_strand(self.read2_neg_pos, strand_determining_read=1)
+        assert (
+            sequenced_strand(stranded_reads.read1_neg_pos, strand_determining_read=1) == STRAND.NEG
         )
-        self.assertEqual(
-            STRAND.NEG, sequenced_strand(self.read2_pos_pos, strand_determining_read=1)
+        assert (
+            sequenced_strand(stranded_reads.read1_pos_pos, strand_determining_read=1) == STRAND.POS
         )
-        self.assertEqual(
-            STRAND.POS, sequenced_strand(self.read2_neg_neg, strand_determining_read=1)
+        assert (
+            sequenced_strand(stranded_reads.read1_neg_neg, strand_determining_read=1) == STRAND.NEG
         )
 
-    def test_read_pair_strand_det2_read2(self):
-        self.assertEqual(
-            STRAND.NEG, sequenced_strand(self.read2_pos_neg, strand_determining_read=2)
+    def test_read_pair_strand_det1_read2(self, stranded_reads):
+        assert (
+            sequenced_strand(stranded_reads.read2_pos_neg, strand_determining_read=1) == STRAND.POS
         )
-        self.assertEqual(
-            STRAND.POS, sequenced_strand(self.read2_neg_pos, strand_determining_read=2)
+        assert (
+            sequenced_strand(stranded_reads.read2_neg_pos, strand_determining_read=1) == STRAND.NEG
         )
-        self.assertEqual(
-            STRAND.POS, sequenced_strand(self.read2_pos_pos, strand_determining_read=2)
+        assert (
+            sequenced_strand(stranded_reads.read2_pos_pos, strand_determining_read=1) == STRAND.NEG
         )
-        self.assertEqual(
-            STRAND.NEG, sequenced_strand(self.read2_neg_neg, strand_determining_read=2)
-        )
-
-    def test_read_pair_strand_det2_read1(self):
-        self.assertEqual(
-            STRAND.NEG, sequenced_strand(self.read1_pos_neg, strand_determining_read=2)
-        )
-        self.assertEqual(
-            STRAND.POS, sequenced_strand(self.read1_neg_pos, strand_determining_read=2)
-        )
-        self.assertEqual(
-            STRAND.NEG, sequenced_strand(self.read1_pos_pos, strand_determining_read=2)
-        )
-        self.assertEqual(
-            STRAND.POS, sequenced_strand(self.read1_neg_neg, strand_determining_read=2)
+        assert (
+            sequenced_strand(stranded_reads.read2_neg_neg, strand_determining_read=1) == STRAND.POS
         )
 
-    def test_read_pair_strand_unpaired(self):
-        with self.assertRaises(ValueError):
-            sequenced_strand(self.unpaired_pos)
-        with self.assertRaises(ValueError):
-            sequenced_strand(self.unpaired_neg)
-
-    def test_read_pair_strand_det_error(self):
-        with self.assertRaises(ValueError):
-            sequenced_strand(self.read1_pos_neg, strand_determining_read=3)
-
-
-class TestReadPairType(unittest.TestCase):
-    def setUp(self):
-        self.LR = MockRead(
-            reference_id=0,
-            next_reference_id=0,
-            reference_start=1,
-            next_reference_start=2,
-            is_reverse=False,
-            mate_is_reverse=True,
+    def test_read_pair_strand_det2_read2(self, stranded_reads):
+        assert (
+            sequenced_strand(stranded_reads.read2_pos_neg, strand_determining_read=2) == STRAND.NEG
         )
-        self.LL = MockRead(
-            reference_id=0,
-            next_reference_id=0,
-            reference_start=1,
-            next_reference_start=2,
-            is_reverse=False,
-            mate_is_reverse=False,
+        assert (
+            sequenced_strand(stranded_reads.read2_neg_pos, strand_determining_read=2) == STRAND.POS
         )
-        self.RR = MockRead(
-            reference_id=0,
-            next_reference_id=0,
-            reference_start=1,
-            next_reference_start=2,
-            is_reverse=True,
-            mate_is_reverse=True,
+        assert (
+            sequenced_strand(stranded_reads.read2_pos_pos, strand_determining_read=2) == STRAND.POS
         )
-        self.RL = MockRead(
-            reference_id=0,
-            next_reference_id=0,
-            reference_start=1,
-            next_reference_start=2,
-            is_reverse=True,
-            mate_is_reverse=False,
+        assert (
+            sequenced_strand(stranded_reads.read2_neg_neg, strand_determining_read=2) == STRAND.NEG
         )
 
-    def test_read_pair_type_LR(self):
-        self.assertEqual(READ_PAIR_TYPE.LR, read_pair_type(self.LR))
+    def test_read_pair_strand_det2_read1(self, stranded_reads):
+        assert (
+            sequenced_strand(stranded_reads.read1_pos_neg, strand_determining_read=2) == STRAND.NEG
+        )
+        assert (
+            sequenced_strand(stranded_reads.read1_neg_pos, strand_determining_read=2) == STRAND.POS
+        )
+        assert (
+            sequenced_strand(stranded_reads.read1_pos_pos, strand_determining_read=2) == STRAND.NEG
+        )
+        assert (
+            sequenced_strand(stranded_reads.read1_neg_neg, strand_determining_read=2) == STRAND.POS
+        )
 
-    def test_read_pair_type_LL(self):
-        self.assertEqual(READ_PAIR_TYPE.LL, read_pair_type(self.LL))
+    def test_read_pair_strand_unpaired(self, stranded_reads):
+        with pytest.raises(ValueError):
+            sequenced_strand(stranded_reads.unpaired_pos)
+        with pytest.raises(ValueError):
+            sequenced_strand(stranded_reads.unpaired_neg)
 
-    def test_read_pair_type_RR(self):
-        self.assertEqual(READ_PAIR_TYPE.RR, read_pair_type(self.RR))
-
-    def test_read_pair_type_RL(self):
-        self.assertEqual(READ_PAIR_TYPE.RL, read_pair_type(self.RL))
-
-    def test_orientation_supports_type_deletion(self):
-        self.assertTrue(orientation_supports_type(self.LR, SVTYPE.DEL))
-        self.assertFalse(orientation_supports_type(self.RL, SVTYPE.DEL))
-        self.assertFalse(orientation_supports_type(self.LL, SVTYPE.DEL))
-        self.assertFalse(orientation_supports_type(self.RR, SVTYPE.DEL))
-
-    def test_orientation_supports_type_insertion(self):
-        self.assertTrue(orientation_supports_type(self.LR, SVTYPE.INS))
-        self.assertFalse(orientation_supports_type(self.RL, SVTYPE.INS))
-        self.assertFalse(orientation_supports_type(self.LL, SVTYPE.INS))
-        self.assertFalse(orientation_supports_type(self.RR, SVTYPE.INS))
-
-    def test_orientation_supports_type_inversion(self):
-        self.assertFalse(orientation_supports_type(self.LR, SVTYPE.INV))
-        self.assertFalse(orientation_supports_type(self.RL, SVTYPE.INV))
-        self.assertTrue(orientation_supports_type(self.LL, SVTYPE.INV))
-        self.assertTrue(orientation_supports_type(self.RR, SVTYPE.INV))
-
-    def test_orientation_supports_type_translocation_inversion(self):
-        self.assertFalse(orientation_supports_type(self.LR, SVTYPE.ITRANS))
-        self.assertFalse(orientation_supports_type(self.RL, SVTYPE.ITRANS))
-        self.assertTrue(orientation_supports_type(self.LL, SVTYPE.ITRANS))
-        self.assertTrue(orientation_supports_type(self.RR, SVTYPE.ITRANS))
-
-    def test_orientation_supports_type_trans_duplication(self):
-        self.assertFalse(orientation_supports_type(self.LR, SVTYPE.DUP))
-        self.assertTrue(orientation_supports_type(self.RL, SVTYPE.DUP))
-        self.assertFalse(orientation_supports_type(self.LL, SVTYPE.DUP))
-        self.assertFalse(orientation_supports_type(self.RR, SVTYPE.DUP))
-
-    def test_orientation_supports_type_translocation(self):
-        self.assertTrue(orientation_supports_type(self.LR, SVTYPE.TRANS))
-        self.assertTrue(orientation_supports_type(self.RL, SVTYPE.TRANS))
-        self.assertFalse(orientation_supports_type(self.LL, SVTYPE.TRANS))
-        self.assertFalse(orientation_supports_type(self.RR, SVTYPE.TRANS))
+    def test_read_pair_strand_det_error(self, stranded_reads):
+        with pytest.raises(ValueError):
+            sequenced_strand(stranded_reads.read1_pos_neg, strand_determining_read=3)
 
 
-class TestHistogram(unittest.TestCase):
+@pytest.fixture
+def read_pairs():
+    n = argparse.Namespace()
+    n.LR = MockRead(
+        reference_id=0,
+        next_reference_id=0,
+        reference_start=1,
+        next_reference_start=2,
+        is_reverse=False,
+        mate_is_reverse=True,
+    )
+    n.LL = MockRead(
+        reference_id=0,
+        next_reference_id=0,
+        reference_start=1,
+        next_reference_start=2,
+        is_reverse=False,
+        mate_is_reverse=False,
+    )
+    n.RR = MockRead(
+        reference_id=0,
+        next_reference_id=0,
+        reference_start=1,
+        next_reference_start=2,
+        is_reverse=True,
+        mate_is_reverse=True,
+    )
+    n.RL = MockRead(
+        reference_id=0,
+        next_reference_id=0,
+        reference_start=1,
+        next_reference_start=2,
+        is_reverse=True,
+        mate_is_reverse=False,
+    )
+    return n
+
+
+class TestReadPairType:
+    def test_read_pair_type_LR(self, read_pairs):
+        assert read_pair_type(read_pairs.LR) == READ_PAIR_TYPE.LR
+
+    def test_read_pair_type_LL(self, read_pairs):
+        assert read_pair_type(read_pairs.LL) == READ_PAIR_TYPE.LL
+
+    def test_read_pair_type_RR(self, read_pairs):
+        assert read_pair_type(read_pairs.RR) == READ_PAIR_TYPE.RR
+
+    def test_read_pair_type_RL(self, read_pairs):
+        assert read_pair_type(read_pairs.RL) == READ_PAIR_TYPE.RL
+
+    def test_orientation_supports_type_deletion(self, read_pairs):
+        assert orientation_supports_type(read_pairs.LR, SVTYPE.DEL)
+        assert not orientation_supports_type(read_pairs.RL, SVTYPE.DEL)
+        assert not orientation_supports_type(read_pairs.LL, SVTYPE.DEL)
+        assert not orientation_supports_type(read_pairs.RR, SVTYPE.DEL)
+
+    def test_orientation_supports_type_insertion(self, read_pairs):
+        assert orientation_supports_type(read_pairs.LR, SVTYPE.INS)
+        assert not orientation_supports_type(read_pairs.RL, SVTYPE.INS)
+        assert not orientation_supports_type(read_pairs.LL, SVTYPE.INS)
+        assert not orientation_supports_type(read_pairs.RR, SVTYPE.INS)
+
+    def test_orientation_supports_type_inversion(self, read_pairs):
+        assert not orientation_supports_type(read_pairs.LR, SVTYPE.INV)
+        assert not orientation_supports_type(read_pairs.RL, SVTYPE.INV)
+        assert orientation_supports_type(read_pairs.LL, SVTYPE.INV)
+        assert orientation_supports_type(read_pairs.RR, SVTYPE.INV)
+
+    def test_orientation_supports_type_translocation_inversion(self, read_pairs):
+        assert not orientation_supports_type(read_pairs.LR, SVTYPE.ITRANS)
+        assert not orientation_supports_type(read_pairs.RL, SVTYPE.ITRANS)
+        assert orientation_supports_type(read_pairs.LL, SVTYPE.ITRANS)
+        assert orientation_supports_type(read_pairs.RR, SVTYPE.ITRANS)
+
+    def test_orientation_supports_type_trans_duplication(self, read_pairs):
+        assert not orientation_supports_type(read_pairs.LR, SVTYPE.DUP)
+        assert orientation_supports_type(read_pairs.RL, SVTYPE.DUP)
+        assert not orientation_supports_type(read_pairs.LL, SVTYPE.DUP)
+        assert not orientation_supports_type(read_pairs.RR, SVTYPE.DUP)
+
+    def test_orientation_supports_type_translocation(self, read_pairs):
+        assert orientation_supports_type(read_pairs.LR, SVTYPE.TRANS)
+        assert orientation_supports_type(read_pairs.RL, SVTYPE.TRANS)
+        assert not orientation_supports_type(read_pairs.LL, SVTYPE.TRANS)
+        assert not orientation_supports_type(read_pairs.RR, SVTYPE.TRANS)
+
+
+class TestHistogram:
     def test_add(self):
         h = Histogram()
         h.add(1)
         h.add(1)
-        self.assertEqual(2, h[1])
+        assert h[1] == 2
         h.add(1, 4)
-        self.assertEqual(6, h[1])
+        assert h[1] == 6
 
     def test_median(self):
         h = Histogram()
         for i in range(1, 11):
             h.add(i)
-        self.assertEqual(5.5, h.median())
+        assert h.median() == 5.5
         h.add(11)
-        self.assertEqual(6, h.median())
+        assert h.median() == 6
 
     def test_distib_stderr(self):
         h = Histogram()
@@ -435,9 +438,9 @@ class TestHistogram(unittest.TestCase):
         for i in range(4, 8):
             h.add(i)
         m = h.median()
-        self.assertEqual(5, m)
+        assert m == 5
         err = h.distribution_stderr(m, 1)
-        self.assertEqual(116 / 15, err)
+        assert err == 116 / 15
 
     def test_add_operator(self):
         x = Histogram()
@@ -445,19 +448,19 @@ class TestHistogram(unittest.TestCase):
         x.add(1)
         y.add(1, 4)
         z = x + y
-        self.assertEqual(1, x[1])
-        self.assertEqual(4, y[1])
-        self.assertEqual(5, z[1])
+        assert x[1] == 1
+        assert y[1] == 4
+        assert z[1] == 5
 
 
-class TestBamStats(unittest.TestCase):
+class TestBamStats:
     def test_genome_bam_stats(self):
         bamfh = BamCache(get_data('mock_reads_for_events.sorted.bam'))
         stats = compute_genome_bam_stats(
             bamfh, 1000, 100, min_mapping_quality=1, sample_cap=10000, distribution_fraction=0.99
         )
-        self.assertGreaterEqual(50, abs(stats.median_fragment_size - 420))
-        self.assertEqual(150, stats.read_length)
+        assert 50 >= abs(stats.median_fragment_size - 420)
+        assert stats.read_length == 150
         bamfh.close()
 
     def test_trans_bam_stats(self):
@@ -472,35 +475,37 @@ class TestBamStats(unittest.TestCase):
             sample_cap=10000,
             distribution_fraction=0.99,
         )
-        self.assertTrue(abs(stats.median_fragment_size - 185) < 5)
-        self.assertEqual(75, stats.read_length)
-        self.assertTrue(stats.stdev_fragment_size < 50)
+        assert abs(stats.median_fragment_size - 185) < 5
+        assert stats.read_length == 75
+        assert stats.stdev_fragment_size < 50
         bamfh.close()
 
 
-class TestMapRefRangeToQueryRange(unittest.TestCase):
-    def setUp(self):
-        self.contig_read = MockRead(
-            cigar=_cigar.convert_string_to_cigar('275M18I12041D278M'),
-            reference_start=89700025,
-            reference_name='10',
-        )
+@pytest.fixture
+def contig_read():
+    return MockRead(
+        cigar=_cigar.convert_string_to_cigar('275M18I12041D278M'),
+        reference_start=89700025,
+        reference_name='10',
+    )
 
-    def test_full_aligned_portion(self):
+
+class TestMapRefRangeToQueryRange:
+    def test_full_aligned_portion(self, contig_read):
         ref_range = Interval(89700026, 89712619)
-        qrange = _read.map_ref_range_to_query_range(self.contig_read, ref_range)
-        self.assertEqual(571, len(qrange))
-        self.assertEqual(1, qrange.start)
-        self.assertEqual(571, qrange.end)
+        qrange = _read.map_ref_range_to_query_range(contig_read, ref_range)
+        assert len(qrange) == 571
+        assert qrange.start == 1
+        assert qrange.end == 571
 
-    def test_multiple_events(self):
+    def test_multiple_events(self, contig_read):
         ref_range = Interval(89700067, 89712347)
-        qrange = _read.map_ref_range_to_query_range(self.contig_read, ref_range)
-        self.assertEqual(len(ref_range) - 12041 + 18, len(qrange))
+        qrange = _read.map_ref_range_to_query_range(contig_read, ref_range)
+        assert len(qrange) == len(ref_range) - 12041 + 18
 
-    def test_no_events(self):
+    def test_no_events(self, contig_read):
         ref_range = Interval(89700031, 89700040)
-        qrange = _read.map_ref_range_to_query_range(self.contig_read, ref_range)
-        self.assertEqual(10, len(qrange))
-        self.assertEqual(6, qrange.start)
-        self.assertEqual(15, qrange.end)
+        qrange = _read.map_ref_range_to_query_range(contig_read, ref_range)
+        assert len(qrange) == 10
+        assert qrange.start == 6
+        assert qrange.end == 15

--- a/tests/integration/test_breakpoint.py
+++ b/tests/integration/test_breakpoint.py
@@ -1,14 +1,14 @@
-import unittest
 from functools import partial
 
+import pytest
 from mavis.annotate.file_io import load_reference_genome
 from mavis.breakpoint import Breakpoint, BreakpointPair
-from mavis.constants import CIGAR, ORIENT, STRAND, reverse_complement
+from mavis.constants import ORIENT, STRAND
 from mavis.interval import Interval
 from mavis.validate.evidence import TranscriptomeEvidence
 
 from ..util import get_data
-from . import MockObject, MockRead, get_example_genes
+from . import MockObject, get_example_genes
 
 REFERENCE_GENOME = None
 REF_CHR = 'fake'
@@ -24,55 +24,61 @@ def setUpModule():
         raise AssertionError('fake genome file does not have the expected contents')
 
 
-class TestNetSizeTransEGFR(unittest.TestCase):
-    def setUp(self):
-        self.evidence = MockObject(
-            annotations={},
-            read_length=100,
-            max_expected_fragment_size=550,
-            call_error=11,
-            overlapping_transcripts=set(get_example_genes()['EGFR'].transcripts),
-        )
-        setattr(
-            self.evidence, '_select_transcripts', lambda *pos: self.evidence.overlapping_transcripts
-        )
-        setattr(self.evidence, 'distance', partial(TranscriptomeEvidence.distance, self.evidence))
+@pytest.fixture
+def egfr_evidence():
+    evidence = MockObject(
+        annotations={},
+        read_length=100,
+        max_expected_fragment_size=550,
+        call_error=11,
+        overlapping_transcripts=set(get_example_genes()['EGFR'].transcripts),
+    )
+    setattr(evidence, '_select_transcripts', lambda *pos: evidence.overlapping_transcripts)
+    setattr(evidence, 'distance', partial(TranscriptomeEvidence.distance, evidence))
+    return evidence
 
-    def egfr_distance(self, pos1, pos2):
-        return TranscriptomeEvidence.distance(self.evidence, pos1, pos2)
 
-    def test_deletion_in_exon(self):
+class TestNetSizeTransEGFR:
+    def test_deletion_in_exon(self, egfr_evidence):
         bpp = BreakpointPair(
             Breakpoint('7', 55238890, orient=ORIENT.LEFT),
             Breakpoint('7', 55238899, orient=ORIENT.RIGHT),
             untemplated_seq='',
         )
-        self.assertEqual(Interval(-8), bpp.net_size(self.egfr_distance))
+        assert bpp.net_size(
+            lambda p1, p2: TranscriptomeEvidence.distance(egfr_evidence, p1, p2)
+        ) == Interval(-8)
 
         bpp = BreakpointPair(
             Breakpoint('7', 55238890, orient=ORIENT.LEFT),
             Breakpoint('7', 55238899, orient=ORIENT.RIGHT),
             untemplated_seq='GTAC',
         )
-        self.assertEqual(Interval(-4), bpp.net_size(self.egfr_distance))
+        assert bpp.net_size(
+            lambda p1, p2: TranscriptomeEvidence.distance(egfr_evidence, p1, p2)
+        ) == Interval(-4)
 
-    def test_deletion_across_intron(self):
+    def test_deletion_across_intron(self, egfr_evidence):
         # 55240539_55240621  55323947_55324313
         bpp = BreakpointPair(
             Breakpoint('7', 55240610, orient=ORIENT.LEFT),
             Breakpoint('7', 55323950, orient=ORIENT.RIGHT),
             untemplated_seq='GTAC',
         )
-        self.assertEqual(Interval(-10), bpp.net_size(self.egfr_distance))
+        assert bpp.net_size(
+            lambda p1, p2: TranscriptomeEvidence.distance(egfr_evidence, p1, p2)
+        ) == Interval(-10)
         # 55210998_55211181 55218987_55219055
         bpp = BreakpointPair(
             Breakpoint('7', 55211180, orient=ORIENT.LEFT),
             Breakpoint('7', 55218990, orient=ORIENT.RIGHT),
             untemplated_seq='',
         )
-        self.assertEqual(Interval(-4 + -135, -4), bpp.net_size(self.egfr_distance))
+        assert bpp.net_size(
+            lambda p1, p2: TranscriptomeEvidence.distance(egfr_evidence, p1, p2)
+        ) == Interval(-4 + -135, -4)
 
-    def test_insertion_at_exon_start_mixed(self):
+    def test_insertion_at_exon_start_mixed(self, egfr_evidence):
         # EXON 15: 55232973-55233130
         # EXON 16: 55238868-55238906
         # EXON 17: 55240676-55240817
@@ -81,55 +87,67 @@ class TestNetSizeTransEGFR(unittest.TestCase):
             Breakpoint('7', 55238868, orient=ORIENT.RIGHT),
             untemplated_seq='TTATCG',
         )
-        self.assertEqual(Interval(6), bpp.net_size(self.egfr_distance))
+        assert bpp.net_size(
+            lambda p1, p2: TranscriptomeEvidence.distance(egfr_evidence, p1, p2)
+        ) == Interval(6)
 
-    def test_insertion_at_exon_start(self):
+    def test_insertion_at_exon_start(self, egfr_evidence):
         # 55238868_55238906
         bpp = BreakpointPair(
             Breakpoint('7', 55233130, orient=ORIENT.LEFT),
             Breakpoint('7', 55238868, orient=ORIENT.RIGHT),
             untemplated_seq='TTATCG',
         )
-        self.assertEqual(Interval(6), bpp.net_size(self.egfr_distance))
+        assert bpp.net_size(
+            lambda p1, p2: TranscriptomeEvidence.distance(egfr_evidence, p1, p2)
+        ) == Interval(6)
 
-    def test_insertion_at_exon_end_mixed(self):
+    def test_insertion_at_exon_end_mixed(self, egfr_evidence):
         # 55238868_55238906
         bpp = BreakpointPair(
             Breakpoint('7', 55238905, orient=ORIENT.LEFT),
             Breakpoint('7', 55238906, orient=ORIENT.RIGHT),
             untemplated_seq='TTATCG',
         )
-        self.assertEqual(Interval(6), bpp.net_size(self.egfr_distance))
+        assert bpp.net_size(
+            lambda p1, p2: TranscriptomeEvidence.distance(egfr_evidence, p1, p2)
+        ) == Interval(6)
 
-    def test_insertion_at_exon_end(self):
+    def test_insertion_at_exon_end(self, egfr_evidence):
         # 55238868_55238906
         bpp = BreakpointPair(
             Breakpoint('7', 55238906, orient=ORIENT.LEFT),
             Breakpoint('7', 55240676, orient=ORIENT.RIGHT),
             untemplated_seq='TTATCG',
         )
-        self.assertEqual(Interval(6), bpp.net_size(self.egfr_distance))
+        assert bpp.net_size(
+            lambda p1, p2: TranscriptomeEvidence.distance(egfr_evidence, p1, p2)
+        ) == Interval(6)
 
-    def test_insertion_in_intron(self):
+    def test_insertion_in_intron(self, egfr_evidence):
         # 55238868_55238906
         bpp = BreakpointPair(
             Breakpoint('7', 5523750, orient=ORIENT.LEFT),
             Breakpoint('7', 5523751, orient=ORIENT.RIGHT),
             untemplated_seq='TTATCG',
         )
-        self.assertEqual(Interval(6), bpp.net_size(self.egfr_distance))
+        assert bpp.net_size(
+            lambda p1, p2: TranscriptomeEvidence.distance(egfr_evidence, p1, p2)
+        ) == Interval(6)
 
-    def test_indel_in_intron(self):
+    def test_indel_in_intron(self, egfr_evidence):
         # 55238868_55238906
         bpp = BreakpointPair(
             Breakpoint('7', 5523700, orient=ORIENT.LEFT),
             Breakpoint('7', 5523751, orient=ORIENT.RIGHT),
             untemplated_seq='TTATCG',
         )
-        self.assertEqual(Interval(-44), bpp.net_size(self.egfr_distance))
+        assert bpp.net_size(
+            lambda p1, p2: TranscriptomeEvidence.distance(egfr_evidence, p1, p2)
+        ) == Interval(-44)
 
 
-class TestLt(unittest.TestCase):
+class TestLt:
     def test_break1(self):
         bpp1 = BreakpointPair(
             Breakpoint('1', 1, 10, orient=ORIENT.LEFT),
@@ -141,7 +159,7 @@ class TestLt(unittest.TestCase):
             Breakpoint('2', 1, orient=ORIENT.LEFT),
             untemplated_seq='',
         )
-        self.assertTrue(bpp2 < bpp1)
+        assert bpp2 < bpp1
 
     def test_useq(self):
         bpp1 = BreakpointPair(
@@ -154,7 +172,7 @@ class TestLt(unittest.TestCase):
             Breakpoint('2', 1, orient=ORIENT.LEFT),
             untemplated_seq=None,
         )
-        self.assertTrue(bpp2 > bpp1)
+        assert bpp2 > bpp1
 
     def test_break2(self):
         bpp1 = BreakpointPair(
@@ -167,20 +185,20 @@ class TestLt(unittest.TestCase):
             Breakpoint('2', 1, orient=ORIENT.LEFT),
             untemplated_seq=None,
         )
-        self.assertTrue(bpp2 < bpp1)
+        assert bpp2 < bpp1
 
 
-class TestBreakpointSequenceHomology(unittest.TestCase):
+class TestBreakpointSequenceHomology:
     def test_left_pos_right_pos(self):
         b1 = Breakpoint(REF_CHR, 157, strand=STRAND.POS, orient=ORIENT.LEFT)
         b2 = Breakpoint(REF_CHR, 1788, strand=STRAND.POS, orient=ORIENT.RIGHT)
         bpp = BreakpointPair(b1, b2)
-        self.assertEqual(('CAATGC', ''), bpp.breakpoint_sequence_homology(REFERENCE_GENOME))
+        assert bpp.breakpoint_sequence_homology(REFERENCE_GENOME) == ('CAATGC', '')
 
         b1 = Breakpoint(REF_CHR, 589, strand=STRAND.POS, orient=ORIENT.LEFT)
         b2 = Breakpoint(REF_CHR, 704, strand=STRAND.POS, orient=ORIENT.RIGHT)
         bpp = BreakpointPair(b1, b2)
-        self.assertEqual(('TTAA', 'ATAGC'), bpp.breakpoint_sequence_homology(REFERENCE_GENOME))
+        assert bpp.breakpoint_sequence_homology(REFERENCE_GENOME) == ('TTAA', 'ATAGC')
 
     def test_left_pos_left_neg(self):
         # CCC|AAA ------------ TTT|GGG
@@ -189,7 +207,7 @@ class TestBreakpointSequenceHomology(unittest.TestCase):
         b1 = Breakpoint(REF_CHR, 1459, strand=STRAND.POS, orient=ORIENT.LEFT)
         b2 = Breakpoint(REF_CHR, 2914, strand=STRAND.NEG, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2)
-        self.assertEqual(('CCC', 'TTT'), bpp.breakpoint_sequence_homology(REFERENCE_GENOME))
+        assert bpp.breakpoint_sequence_homology(REFERENCE_GENOME) == ('CCC', 'TTT')
 
     def test_left_neg_left_pos(self):
         # CCC|AAA ------------ TTT|GGG
@@ -198,7 +216,7 @@ class TestBreakpointSequenceHomology(unittest.TestCase):
         b1 = Breakpoint(REF_CHR, 1459, strand=STRAND.NEG, orient=ORIENT.LEFT)
         b2 = Breakpoint(REF_CHR, 2914, strand=STRAND.POS, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2)
-        self.assertEqual(('CCC', 'TTT'), bpp.breakpoint_sequence_homology(REFERENCE_GENOME))
+        assert bpp.breakpoint_sequence_homology(REFERENCE_GENOME) == ('CCC', 'TTT')
 
     def test_right_pos_right_neg(self):
         # CCC|AAA ------------ TTT|GGG
@@ -207,7 +225,7 @@ class TestBreakpointSequenceHomology(unittest.TestCase):
         b1 = Breakpoint(REF_CHR, 1460, strand=STRAND.POS, orient=ORIENT.RIGHT)
         b2 = Breakpoint(REF_CHR, 2915, strand=STRAND.NEG, orient=ORIENT.RIGHT)
         bpp = BreakpointPair(b1, b2)
-        self.assertEqual(('AAA', 'GGG'), bpp.breakpoint_sequence_homology(REFERENCE_GENOME))
+        assert bpp.breakpoint_sequence_homology(REFERENCE_GENOME) == ('AAA', 'GGG')
 
     def test_right_neg_right_pos(self):
         # CCC|AAA ------------ TTT|GGG
@@ -216,14 +234,14 @@ class TestBreakpointSequenceHomology(unittest.TestCase):
         b1 = Breakpoint(REF_CHR, 1460, strand=STRAND.NEG, orient=ORIENT.RIGHT)
         b2 = Breakpoint(REF_CHR, 2915, strand=STRAND.POS, orient=ORIENT.RIGHT)
         bpp = BreakpointPair(b1, b2)
-        self.assertEqual(('AAA', 'GGG'), bpp.breakpoint_sequence_homology(REFERENCE_GENOME))
+        assert bpp.breakpoint_sequence_homology(REFERENCE_GENOME) == ('AAA', 'GGG')
 
     def test_close_del(self):
         # ....TT|TT....
         b1 = Breakpoint(REF_CHR, 1001, strand=STRAND.POS, orient=ORIENT.LEFT)
         b2 = Breakpoint(REF_CHR, 1002, strand=STRAND.POS, orient=ORIENT.RIGHT)
         bpp = BreakpointPair(b1, b2)
-        self.assertEqual(('', ''), bpp.breakpoint_sequence_homology(REFERENCE_GENOME))
+        assert bpp.breakpoint_sequence_homology(REFERENCE_GENOME) == ('', '')
 
     def test_close_dup(self):
         # ....GATACATTTCTTCTTGAAAA...
@@ -234,11 +252,11 @@ class TestBreakpointSequenceHomology(unittest.TestCase):
         b1 = Breakpoint(REF_CHR, 745, strand=STRAND.POS, orient=ORIENT.RIGHT)
         b2 = Breakpoint(REF_CHR, 747, strand=STRAND.POS, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2)
-        self.assertEqual(('CT', 'TT'), bpp.breakpoint_sequence_homology(REFERENCE_GENOME))
+        assert bpp.breakpoint_sequence_homology(REFERENCE_GENOME) == ('CT', 'TT')
 
     def test_non_specific_error(self):
         b1 = Breakpoint(REF_CHR, 740, 745, strand=STRAND.POS, orient=ORIENT.RIGHT)
         b2 = Breakpoint(REF_CHR, 747, strand=STRAND.POS, orient=ORIENT.LEFT)
         bpp = BreakpointPair(b1, b2)
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             bpp.breakpoint_sequence_homology(REFERENCE_GENOME)

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -15,7 +15,7 @@ CLUSTERED_EVENTS = get_data('clustering_input.tab')
 REF_CHR = 'fake'
 
 
-class TestFullClustering(unittest.TestCase):
+class TestFullClustering:
     def test_mocked_events(self):
         # none of the 24 events in the mocked file should cluster together
         # if we change the mock file we may need to update this function
@@ -26,7 +26,7 @@ class TestFullClustering(unittest.TestCase):
             if bpp.data[COLUMNS.protocol] == PROTOCOL.GENOME:
                 bpps.append(bpp)
                 print(bpp)
-        self.assertEqual(28, len(bpps))
+        assert len(bpps) == 28
         clusters = merge_breakpoint_pairs(bpps, 10, 10)
 
         for cluster, input_pairs in sorted(
@@ -35,8 +35,8 @@ class TestFullClustering(unittest.TestCase):
             print(cluster)
             for ip in input_pairs:
                 print('\t', ip)
-            self.assertEqual(1, len(input_pairs))
-        self.assertEqual(len(bpps), len(clusters))
+            assert len(input_pairs) == 1
+        assert len(clusters) == len(bpps)
 
     def test_clustering_events(self):
         # this file contains 2 events that should be clustered and produce a valid bpp
@@ -47,10 +47,10 @@ class TestFullClustering(unittest.TestCase):
             if bpp.data[COLUMNS.protocol] == PROTOCOL.GENOME:
                 bpps.append(bpp)
                 print(bpp)
-        self.assertEqual(2, len(bpps))
+        assert len(bpps) == 2
         clusters = merge_breakpoint_pairs(bpps, 200, 25)
 
-        self.assertEqual(1, len(clusters))
+        assert len(clusters) == 1
 
         for cluster, input_pairs in sorted(
             clusters.items(), key=lambda x: (x[1][0].break1.chr, x[1][0].break2.chr)
@@ -60,17 +60,17 @@ class TestFullClustering(unittest.TestCase):
                 print('\t', ip)
             print(cluster.flatten())
             # BPP(Breakpoint(15:67333604L), Breakpoint(15:67333606R), opposing=False)
-            self.assertEqual('L', cluster.break1.orient)
-            self.assertEqual('R', cluster.break2.orient)
-            self.assertEqual('15', cluster.break1.chr)
-            self.assertEqual('15', cluster.break2.chr)
-            self.assertEqual(67333604, cluster.break1.start)
-            self.assertEqual(67333606, cluster.break2.start)
-            self.assertEqual(67333604, cluster.break1.end)
-            self.assertEqual(67333606, cluster.break2.end)
+            assert cluster.break1.orient == 'L'
+            assert cluster.break2.orient == 'R'
+            assert cluster.break1.chr == '15'
+            assert cluster.break2.chr == '15'
+            assert cluster.break1.start == 67333604
+            assert cluster.break2.start == 67333606
+            assert cluster.break1.end == 67333604
+            assert cluster.break2.end == 67333606
 
 
-class TestMergeBreakpointPairs(unittest.TestCase):
+class TestMergeBreakpointPairs:
     def test_order_is_retained(self):
         # BPP(Breakpoint(1:1925143-1925155R), Breakpoint(1:1925144L), opposing=False)
         # >>  BPP(Breakpoint(1:1925144L), Breakpoint(1:1925144-1925158R), opposing=False)
@@ -93,10 +93,10 @@ class TestMergeBreakpointPairs(unittest.TestCase):
         for merge, inputs in mapping.items():
             print(merge)
             print(inputs)
-        self.assertEqual(1, len(mapping))
+        assert len(mapping) == 1
         merge = list(mapping)[0]
-        self.assertEqual('L', merge.break1.orient)
-        self.assertEqual('R', merge.break2.orient)
+        assert merge.break1.orient == 'L'
+        assert merge.break2.orient == 'R'
 
     def test_merging_identical_large_inputs(self):
         b1 = BreakpointPair(
@@ -110,17 +110,17 @@ class TestMergeBreakpointPairs(unittest.TestCase):
             opposing_strands=False,
         )
         mapping = merge_breakpoint_pairs([b1, b2], 100, 25, verbose=True)
-        self.assertEqual(1, len(mapping))
+        assert len(mapping) == 1
         merge = list(mapping)[0]
-        self.assertEqual(2, len(mapping[merge]))
-        self.assertEqual('L', merge.break1.orient)
-        self.assertEqual('R', merge.break2.orient)
-        self.assertEqual('11', merge.break1.chr)
-        self.assertEqual('11', merge.break2.chr)
-        self.assertEqual(12856838, merge.break1.start)
-        self.assertEqual(12856840, merge.break2.start)  # putative indel will be shifted
-        self.assertEqual(12897006, merge.break1.end)
-        self.assertEqual(12897006, merge.break2.end)
+        assert len(mapping[merge]) == 2
+        assert merge.break1.orient == 'L'
+        assert merge.break2.orient == 'R'
+        assert merge.break1.chr == '11'
+        assert merge.break2.chr == '11'
+        assert merge.break1.start == 12856838
+        assert merge.break2.start == 12856840  # putative indel will be shifted
+        assert merge.break1.end == 12897006
+        assert merge.break2.end == 12897006
 
     def test_events_separate(self):
         bpps = [
@@ -150,28 +150,28 @@ class TestMergeBreakpointPairs(unittest.TestCase):
             ),
         ]
         mapping = merge_breakpoint_pairs(bpps, 100, 25, verbose=True)
-        self.assertEqual(2, len(mapping))
+        assert len(mapping) == 2
 
 
-class TestMergeIntervals(unittest.TestCase):
+class TestMergeIntervals:
     def test_merge_even_length(self):
         i1 = Interval(1001, 1002)
         result = merge_integer_intervals(i1, i1, weight_adjustment=25)
-        self.assertEqual(i1, result)
+        assert result == i1
 
     def test_merge_odd_length(self):
         i1 = Interval(1001, 1003)
         result = merge_integer_intervals(i1, i1, weight_adjustment=25)
-        self.assertEqual(i1, result)
+        assert result == i1
 
     def test_merge_large_length(self):
         i1 = Interval(1001, 5003)
         result = merge_integer_intervals(i1, i1, weight_adjustment=25)
-        self.assertEqual(i1, result)
+        assert result == i1
 
         i1 = Interval(12856838, 12897006)
         result = merge_integer_intervals(i1, i1, weight_adjustment=25)
-        self.assertEqual(i1, result)
+        assert result == i1
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_pairing.py
+++ b/tests/integration/test_pairing.py
@@ -1,101 +1,130 @@
 import unittest
 
+import pytest
 from mavis.annotate.genomic import PreTranscript
 from mavis.breakpoint import Breakpoint, BreakpointPair
 from mavis.constants import CALL_METHOD, COLUMNS, ORIENT, PROTOCOL, STRAND, SVTYPE
 from mavis.pairing import pairing
 
 
-class TestPairing(unittest.TestCase):
-    def setUp(self):
-        self.gev1 = BreakpointPair(
-            Breakpoint('1', 1),
-            Breakpoint('1', 10),
-            opposing_strands=True,
-            **{
-                COLUMNS.event_type: SVTYPE.DEL,
-                COLUMNS.call_method: CALL_METHOD.CONTIG,
-                COLUMNS.fusion_sequence_fasta_id: None,
-                COLUMNS.protocol: PROTOCOL.GENOME,
-            },
-        )
-        self.gev2 = BreakpointPair(
-            Breakpoint('1', 1),
-            Breakpoint('1', 10),
-            opposing_strands=True,
-            **{
-                COLUMNS.event_type: SVTYPE.DEL,
-                COLUMNS.call_method: CALL_METHOD.CONTIG,
-                COLUMNS.fusion_sequence_fasta_id: None,
-                COLUMNS.protocol: PROTOCOL.GENOME,
-            },
-        )
+@pytest.fixture
+def genomic_event1():
+    return BreakpointPair(
+        Breakpoint('1', 1),
+        Breakpoint('1', 10),
+        opposing_strands=True,
+        **{
+            COLUMNS.event_type: SVTYPE.DEL,
+            COLUMNS.call_method: CALL_METHOD.CONTIG,
+            COLUMNS.fusion_sequence_fasta_id: None,
+            COLUMNS.protocol: PROTOCOL.GENOME,
+        },
+    )
 
-        self.ust1 = PreTranscript(
-            exons=[(1, 100), (301, 400), (501, 600)], strand=STRAND.POS, name='t1'
-        )
-        self.ust2 = PreTranscript(
-            exons=[(1001, 1100), (1301, 1400), (1501, 1600)], strand=STRAND.POS, name='t2'
-        )
-        self.distances = {CALL_METHOD.CONTIG: 0, CALL_METHOD.FLANK: 0, CALL_METHOD.SPLIT: 10}
-        self.TRANSCRIPTS = {self.ust1.name: self.ust1, self.ust2.name: self.ust2}
 
-    def test_genome_protocol_diff_chrom(self):
-        self.gev2.break1.chr = '2'
-        self.assertFalse(pairing.equivalent(self.gev1, self.gev2, self.TRANSCRIPTS))
+@pytest.fixture
+def genomic_event2():
+    return BreakpointPair(
+        Breakpoint('1', 1),
+        Breakpoint('1', 10),
+        opposing_strands=True,
+        **{
+            COLUMNS.event_type: SVTYPE.DEL,
+            COLUMNS.call_method: CALL_METHOD.CONTIG,
+            COLUMNS.fusion_sequence_fasta_id: None,
+            COLUMNS.protocol: PROTOCOL.GENOME,
+        },
+    )
 
-    def test_genome_protocol_diff_orient(self):
-        self.gev2.break1.orient = ORIENT.LEFT
-        self.gev1.break1.orient = ORIENT.RIGHT
-        self.assertFalse(pairing.equivalent(self.gev1, self.gev2, self.TRANSCRIPTS))
 
-    def test_genome_protocol_diff_strand(self):
-        self.gev2.break1.strand = STRAND.POS
-        self.gev1.break1.strand = STRAND.NEG
-        self.assertFalse(pairing.equivalent(self.gev1, self.gev2, self.TRANSCRIPTS))
+@pytest.fixture
+def unspliced_transcript1():
+    return PreTranscript(exons=[(1, 100), (301, 400), (501, 600)], strand=STRAND.POS, name='t1')
 
-    def test_genome_protocol_diff_event_type(self):
-        self.gev2.data[COLUMNS.event_type] = SVTYPE.DEL
-        self.gev1.data[COLUMNS.event_type] = SVTYPE.INS
-        self.assertFalse(pairing.equivalent(self.gev1, self.gev2, self.TRANSCRIPTS))
 
-    def test_genome_protocol_ns_orient(self):
-        self.gev2.break1.orient = ORIENT.LEFT
-        self.gev1.break2.orient = ORIENT.RIGHT
-        self.assertTrue(pairing.equivalent(self.gev1, self.gev2, self.TRANSCRIPTS))
+@pytest.fixture
+def unspliced_transcript2():
+    return PreTranscript(
+        exons=[(1001, 1100), (1301, 1400), (1501, 1600)], strand=STRAND.POS, name='t2'
+    )
 
-    def test_genome_protocol_by_contig(self):
-        self.gev1.call_method = CALL_METHOD.CONTIG
-        self.gev2.call_method = CALL_METHOD.CONTIG
-        self.distances[CALL_METHOD.CONTIG] = 0
-        self.distances[CALL_METHOD.SPLIT] = 10
-        self.assertTrue(pairing.equivalent(self.gev1, self.gev2, distances=self.distances))
 
-        self.gev1.break1.start = 2
-        self.gev1.break1.end = 20
-        self.assertFalse(pairing.equivalent(self.gev1, self.gev2, distances=self.distances))
+@pytest.fixture
+def transcripts(unspliced_transcript1, unspliced_transcript2):
+    return {
+        unspliced_transcript1.name: unspliced_transcript1,
+        unspliced_transcript2.name: unspliced_transcript2,
+    }
 
-    def test_genome_protocol_by_split(self):
-        self.gev1.call_method = CALL_METHOD.SPLIT
-        self.gev2.call_method = CALL_METHOD.SPLIT
-        self.assertTrue(pairing.equivalent(self.gev1, self.gev2, distances=self.distances))
-        self.distances[CALL_METHOD.FLANK] = 100
-        self.distances[CALL_METHOD.SPLIT] = 10
-        self.gev1.break1.start = 11
-        self.gev1.break1.end = 20
-        self.assertFalse(pairing.equivalent(self.gev1, self.gev2, distances=self.distances))
 
-    def test_genome_protocol_by_flanking(self):
-        self.gev1.call_method = CALL_METHOD.FLANK
-        self.gev2.call_method = CALL_METHOD.FLANK
-        self.assertTrue(pairing.equivalent(self.gev1, self.gev2, distances=self.distances))
-        self.distances[CALL_METHOD.FLANK] = 10
-        self.distances[CALL_METHOD.SPLIT] = 100
-        self.gev1.break1.start = 11
-        self.gev1.break1.end = 20
-        self.assertFalse(pairing.equivalent(self.gev1, self.gev2, distances=self.distances))
+@pytest.fixture
+def distances():
+    return {CALL_METHOD.CONTIG: 0, CALL_METHOD.FLANK: 0, CALL_METHOD.SPLIT: 10}
 
-    def test_mixed_protocol_fusions_same_sequence(self):
+
+class TestPairing:
+    def test_genome_protocol_diff_chrom(self, genomic_event1, genomic_event2, transcripts):
+        genomic_event2.break1.chr = '2'
+        assert not pairing.equivalent(genomic_event1, genomic_event2, transcripts)
+
+    def test_genome_protocol_diff_orient(self, genomic_event1, genomic_event2, transcripts):
+        genomic_event2.break1.orient = ORIENT.LEFT
+        genomic_event1.break1.orient = ORIENT.RIGHT
+        assert not pairing.equivalent(genomic_event1, genomic_event2, transcripts)
+
+    def test_genome_protocol_diff_strand(self, genomic_event1, genomic_event2, transcripts):
+        genomic_event2.break1.strand = STRAND.POS
+        genomic_event1.break1.strand = STRAND.NEG
+        assert not pairing.equivalent(genomic_event1, genomic_event2, transcripts)
+
+    def test_genome_protocol_diff_event_type(self, genomic_event1, genomic_event2, transcripts):
+        genomic_event2.data[COLUMNS.event_type] = SVTYPE.DEL
+        genomic_event1.data[COLUMNS.event_type] = SVTYPE.INS
+        assert not pairing.equivalent(genomic_event1, genomic_event2, transcripts)
+
+    def test_genome_protocol_ns_orient(self, genomic_event1, genomic_event2, transcripts):
+        genomic_event2.break1.orient = ORIENT.LEFT
+        genomic_event1.break2.orient = ORIENT.RIGHT
+        assert pairing.equivalent(genomic_event1, genomic_event2, transcripts)
+
+    def test_genome_protocol_by_contig(
+        self, genomic_event1, genomic_event2, transcripts, distances
+    ):
+        genomic_event1.call_method = CALL_METHOD.CONTIG
+        genomic_event2.call_method = CALL_METHOD.CONTIG
+        distances[CALL_METHOD.CONTIG] = 0
+        distances[CALL_METHOD.SPLIT] = 10
+        assert pairing.equivalent(genomic_event1, genomic_event2, distances=distances)
+
+        genomic_event1.break1.start = 2
+        genomic_event1.break1.end = 20
+        assert not pairing.equivalent(genomic_event1, genomic_event2, distances=distances)
+
+    def test_genome_protocol_by_split(self, genomic_event1, genomic_event2, transcripts, distances):
+        genomic_event1.call_method = CALL_METHOD.SPLIT
+        genomic_event2.call_method = CALL_METHOD.SPLIT
+        assert pairing.equivalent(genomic_event1, genomic_event2, distances=distances)
+        distances[CALL_METHOD.FLANK] = 100
+        distances[CALL_METHOD.SPLIT] = 10
+        genomic_event1.break1.start = 11
+        genomic_event1.break1.end = 20
+        assert not pairing.equivalent(genomic_event1, genomic_event2, distances=distances)
+
+    def test_genome_protocol_by_flanking(
+        self, genomic_event1, genomic_event2, transcripts, distances
+    ):
+        genomic_event1.call_method = CALL_METHOD.FLANK
+        genomic_event2.call_method = CALL_METHOD.FLANK
+        assert pairing.equivalent(genomic_event1, genomic_event2, distances=distances)
+        distances[CALL_METHOD.FLANK] = 10
+        distances[CALL_METHOD.SPLIT] = 100
+        genomic_event1.break1.start = 11
+        genomic_event1.break1.end = 20
+        assert not pairing.equivalent(genomic_event1, genomic_event2, distances=distances)
+
+    def test_mixed_protocol_fusions_same_sequence(
+        self, genomic_event1, genomic_event2, transcripts
+    ):
         genome_ev = BreakpointPair(
             Breakpoint('1', 1),
             Breakpoint('1', 10),
@@ -126,12 +155,14 @@ class TestPairing(unittest.TestCase):
                 COLUMNS.fusion_cdna_coding_end: 10,
             },
         )
-        self.assertFalse(pairing.equivalent(genome_ev, trans_ev, self.TRANSCRIPTS))
+        assert not pairing.equivalent(genome_ev, trans_ev, transcripts)
         genome_ev.data[COLUMNS.fusion_sequence_fasta_id] = 'a'
         trans_ev.data[COLUMNS.fusion_sequence_fasta_id] = 'a'
-        self.assertTrue(pairing.inferred_equivalent(genome_ev, trans_ev, self.TRANSCRIPTS))
+        assert pairing.inferred_equivalent(genome_ev, trans_ev, transcripts)
 
-    def test_mixed_protocol_fusions_same_sequence_diff_translation(self):
+    def test_mixed_protocol_fusions_same_sequence_diff_translation(
+        self, genomic_event1, genomic_event2, transcripts
+    ):
         genome_ev = BreakpointPair(
             Breakpoint('1', 1),
             Breakpoint('1', 10),
@@ -162,9 +193,11 @@ class TestPairing(unittest.TestCase):
                 COLUMNS.fusion_cdna_coding_end: 50,
             },
         )
-        self.assertFalse(pairing.inferred_equivalent(genome_ev, trans_ev, self.TRANSCRIPTS))
+        assert not pairing.inferred_equivalent(genome_ev, trans_ev, transcripts)
 
-    def test_mixed_protocol_fusions_different_sequence(self):
+    def test_mixed_protocol_fusions_different_sequence(
+        self, genomic_event1, genomic_event2, transcripts
+    ):
         genome_ev = BreakpointPair(
             Breakpoint('1', 1),
             Breakpoint('1', 10),
@@ -195,9 +228,11 @@ class TestPairing(unittest.TestCase):
                 COLUMNS.fusion_cdna_coding_end: 10,
             },
         )
-        self.assertFalse(pairing.inferred_equivalent(genome_ev, trans_ev, self.TRANSCRIPTS))
+        assert not pairing.inferred_equivalent(genome_ev, trans_ev, transcripts)
 
-    def test_mixed_protocol_one_predicted_one_match(self):
+    def test_mixed_protocol_one_predicted_one_match(
+        self, genomic_event1, genomic_event2, transcripts, unspliced_transcript1
+    ):
         genome_ev = BreakpointPair(
             Breakpoint('1', 350, orient=ORIENT.LEFT),
             Breakpoint('1', 400, orient=ORIENT.RIGHT),
@@ -207,7 +242,7 @@ class TestPairing(unittest.TestCase):
                 COLUMNS.call_method: CALL_METHOD.CONTIG,
                 COLUMNS.fusion_sequence_fasta_id: None,
                 COLUMNS.protocol: PROTOCOL.GENOME,
-                COLUMNS.transcript1: self.ust1.name,
+                COLUMNS.transcript1: unspliced_transcript1.name,
                 COLUMNS.transcript2: None,
             },
         )
@@ -220,21 +255,23 @@ class TestPairing(unittest.TestCase):
                 COLUMNS.call_method: CALL_METHOD.CONTIG,
                 COLUMNS.fusion_sequence_fasta_id: None,
                 COLUMNS.protocol: PROTOCOL.TRANS,
-                COLUMNS.transcript1: self.ust1.name,
+                COLUMNS.transcript1: unspliced_transcript1.name,
                 COLUMNS.transcript2: None,
             },
         )
-        self.assertTrue(pairing.equivalent(genome_ev, trans_ev, self.TRANSCRIPTS))
-        self.assertTrue(pairing.equivalent(trans_ev, genome_ev, self.TRANSCRIPTS))
+        assert pairing.equivalent(genome_ev, trans_ev, transcripts)
+        assert pairing.equivalent(trans_ev, genome_ev, transcripts)
 
-        genome_ev.data[COLUMNS.transcript2] = self.ust1.name
+        genome_ev.data[COLUMNS.transcript2] = unspliced_transcript1.name
         genome_ev.data[COLUMNS.transcript1] = None
-        trans_ev.data[COLUMNS.transcript2] = self.ust1.name
+        trans_ev.data[COLUMNS.transcript2] = unspliced_transcript1.name
         trans_ev.data[COLUMNS.transcript1] = None
-        self.assertTrue(pairing.inferred_equivalent(genome_ev, trans_ev, self.TRANSCRIPTS))
-        self.assertTrue(pairing.inferred_equivalent(trans_ev, genome_ev, self.TRANSCRIPTS))
+        assert pairing.inferred_equivalent(genome_ev, trans_ev, transcripts)
+        assert pairing.inferred_equivalent(trans_ev, genome_ev, transcripts)
 
-    def test_mixed_protocol_one_predicted_one_mismatch(self):
+    def test_mixed_protocol_one_predicted_one_mismatch(
+        self, genomic_event1, genomic_event2, transcripts, unspliced_transcript1
+    ):
         genome_ev = BreakpointPair(
             Breakpoint('1', 350, orient=ORIENT.LEFT),
             Breakpoint('1', 400, orient=ORIENT.RIGHT),
@@ -244,7 +281,7 @@ class TestPairing(unittest.TestCase):
                 COLUMNS.call_method: CALL_METHOD.CONTIG,
                 COLUMNS.fusion_sequence_fasta_id: None,
                 COLUMNS.protocol: PROTOCOL.GENOME,
-                COLUMNS.transcript1: self.ust1.name,
+                COLUMNS.transcript1: unspliced_transcript1.name,
                 COLUMNS.transcript2: None,
             },
         )
@@ -257,19 +294,19 @@ class TestPairing(unittest.TestCase):
                 COLUMNS.call_method: CALL_METHOD.CONTIG,
                 COLUMNS.fusion_sequence_fasta_id: None,
                 COLUMNS.protocol: PROTOCOL.TRANS,
-                COLUMNS.transcript1: self.ust1.name,
+                COLUMNS.transcript1: unspliced_transcript1.name,
                 COLUMNS.transcript2: None,
             },
         )
-        self.assertTrue(pairing.equivalent(genome_ev, trans_ev, self.TRANSCRIPTS))
-        self.assertTrue(pairing.equivalent(trans_ev, genome_ev, self.TRANSCRIPTS))
+        assert pairing.equivalent(genome_ev, trans_ev, transcripts)
+        assert pairing.equivalent(trans_ev, genome_ev, transcripts)
 
-        genome_ev.data[COLUMNS.transcript2] = self.ust1.name
+        genome_ev.data[COLUMNS.transcript2] = unspliced_transcript1.name
         genome_ev.data[COLUMNS.transcript1] = None
-        trans_ev.data[COLUMNS.transcript2] = self.ust1.name
+        trans_ev.data[COLUMNS.transcript2] = unspliced_transcript1.name
         trans_ev.data[COLUMNS.transcript1] = None
-        self.assertTrue(pairing.inferred_equivalent(genome_ev, trans_ev, self.TRANSCRIPTS))
-        self.assertTrue(pairing.inferred_equivalent(trans_ev, genome_ev, self.TRANSCRIPTS))
+        assert pairing.inferred_equivalent(genome_ev, trans_ev, transcripts)
+        assert pairing.inferred_equivalent(trans_ev, genome_ev, transcripts)
 
     def test_mixed_protocol_both_predicted(self):
 
@@ -288,101 +325,107 @@ class TestPairing(unittest.TestCase):
         raise unittest.SkipTest('TODO')
 
 
-class TestBreakpointPrediction(unittest.TestCase):
-    def setUp(self):
-        self.pre_transcript = PreTranscript([(101, 200), (301, 400), (501, 600)], strand=STRAND.POS)
-        self.n_ust = PreTranscript([(101, 200), (301, 400), (501, 600)], strand=STRAND.NEG)
+@pytest.fixture
+def positive_transcript():
+    return PreTranscript([(101, 200), (301, 400), (501, 600)], strand=STRAND.POS)
 
-    def test_exonic_five_prime(self):
+
+@pytest.fixture
+def negative_transcript():
+    return PreTranscript([(101, 200), (301, 400), (501, 600)], strand=STRAND.NEG)
+
+
+class TestBreakpointPrediction:
+    def test_exonic_five_prime(self, positive_transcript):
         b = Breakpoint('1', 350, orient=ORIENT.LEFT)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.pre_transcript)
-        self.assertEqual(2, len(breaks))
-        self.assertEqual(200, breaks[0].start)
-        self.assertEqual(b, breaks[1])
+        breaks = pairing.predict_transcriptome_breakpoint(b, positive_transcript)
+        assert len(breaks) == 2
+        assert breaks[0].start == 200
+        assert breaks[1] == b
 
-    def test_exonic_five_prime_first_exon(self):
+    def test_exonic_five_prime_first_exon(self, positive_transcript):
         b = Breakpoint('1', 150, orient=ORIENT.LEFT)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.pre_transcript)
-        self.assertEqual(1, len(breaks))
-        self.assertEqual(b, breaks[0])
+        breaks = pairing.predict_transcriptome_breakpoint(b, positive_transcript)
+        assert len(breaks) == 1
+        assert breaks[0] == b
 
-    def test_exonic_three_prime(self):
+    def test_exonic_three_prime(self, positive_transcript):
         b = Breakpoint('1', 350, orient=ORIENT.RIGHT)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.pre_transcript)
-        self.assertEqual(2, len(breaks))
-        self.assertEqual(501, breaks[1].start)
-        self.assertEqual(b, breaks[0])
+        breaks = pairing.predict_transcriptome_breakpoint(b, positive_transcript)
+        assert len(breaks) == 2
+        assert breaks[1].start == 501
+        assert breaks[0] == b
 
-    def test_exonic_three_prime_last_exon(self):
+    def test_exonic_three_prime_last_exon(self, positive_transcript):
         b = Breakpoint('1', 550, orient=ORIENT.RIGHT)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.pre_transcript)
-        self.assertEqual(1, len(breaks))
-        self.assertEqual(b, breaks[0])
+        breaks = pairing.predict_transcriptome_breakpoint(b, positive_transcript)
+        assert len(breaks) == 1
+        assert breaks[0] == b
 
-    def test_intronic_five_prime(self):
+    def test_intronic_five_prime(self, positive_transcript):
         b = Breakpoint('1', 450, orient=ORIENT.LEFT)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.pre_transcript)
-        self.assertEqual(1, len(breaks))
-        self.assertEqual(400, breaks[0].start)
+        breaks = pairing.predict_transcriptome_breakpoint(b, positive_transcript)
+        assert len(breaks) == 1
+        assert breaks[0].start == 400
 
-    def test_intronic_three_prime(self):
+    def test_intronic_three_prime(self, positive_transcript):
         b = Breakpoint('1', 250, orient=ORIENT.RIGHT)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.pre_transcript)
-        self.assertEqual(1, len(breaks))
-        self.assertEqual(301, breaks[0].start)
+        breaks = pairing.predict_transcriptome_breakpoint(b, positive_transcript)
+        assert len(breaks) == 1
+        assert breaks[0].start == 301
 
-    def test_outside_transcript(self):
+    def test_outside_transcript(self, positive_transcript):
         b = Breakpoint('1', 100, orient=ORIENT.RIGHT)
-        with self.assertRaises(AssertionError):
-            pairing.predict_transcriptome_breakpoint(b, self.pre_transcript)
+        with pytest.raises(AssertionError):
+            pairing.predict_transcriptome_breakpoint(b, positive_transcript)
 
     # for neg transcripts
-    def test_exonic_three_prime_neg(self):
+    def test_exonic_three_prime_neg(self, negative_transcript):
         b = Breakpoint('1', 350, orient=ORIENT.LEFT, strand=STRAND.NEG)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.n_ust)
-        self.assertEqual(2, len(breaks))
-        self.assertEqual(200, breaks[0].start)
-        self.assertEqual(b, breaks[1])
+        breaks = pairing.predict_transcriptome_breakpoint(b, negative_transcript)
+        assert len(breaks) == 2
+        assert breaks[0].start == 200
+        assert breaks[1] == b
 
-    def test_intronic_three_prime_neg(self):
+    def test_intronic_three_prime_neg(self, negative_transcript):
         b = Breakpoint('1', 450, orient=ORIENT.LEFT, strand=STRAND.NEG)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.n_ust)
-        self.assertEqual(1, len(breaks))
-        self.assertEqual(400, breaks[0].start)
+        breaks = pairing.predict_transcriptome_breakpoint(b, negative_transcript)
+        assert len(breaks) == 1
+        assert breaks[0].start == 400
 
-    def test_exonic_five_prime_neg_first_exon(self):
+    def test_exonic_five_prime_neg_first_exon(self, negative_transcript):
         b = Breakpoint('1', 150, orient=ORIENT.LEFT)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.n_ust)
-        self.assertEqual(1, len(breaks))
-        self.assertEqual(b, breaks[0])
+        breaks = pairing.predict_transcriptome_breakpoint(b, negative_transcript)
+        assert len(breaks) == 1
+        assert breaks[0] == b
 
-    def test_exonic_three_prime_neg_first_exon(self):
+    def test_exonic_three_prime_neg_first_exon(self, negative_transcript):
         b = Breakpoint('1', 150, orient=ORIENT.LEFT)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.n_ust)
-        self.assertEqual(1, len(breaks))
-        self.assertEqual(b, breaks[0])
+        breaks = pairing.predict_transcriptome_breakpoint(b, negative_transcript)
+        assert len(breaks) == 1
+        assert breaks[0] == b
 
-    def test_exonic_five_prime_neg(self):
+    def test_exonic_five_prime_neg(self, negative_transcript):
         b = Breakpoint('1', 350, orient=ORIENT.RIGHT)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.n_ust)
-        self.assertEqual(2, len(breaks))
-        self.assertEqual(501, breaks[1].start)
-        self.assertEqual(b, breaks[0])
+        breaks = pairing.predict_transcriptome_breakpoint(b, negative_transcript)
+        assert len(breaks) == 2
+        assert breaks[1].start == 501
+        assert breaks[0] == b
 
-    def test_exonic_five_prime_neg_last_exon(self):
+    def test_exonic_five_prime_neg_last_exon(self, negative_transcript):
         b = Breakpoint('1', 550, orient=ORIENT.RIGHT)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.n_ust)
-        self.assertEqual(1, len(breaks))
-        self.assertEqual(b, breaks[0])
+        breaks = pairing.predict_transcriptome_breakpoint(b, negative_transcript)
+        assert len(breaks) == 1
+        assert breaks[0] == b
 
-    def test_intronic_five_prime_neg(self):
+    def test_intronic_five_prime_neg(self, negative_transcript):
         b = Breakpoint('1', 250, orient=ORIENT.RIGHT)
-        breaks = pairing.predict_transcriptome_breakpoint(b, self.n_ust)
-        self.assertEqual(1, len(breaks))
-        self.assertEqual(301, breaks[0].start)
+        breaks = pairing.predict_transcriptome_breakpoint(b, negative_transcript)
+        assert len(breaks) == 1
+        assert breaks[0].start == 301
 
 
-class TestEquivalent(unittest.TestCase):
+class TestEquivalent:
     def test_useq_uncertainty(self):
         event1 = BreakpointPair(
             Breakpoint('1', 157540650, orient='L'),
@@ -397,7 +440,7 @@ class TestEquivalent(unittest.TestCase):
             event_type='deletion',
             call_method='spanning reads',
         )
-        self.assertTrue(pairing.equivalent(event1, event2))
+        assert pairing.equivalent(event1, event2)
 
     def test_useq_uncertainty2(self):
         event1 = BreakpointPair(
@@ -414,4 +457,4 @@ class TestEquivalent(unittest.TestCase):
             call_method='contig',
             untemplated_seq='TTTTTTTTT',
         )
-        self.assertTrue(pairing.equivalent(event1, event2))
+        assert pairing.equivalent(event1, event2)

--- a/tests/integration/test_splicing.py
+++ b/tests/integration/test_splicing.py
@@ -1,8 +1,7 @@
-import os
-import unittest
+import argparse
 
+import pytest
 from mavis.annotate.constants import SPLICE_SITE_RADIUS
-from mavis.annotate.file_io import load_annotations, load_reference_genome
 from mavis.annotate.genomic import Exon, PreTranscript
 from mavis.annotate.splicing import predict_splice_sites
 from mavis.annotate.variant import annotate_events
@@ -10,7 +9,7 @@ from mavis.breakpoint import Breakpoint, BreakpointPair
 from mavis.constants import PROTOCOL, SPLICE_TYPE, STRAND, SVTYPE, reverse_complement
 from mavis.interval import Interval
 
-from . import DATA_DIR, MockLongString, MockObject, get_example_genes
+from . import MockLongString, MockObject, get_example_genes
 
 EXAMPLE_GENES = None
 
@@ -20,340 +19,316 @@ def setUpModule():
     EXAMPLE_GENES = get_example_genes()
 
 
-class TestSplicingPatterns(unittest.TestCase):
-    def setUp(self):
-        self.setup_by_strand(STRAND.POS)
+@pytest.fixture
+def neg_splicing_pattern():
+    n = argparse.Namespace()
+    n.ex1 = Exon(100, 199, strand=STRAND.NEG)  # C
+    n.ex2 = Exon(500, 599, strand=STRAND.NEG)  # G
+    n.ex3 = Exon(1200, 1299, strand=STRAND.NEG)  # T
+    n.ex4 = Exon(1500, 1599, strand=STRAND.NEG)  # C
+    n.ex5 = Exon(1700, 1799, strand=STRAND.NEG)  # G
+    n.ex6 = Exon(2000, 2099, strand=STRAND.NEG)  # C
+    # introns: 99, 300, 600, 200, 100, ...
+    reference_sequence = 'a' * 99 + 'C' * 100 + 'a' * 300 + 'G' * 100
+    reference_sequence += 'a' * 600 + 'T' * 100 + 'a' * 200 + 'C' * 100
+    reference_sequence += 'a' * 100 + 'G' * 100 + 'a' * 200 + 'C' * 100
+    n.reference_sequence = reference_sequence
+    n.pre_transcript = PreTranscript(
+        exons=[n.ex1, n.ex2, n.ex3, n.ex4, n.ex5, n.ex6], strand=STRAND.NEG
+    )
+    return n
 
-    def setup_by_strand(self, strand):
-        self.ex1 = Exon(100, 199, strand=strand)  # C
-        self.ex2 = Exon(500, 599, strand=strand)  # G
-        self.ex3 = Exon(1200, 1299, strand=strand)  # T
-        self.ex4 = Exon(1500, 1599, strand=strand)  # C
-        self.ex5 = Exon(1700, 1799, strand=strand)  # G
-        self.ex6 = Exon(2000, 2099, strand=strand)  # C
-        # introns: 99, 300, 600, 200, 100, ...
-        reference_sequence = 'a' * 99 + 'C' * 100 + 'a' * 300 + 'G' * 100
-        reference_sequence += 'a' * 600 + 'T' * 100 + 'a' * 200 + 'C' * 100
-        reference_sequence += 'a' * 100 + 'G' * 100 + 'a' * 200 + 'C' * 100
-        self.reference_sequence = reference_sequence
-        self.pre_transcript = PreTranscript(
-            exons=[self.ex1, self.ex2, self.ex3, self.ex4, self.ex5, self.ex6], strand=strand
-        )
 
+@pytest.fixture
+def pos_splicing_pattern():
+    n = argparse.Namespace()
+    n.ex1 = Exon(100, 199, strand=STRAND.POS)  # C
+    n.ex2 = Exon(500, 599, strand=STRAND.POS)  # G
+    n.ex3 = Exon(1200, 1299, strand=STRAND.POS)  # T
+    n.ex4 = Exon(1500, 1599, strand=STRAND.POS)  # C
+    n.ex5 = Exon(1700, 1799, strand=STRAND.POS)  # G
+    n.ex6 = Exon(2000, 2099, strand=STRAND.POS)  # C
+    # introns: 99, 300, 600, 200, 100, ...
+    reference_sequence = 'a' * 99 + 'C' * 100 + 'a' * 300 + 'G' * 100
+    reference_sequence += 'a' * 600 + 'T' * 100 + 'a' * 200 + 'C' * 100
+    reference_sequence += 'a' * 100 + 'G' * 100 + 'a' * 200 + 'C' * 100
+    n.reference_sequence = reference_sequence
+    n.pre_transcript = PreTranscript(
+        exons=[n.ex1, n.ex2, n.ex3, n.ex4, n.ex5, n.ex6], strand=STRAND.POS
+    )
+    return n
+
+
+class TestSplicingPatterns:
     def test_single_exon(self):
         t = PreTranscript([(3, 4)], strand=STRAND.POS)
         patt = t.generate_splicing_patterns()
-        self.assertEqual(1, len(patt))
-        self.assertEqual(0, len(patt[0]))
-        self.assertEqual(SPLICE_TYPE.NORMAL, patt[0].splice_type)
+        assert len(patt) == 1
+        assert len(patt[0]) == 0
+        assert patt[0].splice_type == SPLICE_TYPE.NORMAL
 
-    def test_normal_pattern_pos(self):
-        patt = self.pre_transcript.generate_splicing_patterns()
-        self.assertEqual(1, len(patt))
-        self.assertEqual(
-            [
-                self.ex1.end,
-                self.ex2.start,
-                self.ex2.end,
-                self.ex3.start,
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            [s.pos for s in patt[0]],
-        )
-        self.assertEqual(SPLICE_TYPE.NORMAL, patt[0].splice_type)
+    def test_normal_pattern_pos(self, pos_splicing_pattern):
+        patt = pos_splicing_pattern.pre_transcript.generate_splicing_patterns()
+        assert len(patt) == 1
+        assert [s.pos for s in patt[0]] == [
+            pos_splicing_pattern.ex1.end,
+            pos_splicing_pattern.ex2.start,
+            pos_splicing_pattern.ex2.end,
+            pos_splicing_pattern.ex3.start,
+            pos_splicing_pattern.ex3.end,
+            pos_splicing_pattern.ex4.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+            pos_splicing_pattern.ex5.end,
+            pos_splicing_pattern.ex6.start,
+        ]
+        assert patt[0].splice_type == SPLICE_TYPE.NORMAL
 
-    def test_normal_pattern_neg(self):
-        self.setup_by_strand(STRAND.NEG)
-        self.assertTrue(self.pre_transcript.is_reverse)
-        patt = self.pre_transcript.generate_splicing_patterns()
-        self.assertEqual(1, len(patt))
-        self.assertEqual(
-            [
-                self.ex1.end,
-                self.ex2.start,
-                self.ex2.end,
-                self.ex3.start,
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            sorted([s.pos for s in patt[0]]),
-        )
-        self.assertEqual(SPLICE_TYPE.NORMAL, patt[0].splice_type)
+    def test_normal_pattern_neg(self, neg_splicing_pattern):
+        assert neg_splicing_pattern.pre_transcript.is_reverse
+        patt = neg_splicing_pattern.pre_transcript.generate_splicing_patterns()
+        assert len(patt) == 1
+        assert sorted([s.pos for s in patt[0]]) == [
+            neg_splicing_pattern.ex1.end,
+            neg_splicing_pattern.ex2.start,
+            neg_splicing_pattern.ex2.end,
+            neg_splicing_pattern.ex3.start,
+            neg_splicing_pattern.ex3.end,
+            neg_splicing_pattern.ex4.start,
+            neg_splicing_pattern.ex4.end,
+            neg_splicing_pattern.ex5.start,
+            neg_splicing_pattern.ex5.end,
+            neg_splicing_pattern.ex6.start,
+        ]
+        assert patt[0].splice_type == SPLICE_TYPE.NORMAL
 
-    def test_abrogate_a_pos(self):
-        self.ex2.start_splice_site.intact = False
-        patt = self.pre_transcript.generate_splicing_patterns()
-        self.assertEqual(2, len(patt))
+    def test_abrogate_a_pos(self, pos_splicing_pattern):
+        pos_splicing_pattern.ex2.start_splice_site.intact = False
+        patt = pos_splicing_pattern.pre_transcript.generate_splicing_patterns()
+        assert len(patt) == 2
 
-        self.assertEqual(
-            [
-                self.ex1.end,
-                self.ex3.start,
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            [s.pos for s in patt[0]],
-        )
-        self.assertEqual(SPLICE_TYPE.SKIP, patt[0].splice_type)
+        assert [s.pos for s in patt[0]] == [
+            pos_splicing_pattern.ex1.end,
+            pos_splicing_pattern.ex3.start,
+            pos_splicing_pattern.ex3.end,
+            pos_splicing_pattern.ex4.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+            pos_splicing_pattern.ex5.end,
+            pos_splicing_pattern.ex6.start,
+        ]
+        assert patt[0].splice_type == SPLICE_TYPE.SKIP
 
-        self.assertEqual(
-            [
-                self.ex2.end,
-                self.ex3.start,
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            [s.pos for s in patt[1]],
-        )
-        self.assertEqual(SPLICE_TYPE.RETAIN, patt[1].splice_type)
+        assert [s.pos for s in patt[1]] == [
+            pos_splicing_pattern.ex2.end,
+            pos_splicing_pattern.ex3.start,
+            pos_splicing_pattern.ex3.end,
+            pos_splicing_pattern.ex4.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+            pos_splicing_pattern.ex5.end,
+            pos_splicing_pattern.ex6.start,
+        ]
+        assert patt[1].splice_type == SPLICE_TYPE.RETAIN
 
-    def test_abrogate_a_neg(self):
-        self.setup_by_strand(STRAND.NEG)
-        self.ex2.start_splice_site.intact = False
-        patt = sorted(self.pre_transcript.generate_splicing_patterns())
-        self.assertEqual(2, len(patt))
-        self.assertEqual(
-            [
-                self.ex1.end,
-                self.ex3.start,
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            sorted([s.pos for s in patt[0]]),
-        )
-        self.assertEqual(SPLICE_TYPE.SKIP, patt[0].splice_type)
-        self.assertEqual(
-            [
-                self.ex2.end,
-                self.ex3.start,
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            sorted([s.pos for s in patt[1]]),
-        )
-        self.assertEqual(SPLICE_TYPE.RETAIN, patt[1].splice_type)
+    def test_abrogate_a_neg(self, neg_splicing_pattern):
+        neg_splicing_pattern.ex2.start_splice_site.intact = False
+        patt = sorted(neg_splicing_pattern.pre_transcript.generate_splicing_patterns())
+        assert len(patt) == 2
+        assert sorted([s.pos for s in patt[0]]) == [
+            neg_splicing_pattern.ex1.end,
+            neg_splicing_pattern.ex3.start,
+            neg_splicing_pattern.ex3.end,
+            neg_splicing_pattern.ex4.start,
+            neg_splicing_pattern.ex4.end,
+            neg_splicing_pattern.ex5.start,
+            neg_splicing_pattern.ex5.end,
+            neg_splicing_pattern.ex6.start,
+        ]
+        assert patt[0].splice_type == SPLICE_TYPE.SKIP
+        assert sorted([s.pos for s in patt[1]]) == [
+            neg_splicing_pattern.ex2.end,
+            neg_splicing_pattern.ex3.start,
+            neg_splicing_pattern.ex3.end,
+            neg_splicing_pattern.ex4.start,
+            neg_splicing_pattern.ex4.end,
+            neg_splicing_pattern.ex5.start,
+            neg_splicing_pattern.ex5.end,
+            neg_splicing_pattern.ex6.start,
+        ]
+        assert patt[1].splice_type == SPLICE_TYPE.RETAIN
 
-    def test_abrogate_a_last_exon(self):
-        self.ex6.start_splice_site.intact = False
-        patt = self.pre_transcript.generate_splicing_patterns()
-        self.assertEqual(1, len(patt))
-        self.assertEqual(
-            [
-                self.ex1.end,
-                self.ex2.start,
-                self.ex2.end,
-                self.ex3.start,
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-            ],
-            [s.pos for s in patt[0]],
-        )
-        self.assertEqual(SPLICE_TYPE.RETAIN, patt[0].splice_type)
+    def test_abrogate_a_last_exon(self, pos_splicing_pattern):
+        pos_splicing_pattern.ex6.start_splice_site.intact = False
+        patt = pos_splicing_pattern.pre_transcript.generate_splicing_patterns()
+        assert len(patt) == 1
+        assert [s.pos for s in patt[0]] == [
+            pos_splicing_pattern.ex1.end,
+            pos_splicing_pattern.ex2.start,
+            pos_splicing_pattern.ex2.end,
+            pos_splicing_pattern.ex3.start,
+            pos_splicing_pattern.ex3.end,
+            pos_splicing_pattern.ex4.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+        ]
+        assert patt[0].splice_type == SPLICE_TYPE.RETAIN
 
-    def test_abrogate_d_first_exon(self):
-        self.ex1.end_splice_site.intact = False
-        patt = self.pre_transcript.generate_splicing_patterns()
-        self.assertEqual(1, len(patt))
-        self.assertEqual(
-            [
-                self.ex2.end,
-                self.ex3.start,
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            [s.pos for s in patt[0]],
-        )
-        self.assertEqual(SPLICE_TYPE.RETAIN, patt[0].splice_type)
+    def test_abrogate_d_first_exon(self, pos_splicing_pattern):
+        pos_splicing_pattern.ex1.end_splice_site.intact = False
+        patt = pos_splicing_pattern.pre_transcript.generate_splicing_patterns()
+        assert len(patt) == 1
+        assert [s.pos for s in patt[0]] == [
+            pos_splicing_pattern.ex2.end,
+            pos_splicing_pattern.ex3.start,
+            pos_splicing_pattern.ex3.end,
+            pos_splicing_pattern.ex4.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+            pos_splicing_pattern.ex5.end,
+            pos_splicing_pattern.ex6.start,
+        ]
+        assert patt[0].splice_type == SPLICE_TYPE.RETAIN
 
-    def test_abrogate_ad(self):
-        self.ex2.start_splice_site.intact = False
-        patt = self.pre_transcript.generate_splicing_patterns()
-        self.assertEqual(2, len(patt))
-        self.assertEqual(
-            [
-                self.ex1.end,
-                self.ex3.start,
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            [s.pos for s in patt[0]],
-        )
-        self.assertEqual(SPLICE_TYPE.SKIP, patt[0].splice_type)
+    def test_abrogate_ad(self, pos_splicing_pattern):
+        pos_splicing_pattern.ex2.start_splice_site.intact = False
+        patt = pos_splicing_pattern.pre_transcript.generate_splicing_patterns()
+        assert len(patt) == 2
+        assert [s.pos for s in patt[0]] == [
+            pos_splicing_pattern.ex1.end,
+            pos_splicing_pattern.ex3.start,
+            pos_splicing_pattern.ex3.end,
+            pos_splicing_pattern.ex4.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+            pos_splicing_pattern.ex5.end,
+            pos_splicing_pattern.ex6.start,
+        ]
+        assert patt[0].splice_type == SPLICE_TYPE.SKIP
 
-        self.assertEqual(
-            [
-                self.ex2.end,
-                self.ex3.start,
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            [s.pos for s in patt[1]],
-        )
-        self.assertEqual(SPLICE_TYPE.RETAIN, patt[1].splice_type)
+        assert [s.pos for s in patt[1]] == [
+            pos_splicing_pattern.ex2.end,
+            pos_splicing_pattern.ex3.start,
+            pos_splicing_pattern.ex3.end,
+            pos_splicing_pattern.ex4.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+            pos_splicing_pattern.ex5.end,
+            pos_splicing_pattern.ex6.start,
+        ]
+        assert patt[1].splice_type == SPLICE_TYPE.RETAIN
 
-    def test_abrogate_da(self):
-        self.ex2.end_splice_site.intact = False
-        self.ex3.start_splice_site.intact = False
-        patt = self.pre_transcript.generate_splicing_patterns()
-        self.assertEqual(1, len(patt))
-        self.assertEqual(
-            [
-                self.ex1.end,
-                self.ex2.start,
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            [s.pos for s in patt[0]],
-        )
-        self.assertEqual(SPLICE_TYPE.RETAIN, patt[0].splice_type)
+    def test_abrogate_da(self, pos_splicing_pattern):
+        pos_splicing_pattern.ex2.end_splice_site.intact = False
+        pos_splicing_pattern.ex3.start_splice_site.intact = False
+        patt = pos_splicing_pattern.pre_transcript.generate_splicing_patterns()
+        assert len(patt) == 1
+        assert [s.pos for s in patt[0]] == [
+            pos_splicing_pattern.ex1.end,
+            pos_splicing_pattern.ex2.start,
+            pos_splicing_pattern.ex3.end,
+            pos_splicing_pattern.ex4.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+            pos_splicing_pattern.ex5.end,
+            pos_splicing_pattern.ex6.start,
+        ]
+        assert patt[0].splice_type == SPLICE_TYPE.RETAIN
 
-    def test_multiple_exons_or_multiple_introns_abrogate_ada(self):
-        self.ex2.start_splice_site.intact = False
-        self.ex2.end_splice_site.intact = False
-        self.ex3.start_splice_site.intact = False
-        patt = self.pre_transcript.generate_splicing_patterns()
-        self.assertEqual(2, len(patt))
+    def test_multiple_exons_or_multiple_introns_abrogate_ada(self, pos_splicing_pattern):
+        pos_splicing_pattern.ex2.start_splice_site.intact = False
+        pos_splicing_pattern.ex2.end_splice_site.intact = False
+        pos_splicing_pattern.ex3.start_splice_site.intact = False
+        patt = pos_splicing_pattern.pre_transcript.generate_splicing_patterns()
+        assert len(patt) == 2
 
-        self.assertEqual(
-            [
-                self.ex1.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            [s.pos for s in patt[0]],
-        )
-        self.assertEqual(SPLICE_TYPE.MULTI_SKIP, patt[0].splice_type)
+        assert [s.pos for s in patt[0]] == [
+            pos_splicing_pattern.ex1.end,
+            pos_splicing_pattern.ex4.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+            pos_splicing_pattern.ex5.end,
+            pos_splicing_pattern.ex6.start,
+        ]
+        assert patt[0].splice_type == SPLICE_TYPE.MULTI_SKIP
 
-        self.assertEqual(
-            [
-                self.ex3.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            [s.pos for s in patt[1]],
-        )
-        self.assertEqual(SPLICE_TYPE.MULTI_RETAIN, patt[1].splice_type)
+        assert [s.pos for s in patt[1]] == [
+            pos_splicing_pattern.ex3.end,
+            pos_splicing_pattern.ex4.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+            pos_splicing_pattern.ex5.end,
+            pos_splicing_pattern.ex6.start,
+        ]
+        assert patt[1].splice_type == SPLICE_TYPE.MULTI_RETAIN
 
-    def test_multiple_exons_or_multiple_introns_abrogate_dad(self):
-        self.ex2.end_splice_site.intact = False
-        self.ex3.start_splice_site.intact = False
-        self.ex3.end_splice_site.intact = False
-        patt = self.pre_transcript.generate_splicing_patterns()
-        self.assertEqual(2, len(patt))
+    def test_multiple_exons_or_multiple_introns_abrogate_dad(self, pos_splicing_pattern):
+        pos_splicing_pattern.ex2.end_splice_site.intact = False
+        pos_splicing_pattern.ex3.start_splice_site.intact = False
+        pos_splicing_pattern.ex3.end_splice_site.intact = False
+        patt = pos_splicing_pattern.pre_transcript.generate_splicing_patterns()
+        assert len(patt) == 2
 
-        self.assertEqual(
-            [
-                self.ex1.end,
-                self.ex2.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            [s.pos for s in patt[0]],
-        )
-        self.assertEqual(SPLICE_TYPE.MULTI_RETAIN, patt[0].splice_type)
+        assert [s.pos for s in patt[0]] == [
+            pos_splicing_pattern.ex1.end,
+            pos_splicing_pattern.ex2.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+            pos_splicing_pattern.ex5.end,
+            pos_splicing_pattern.ex6.start,
+        ]
+        assert patt[0].splice_type == SPLICE_TYPE.MULTI_RETAIN
 
-        self.assertEqual(
-            [
-                self.ex1.end,
-                self.ex4.start,
-                self.ex4.end,
-                self.ex5.start,
-                self.ex5.end,
-                self.ex6.start,
-            ],
-            [s.pos for s in patt[1]],
-        )
-        self.assertEqual(SPLICE_TYPE.MULTI_SKIP, patt[1].splice_type)
+        assert [s.pos for s in patt[1]] == [
+            pos_splicing_pattern.ex1.end,
+            pos_splicing_pattern.ex4.start,
+            pos_splicing_pattern.ex4.end,
+            pos_splicing_pattern.ex5.start,
+            pos_splicing_pattern.ex5.end,
+            pos_splicing_pattern.ex6.start,
+        ]
+        assert patt[1].splice_type == SPLICE_TYPE.MULTI_SKIP
 
-    def test_complex(self):
-        self.ex2.end_splice_site.intact = False
-        self.ex4.end_splice_site.intact = False
-        patt = self.pre_transcript.generate_splicing_patterns()
-        self.assertEqual(4, len(patt))
-        self.assertTrue(SPLICE_TYPE.COMPLEX in [p.splice_type for p in patt])
+    def test_complex(self, pos_splicing_pattern):
+        pos_splicing_pattern.ex2.end_splice_site.intact = False
+        pos_splicing_pattern.ex4.end_splice_site.intact = False
+        patt = pos_splicing_pattern.pre_transcript.generate_splicing_patterns()
+        assert len(patt) == 4
+        assert SPLICE_TYPE.COMPLEX in [p.splice_type for p in patt]
 
 
-class TestExonSpliceSites(unittest.TestCase):
+class TestExonSpliceSites:
     def test_end_splice_site(self):
         e = Exon(100, 199, strand=STRAND.POS)
-        self.assertEqual(2, SPLICE_SITE_RADIUS)
-        self.assertEqual(Interval(198, 201), e.end_splice_site)
+        assert SPLICE_SITE_RADIUS == 2
+        print(e.end_splice_site)
+        assert Interval(198, 201) == e.end_splice_site
 
     def test_start_splice_site(self):
         e = Exon(100, 199, strand=STRAND.POS)
-        self.assertEqual(2, SPLICE_SITE_RADIUS)
-        self.assertEqual(Interval(98, 101), e.start_splice_site)
+        assert SPLICE_SITE_RADIUS == 2
+        print(e.start_splice_site)
+        assert Interval(98, 101) == e.start_splice_site
 
 
-class TestPredictSpliceSites(unittest.TestCase):
+class TestPredictSpliceSites:
     def test_gimap4(self):
         gimap4 = EXAMPLE_GENES['GIMAP4']
         donors = predict_splice_sites(gimap4.seq)
         for d in donors:
             print(d)
-        self.assertEqual(5, len(donors))
+        assert len(donors) == 5
 
     def test_gimap4_reverse(self):
         gimap4 = EXAMPLE_GENES['GIMAP4']
         gimap4_seq = reverse_complement(gimap4.seq)
         donors = predict_splice_sites(gimap4_seq, True)
         for d in donors:
-            self.assertEqual(d.seq, gimap4_seq[d.start - 1 : d.end])
-        self.assertEqual(5, len(donors))
+            assert gimap4_seq[d.start - 1 : d.end] == d.seq
+        assert len(donors) == 5
 
+    @pytest.mark.skip(reason='TODO: dependent functionality not yet implemented')
     def test_fusion_with_novel_splice_site(self):
-        raise unittest.SkipTest('TODO: dependent functionality not yet implemented')
         bpp = BreakpointPair(
             Breakpoint('7', 150268089, 150268089, 'L', '+'),
             Breakpoint('8', 79715940, 79715940, 'L', '-'),
@@ -368,7 +343,7 @@ class TestPredictSpliceSites(unittest.TestCase):
             il7.chr: MockObject(seq=MockLongString(il7.seq, offset=il7.start - 1)),
         }
         annotations = annotate_events([bpp], {gimap4.chr: [gimap4], il7.chr: [il7]}, ref_genome)
-        self.assertEqual(1, len(annotations))
+        assert len(annotations) == 1
         ann = annotations[0]
         print(ann, ann.transcript1, ann.transcript2)
         print(ann.fusion)
@@ -378,4 +353,4 @@ class TestPredictSpliceSites(unittest.TestCase):
         )
         for ex in ann.fusion.transcripts[0].exons:
             print(ex, len(ex))
-        self.assertTrue(False)
+        assert False

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -1,5 +1,4 @@
-import unittest
-
+import pytest
 from mavis.annotate.file_io import load_reference_genome
 from mavis.bam import cigar as _cigar
 from mavis.bam.cache import BamCache
@@ -10,8 +9,8 @@ from mavis.schemas import DEFAULTS
 from mavis.validate.base import Evidence
 from mavis.validate.evidence import GenomeEvidence
 
-from ..util import get_data
-from . import RUN_FULL, MockLongString, MockObject, MockRead, mock_read_pair
+from ..util import get_data, long_running_test
+from . import MockLongString, MockObject, MockRead, mock_read_pair
 
 REFERENCE_GENOME = None
 
@@ -42,10 +41,8 @@ def setUpModule():
     # add a check to determine if it is the expected bam file
 
 
-@unittest.skipIf(
-    not RUN_FULL, 'slower tests will not be run unless the environment variable RUN_FULL is given'
-)
-class TestFullEvidenceGathering(unittest.TestCase):
+@long_running_test
+class TestFullEvidenceGathering:
     # need to make the assertions more specific by checking the actual names of the reads found in each bin
     # rather than just the counts.
     def genome_evidence(self, break1, break2, opposing_strands):
@@ -130,9 +127,9 @@ class TestFullEvidenceGathering(unittest.TestCase):
         )
         ev1.load_evidence()
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
-        self.assertEqual(14, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(20, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(21, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 14
+        assert self.count_original_reads(ev1.split_reads[1]) == 20
+        assert len(ev1.flanking_pairs) == 21
 
         # second example
         ev1 = self.genome_evidence(
@@ -142,10 +139,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         )
         ev1.load_evidence()
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
-        self.assertEqual(21, self.count_original_reads(ev1.split_reads[0]))
+        assert self.count_original_reads(ev1.split_reads[0]) == 21
         # one of the reads that appears to look good in the bam is too low quality % match
-        self.assertEqual(40, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(57, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[1]) == 40
+        assert len(ev1.flanking_pairs) == 57
 
     def test_load_evidence_inversion(self):
         # first example
@@ -157,9 +154,9 @@ class TestFullEvidenceGathering(unittest.TestCase):
 
         ev1.load_evidence()
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
-        self.assertEqual(54, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(20, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(104, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 54
+        assert self.count_original_reads(ev1.split_reads[1]) == 20
+        assert len(ev1.flanking_pairs) == 104
 
         # second example
         ev1 = self.genome_evidence(
@@ -169,9 +166,9 @@ class TestFullEvidenceGathering(unittest.TestCase):
         )
         ev1.load_evidence()
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
-        self.assertEqual(15, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(27, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(52, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[1]) == 15
+        assert self.count_original_reads(ev1.split_reads[0]) == 27
+        assert len(ev1.flanking_pairs) == 52
 
     def test_load_evidence_duplication(self):
         ev1 = self.genome_evidence(
@@ -182,9 +179,9 @@ class TestFullEvidenceGathering(unittest.TestCase):
         ev1.load_evidence()
         self.print_evidence(ev1)
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
-        self.assertEqual(35, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(11, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(64, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 35
+        assert self.count_original_reads(ev1.split_reads[1]) == 11
+        assert len(ev1.flanking_pairs) == 64
 
     def test_load_evidence_deletion1(self):
         # first example
@@ -196,9 +193,9 @@ class TestFullEvidenceGathering(unittest.TestCase):
         ev1.load_evidence()
         self.print_evidence(ev1)
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
-        self.assertEqual(49, len(ev1.flanking_pairs))
-        self.assertEqual(22, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(14, self.count_original_reads(ev1.split_reads[1]))
+        assert len(ev1.flanking_pairs) == 49
+        assert self.count_original_reads(ev1.split_reads[0]) == 22
+        assert self.count_original_reads(ev1.split_reads[1]) == 14
 
     def test_load_evidence_deletion2(self):
         # second example
@@ -210,9 +207,9 @@ class TestFullEvidenceGathering(unittest.TestCase):
         ev1.load_evidence()
         self.print_evidence(ev1)
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
-        self.assertEqual(4, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(10, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(27, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 4
+        assert self.count_original_reads(ev1.split_reads[1]) == 10
+        assert len(ev1.flanking_pairs) == 27
 
     def test_load_evidence_deletion3(self):
         # third example
@@ -224,9 +221,9 @@ class TestFullEvidenceGathering(unittest.TestCase):
         ev1.load_evidence()
         self.print_evidence(ev1)
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
-        self.assertEqual(8, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(9, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(26, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 8
+        assert self.count_original_reads(ev1.split_reads[1]) == 9
+        assert len(ev1.flanking_pairs) == 26
 
     def test_load_evidence_deletion4(self):
         # forth example
@@ -238,9 +235,9 @@ class TestFullEvidenceGathering(unittest.TestCase):
         ev1.load_evidence()
         self.print_evidence(ev1)
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
-        self.assertEqual(20, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(18, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(40, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 20
+        assert self.count_original_reads(ev1.split_reads[1]) == 18
+        assert len(ev1.flanking_pairs) == 40
 
     def test_load_evidence_small_deletion1(self):
         # first example
@@ -255,10 +252,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs), len(ev1.spanning_reads))
         print(len(ev1.spanning_reads))
 
-        self.assertEqual(5, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(3, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(20, len(ev1.spanning_reads))
-        self.assertEqual(6, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 5
+        assert self.count_original_reads(ev1.split_reads[1]) == 3
+        assert len(ev1.spanning_reads) == 20
+        assert len(ev1.flanking_pairs) == 6
 
     def test_load_evidence_small_deletion2(self):
         # second example
@@ -275,10 +272,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         for read, mate in ev1.flanking_pairs:
             print(read.query_name)
 
-        self.assertEqual(27, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(52, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(19, len(ev1.spanning_reads))
-        self.assertEqual(7, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 27
+        assert self.count_original_reads(ev1.split_reads[1]) == 52
+        assert len(ev1.spanning_reads) == 19
+        assert len(ev1.flanking_pairs) == 7
 
     def test_load_evidence_small_deletion_test1(self):
         ev1 = self.genome_evidence(
@@ -294,10 +291,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         for read, mate in ev1.flanking_pairs:
             print(read.query_name)
 
-        self.assertEqual(18, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(16, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(0, len(ev1.spanning_reads))
-        self.assertEqual(22, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 18
+        assert self.count_original_reads(ev1.split_reads[1]) == 16
+        assert len(ev1.spanning_reads) == 0
+        assert len(ev1.flanking_pairs) == 22
 
     def test_load_evidence_small_deletion_test2(self):
         ev1 = self.genome_evidence(
@@ -307,10 +304,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         )
         ev1.load_evidence()
         self.print_evidence(ev1)
-        self.assertEqual(20, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(18, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(0, len(ev1.spanning_reads))
-        self.assertEqual(40, len(set(ev1.flanking_pairs)))
+        assert self.count_original_reads(ev1.split_reads[0]) == 20
+        assert self.count_original_reads(ev1.split_reads[1]) == 18
+        assert len(ev1.spanning_reads) == 0
+        assert len(set(ev1.flanking_pairs)) == 40
 
     def test_load_evidence_small_deletion_test3(self):
         ev1 = self.genome_evidence(
@@ -326,10 +323,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         for read in sorted(ev1.spanning_reads, key=lambda x: x.query_name):
             print(read.query_name)
 
-        self.assertEqual(27, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(5, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(0, len(ev1.spanning_reads))
-        self.assertEqual(53, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 27
+        assert self.count_original_reads(ev1.split_reads[1]) == 5
+        assert len(ev1.spanning_reads) == 0
+        assert len(ev1.flanking_pairs) == 53
 
     def test_load_evidence_small_deletion_test4(self):
         ev1 = self.genome_evidence(
@@ -345,10 +342,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         print(self.count_original_reads(ev1.split_reads[0]))
         print(self.count_original_reads(ev1.split_reads[1]))
 
-        self.assertEqual(33, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(6, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(0, len(ev1.spanning_reads))
-        self.assertEqual(77, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 33
+        assert self.count_original_reads(ev1.split_reads[1]) == 6
+        assert len(ev1.spanning_reads) == 0
+        assert len(ev1.flanking_pairs) == 77
 
     def test_load_evidence_small_deletion_test5(self):
         ev1 = self.genome_evidence(
@@ -364,10 +361,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         print(self.count_original_reads(ev1.split_reads[0]))
         print(self.count_original_reads(ev1.split_reads[1]))
 
-        self.assertEqual(19, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(11, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(0, len(ev1.spanning_reads))
-        self.assertEqual(48, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 19
+        assert self.count_original_reads(ev1.split_reads[1]) == 11
+        assert len(ev1.spanning_reads) == 0
+        assert len(ev1.flanking_pairs) == 48
 
     def test_load_evidence_small_deletion_test6(self):
         ev1 = self.genome_evidence(
@@ -382,9 +379,9 @@ class TestFullEvidenceGathering(unittest.TestCase):
         print(self.count_original_reads(ev1.split_reads[0]))
         print(self.count_original_reads(ev1.split_reads[1]))
 
-        self.assertEqual(18, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(13, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(53, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 18
+        assert self.count_original_reads(ev1.split_reads[1]) == 13
+        assert len(ev1.flanking_pairs) == 53
 
     def test_load_evidence_small_deletion_test7(self):
         ev1 = self.genome_evidence(
@@ -400,9 +397,9 @@ class TestFullEvidenceGathering(unittest.TestCase):
         print(self.count_original_reads(ev1.split_reads[0]))
         print(self.count_original_reads(ev1.split_reads[1]))
 
-        self.assertEqual(39, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(13, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(49, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 39
+        assert self.count_original_reads(ev1.split_reads[1]) == 13
+        assert len(ev1.flanking_pairs) == 49
 
     def test_load_evidence_small_deletion_test8(self):
         ev1 = self.genome_evidence(
@@ -418,11 +415,11 @@ class TestFullEvidenceGathering(unittest.TestCase):
         print(self.count_original_reads(ev1.split_reads[0]))
         print(self.count_original_reads(ev1.split_reads[1]))
 
-        self.assertEqual(59, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(8, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(59, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 59
+        assert self.count_original_reads(ev1.split_reads[1]) == 8
+        assert len(ev1.flanking_pairs) == 59
 
-    @unittest.skip('skip because too complex')
+    @pytest.mark.skip(reason='skip because too complex')
     def test_load_evidence_complex_deletion(self):
         ev1 = self.genome_evidence(
             Breakpoint('reference12', 6001, orient=ORIENT.LEFT),
@@ -440,12 +437,12 @@ class TestFullEvidenceGathering(unittest.TestCase):
         for read in sorted(ev1.spanning_reads, key=lambda x: x.query_name):
             print(read.query_name)
 
-        self.assertEqual(76, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(83, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(1, len(ev1.spanning_reads))
-        self.assertEqual(2, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 76
+        assert self.count_original_reads(ev1.split_reads[1]) == 83
+        assert len(ev1.spanning_reads) == 1
+        assert len(ev1.flanking_pairs) == 2
 
-    @unittest.skip('skip because high coverage')
+    @pytest.mark.skip(reason='skip because high coverage')
     def test_load_evidence_small_insertion(self):
         ev1 = self.genome_evidence(
             Breakpoint('reference1', 2000, orient=ORIENT.LEFT),
@@ -460,12 +457,12 @@ class TestFullEvidenceGathering(unittest.TestCase):
         for read in sorted(ev1.spanning_reads, key=lambda x: x.query_name):
             print(read.query_name)
 
-        self.assertEqual(17, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(17, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(48, len(ev1.spanning_reads))
-        self.assertEqual(4, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 17
+        assert self.count_original_reads(ev1.split_reads[1]) == 17
+        assert len(ev1.spanning_reads) == 48
+        assert len(ev1.flanking_pairs) == 4
 
-    @unittest.skip('skip because too high coverage')
+    @pytest.mark.skip(reason='skip because too high coverage')
     def test_load_evidence_small_insertion_high_coverage(self):
         ev1 = self.genome_evidence(
             Breakpoint('reference9', 2000, orient=ORIENT.LEFT),
@@ -480,10 +477,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         for read in sorted(ev1.spanning_reads, key=lambda x: x.query_name):
             print(read.query_name)
 
-        self.assertEqual(37, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(52, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(37, len(ev1.spanning_reads))
-        self.assertEqual(9, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 37
+        assert self.count_original_reads(ev1.split_reads[1]) == 52
+        assert len(ev1.spanning_reads) == 37
+        assert len(ev1.flanking_pairs) == 9
 
         ev1 = self.genome_evidence(
             Breakpoint('reference16', 2000, orient=ORIENT.LEFT),
@@ -498,10 +495,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         for read in sorted(ev1.spanning_reads, key=lambda x: x.query_name):
             print(read.query_name)
 
-        self.assertEqual(27, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(52, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(19, len(ev1.spanning_reads))
-        self.assertEqual(9, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 27
+        assert self.count_original_reads(ev1.split_reads[1]) == 52
+        assert len(ev1.spanning_reads) == 19
+        assert len(ev1.flanking_pairs) == 9
 
     def test_load_evidence_small_duplication(self):
         ev1 = self.genome_evidence(
@@ -517,10 +514,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         for read in sorted(ev1.spanning_reads, key=lambda x: x.query_name):
             print(read.query_name)
 
-        self.assertEqual(29, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(51, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(0, len(ev1.spanning_reads))
-        self.assertEqual(0, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 29
+        assert self.count_original_reads(ev1.split_reads[1]) == 51
+        assert len(ev1.spanning_reads) == 0
+        assert len(ev1.flanking_pairs) == 0
 
         # Example 2
         ev1 = self.genome_evidence(
@@ -536,10 +533,10 @@ class TestFullEvidenceGathering(unittest.TestCase):
         for read in sorted(ev1.spanning_reads, key=lambda x: x.query_name):
             print(read.query_name)
 
-        self.assertEqual(25, self.count_original_reads(ev1.split_reads[0]))
-        self.assertEqual(56, self.count_original_reads(ev1.split_reads[1]))
-        self.assertEqual(3, len(ev1.spanning_reads))
-        self.assertEqual(0, len(ev1.flanking_pairs))
+        assert self.count_original_reads(ev1.split_reads[0]) == 25
+        assert self.count_original_reads(ev1.split_reads[1]) == 56
+        assert len(ev1.spanning_reads) == 3
+        assert len(ev1.flanking_pairs) == 0
 
     def test_load_evidence_low_qual_deletion(self):
         ev1 = self.genome_evidence(
@@ -551,31 +548,32 @@ class TestFullEvidenceGathering(unittest.TestCase):
         self.print_evidence(ev1)
         print(len(ev1.spanning_reads))
         print(len(ev1.split_reads[0]), len(ev1.flanking_pairs))
-        self.assertEqual(0, len(ev1.split_reads[0]))
-        self.assertEqual(0, len(ev1.split_reads[1]))
-        self.assertEqual(0, len(ev1.flanking_pairs))
+        assert len(ev1.split_reads[0]) == 0
+        assert len(ev1.split_reads[1]) == 0
+        assert len(ev1.flanking_pairs) == 0
 
 
-class TestEvidenceGathering(unittest.TestCase):
-    def setUp(self):
-        # test loading of evidence for event found on reference3 1114 2187
-        self.ev1 = GenomeEvidence(
-            Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
-            Breakpoint('reference3', 2187, orient=ORIENT.RIGHT),
-            BAM_CACHE,
-            REFERENCE_GENOME,
-            opposing_strands=True,
-            read_length=125,
-            stdev_fragment_size=100,
-            median_fragment_size=380,
-            config={
-                'validate.stdev_count_abnormal': 3,
-                'validate.min_flanking_pairs_resolution': 3,
-                'validate.assembly_min_edge_trim_weight': 3,
-            },
-        )
+@pytest.fixture
+def ev_gathering_setup():
+    return GenomeEvidence(
+        Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
+        Breakpoint('reference3', 2187, orient=ORIENT.RIGHT),
+        BAM_CACHE,
+        REFERENCE_GENOME,
+        opposing_strands=True,
+        read_length=125,
+        stdev_fragment_size=100,
+        median_fragment_size=380,
+        config={
+            'validate.stdev_count_abnormal': 3,
+            'validate.min_flanking_pairs_resolution': 3,
+            'validate.assembly_min_edge_trim_weight': 3,
+        },
+    )
 
-    def test_collect_split_read(self):
+
+class TestEvidenceGathering:
+    def test_collect_split_read(self, ev_gathering_setup):
         ev1_sr = MockRead(
             query_name='HISEQX1_11:3:1105:15351:25130:split',
             reference_id=1,
@@ -589,10 +587,10 @@ class TestEvidenceGathering(unittest.TestCase):
             next_reference_id=1,
             next_reference_start=2341,
         )
-        self.ev1.collect_split_read(ev1_sr, True)
-        self.assertEqual(ev1_sr, list(self.ev1.split_reads[0])[0])
+        ev_gathering_setup.collect_split_read(ev1_sr, True)
+        assert list(ev_gathering_setup.split_reads[0])[0] == ev1_sr
 
-    def test_collect_split_read_failure(self):
+    def test_collect_split_read_failure(self, ev_gathering_setup):
         # wrong cigar string
         ev1_sr = MockRead(
             query_name='HISEQX1_11:4:1203:3062:55280:split',
@@ -607,10 +605,10 @@ class TestEvidenceGathering(unittest.TestCase):
             next_reference_id=1,
             next_reference_start=2550,
         )
-        self.assertFalse(self.ev1.collect_split_read(ev1_sr, True))
+        assert not ev_gathering_setup.collect_split_read(ev1_sr, True)
 
-    def test_collect_flanking_pair(self):
-        self.ev1.collect_flanking_pair(
+    def test_collect_flanking_pair(self, ev_gathering_setup):
+        ev_gathering_setup.collect_flanking_pair(
             MockRead(
                 reference_id=1,
                 reference_start=2214,
@@ -631,47 +629,45 @@ class TestEvidenceGathering(unittest.TestCase):
                 is_read1=False,
             ),
         )
-        self.assertEqual(1, len(self.ev1.flanking_pairs))
+        assert len(ev_gathering_setup.flanking_pairs) == 1
 
-    def test_collect_flanking_pair_not_overlapping_evidence_window(self):
+    def test_collect_flanking_pair_not_overlapping_evidence_window(self, ev_gathering_setup):
         # first read in pair does not overlap the first evidence window
         # therefore this should return False and not add to the flanking_pairs
         pair = mock_read_pair(
             MockRead(reference_id=1, reference_start=1903, reference_end=2053, is_reverse=True),
             MockRead(reference_id=1, reference_start=2052, reference_end=2053, is_reverse=True),
         )
-        self.assertFalse(self.ev1.collect_flanking_pair(*pair))
-        self.assertEqual(0, len(self.ev1.flanking_pairs))
+        assert not ev_gathering_setup.collect_flanking_pair(*pair)
+        assert len(ev_gathering_setup.flanking_pairs) == 0
 
-    #    @unittest.skip("demonstrating skipping")
-    def test_load_evidence(self):
-        print(self.ev1)
-        self.ev1.load_evidence()
-        print(self.ev1.spanning_reads)
-        self.assertEqual(
-            2,
+    def test_load_evidence(self, ev_gathering_setup):
+        print(ev_gathering_setup)
+        ev_gathering_setup.load_evidence()
+        print(ev_gathering_setup.spanning_reads)
+        assert (
             len(
                 [
                     r
-                    for r in self.ev1.split_reads[0]
+                    for r in ev_gathering_setup.split_reads[0]
                     if not r.has_tag(PYSAM_READ_FLAGS.TARGETED_ALIGNMENT)
                 ]
-            ),
+            )
+            == 2
         )
-        self.assertEqual(7, len(self.ev1.flanking_pairs))
-        self.assertEqual(
-            2,
+        assert len(ev_gathering_setup.flanking_pairs) == 7
+        assert (
             len(
                 [
                     r
-                    for r in self.ev1.split_reads[1]
+                    for r in ev_gathering_setup.split_reads[1]
                     if not r.has_tag(PYSAM_READ_FLAGS.TARGETED_ALIGNMENT)
                 ]
-            ),
+            )
+            == 2
         )
 
-    #    @unittest.skip("demonstrating skipping")
-    def test_assemble_split_reads(self):
+    def test_assemble_split_reads(self, ev_gathering_setup):
         sr1 = MockRead(
             query_name='HISEQX1_11:3:1105:15351:25130:split',
             query_sequence='TCGTGAGTGGCAGGTGCCATCGTGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTG',
@@ -709,23 +705,23 @@ class TestEvidenceGathering(unittest.TestCase):
             query_sequence='CTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTGGTTATGAAATTTCAGGGTTTTCATTTCTGTATGTT',
             flag=113,
         )
-        self.ev1.split_reads = (
+        ev_gathering_setup.split_reads = (
             {sr1},
             {sr1, sr3, sr7, sr9, sr12, sr15, sr19, sr24},
         )  # subset needed to make a contig
-        #        self.ev1.split_reads=([],[sr1,sr3,sr5,sr6,sr7,sr8,sr9,sr10,sr11,sr12,sr13,sr14,sr15,sr16,sr17,sr18,sr19,sr20,sr21,sr22,sr23,sr24]) #full set of reads produces different contig from subset.
+        #        ev_gathering_setup.split_reads=([],[sr1,sr3,sr5,sr6,sr7,sr8,sr9,sr10,sr11,sr12,sr13,sr14,sr15,sr16,sr17,sr18,sr19,sr20,sr21,sr22,sr23,sr24]) #full set of reads produces different contig from subset.
         # full contig with more read support should be
         # CTGAGCATGAAAGCCCTGTAAACACAGAATTTGGATTCTTTCCTGTTTGGTTCCTGGTCGTGAGTGGCAGGTGCCATCATGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTGGTTATGAAATTTCAGGGTTTTCATTTCTGTATGTTAAT
-        self.ev1.half_mapped = (set(), {sr2})
-        self.ev1.assemble_contig()
-        print(self.ev1.contigs)
+        ev_gathering_setup.half_mapped = (set(), {sr2})
+        ev_gathering_setup.assemble_contig()
+        print(ev_gathering_setup.contigs)
         exp = 'CAACAATATGTAGGAAGCCATTATCTGAAGTGTAAGCAACTGCATAGTGCTATTTTAATTATGCATTGCAGGGAAACTGTGAGCAGAGCTATATATTTAGGTAGACTGCTCTCAGGCAGAATGAAACATGATGGCACCTGCCACTCACGACCAGGAACCAAACAGGAAAGAATC'
-        self.assertEqual(exp, self.ev1.contigs[0].seq)
+        assert ev_gathering_setup.contigs[0].seq == exp
 
 
-class TestStandardizeRead(unittest.TestCase):
-    def setUp(self):
-        self.mock_evidence = MockObject(
+class TestStandardizeRead:
+    def test_bwa_mem(self):
+        mock_evidence = MockObject(
             reference_genome={
                 '1': MockObject(
                     seq=MockLongString(
@@ -749,8 +745,6 @@ class TestStandardizeRead(unittest.TestCase):
                 **DEFAULTS,
             },
         )
-
-    def test_bwa_mem(self):
         # SamRead(1:224646710-224646924, 183=12D19=, TCAGCTCTCT...) TCAGCTCTCTTAGGGCACACCCTCCAAGGTGCCTAAATGCCATCCCAGGATTGGTTCCAGTGTCTATTATCTGTTTGACTCCAAATGGCCAAACACCTGACTTCCTCTCTGGTAGCCTGGCTTTTATCTTCTAGGACATCCAGGGCCCCTCTCTTTGCCTTCCCCTCTTTCTTCCTTCTACTGCTTCAGCAGACATCATGTG
         # std SamRead(1:224646710-224646924, 183=12D19=, TCAGCTCTCT...) TCAGCTCTCTTAGGGCACACCCTCCAAGGTGCCTAAATGCCATCCCAGGATTGGTTCCAGTGTCTATTATCTGTTTGACTCCAAATGGCCAAACACCTGACTTCCTCTCTGGTAGCCTGGCTTTTATCTTCTAGGACATCCAGGGCCCCTCTCTTTGCCTTCCCCTCTTTCTTCCTTCTACTGCTTCAGCAGACATCATGTG
         # > BPP(Breakpoint(1:224646893L-), Breakpoint(1:224646906R-), opposing=False, seq='')
@@ -762,17 +756,11 @@ class TestStandardizeRead(unittest.TestCase):
         read.cigar = _cigar.join(_cigar.convert_string_to_cigar('183=12D19='))
         read.query_name = 'name'
         read.mapping_quality = NA_MAPPING_QUALITY
-        std_read = Evidence.standardize_read(self.mock_evidence, read)
-        print(SamRead.__repr__(read))
-        print(SamRead.__repr__(std_read))
-        self.assertEqual(_cigar.convert_string_to_cigar('186=12D16='), std_read.cigar)
-        self.assertEqual(read.reference_start, std_read.reference_start)
+        std_read = Evidence.standardize_read(mock_evidence, read)
+        assert std_read.cigar == _cigar.convert_string_to_cigar('186=12D16=')
+        assert std_read.reference_start == read.reference_start
 
 
 class MockEvidence:
     def __init__(self, ref=None):
         self.HUMAN_REFERENCE_GENOME = ref
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/integration/test_validate_call.py
+++ b/tests/integration/test_validate_call.py
@@ -1,6 +1,6 @@
-import unittest
 from unittest import mock
 
+import pytest
 from mavis.align import call_paired_read_event, select_contig_alignments
 from mavis.annotate.file_io import load_reference_genome
 from mavis.annotate.genomic import PreTranscript, Transcript
@@ -15,7 +15,7 @@ from mavis.validate import call
 from mavis.validate.base import Evidence
 from mavis.validate.evidence import GenomeEvidence, TranscriptomeEvidence
 
-from ..util import get_data
+from ..util import get_data, todo
 from . import MockBamFileHandle, MockLongString, MockRead, get_example_genes, mock_read_pair
 
 REFERENCE_GENOME = None
@@ -52,7 +52,7 @@ def tearDownModule():
     mock.patch.stopall()
 
 
-class TestCallByContig(unittest.TestCase):
+class TestCallByContig:
     def test_EGFR_small_del_transcriptome(self):
         gene = get_example_genes()['EGFR']
         reference_annotations = {gene.chr: [gene]}
@@ -93,35 +93,14 @@ class TestCallByContig(unittest.TestCase):
         for ev in events:
             print(ev)
             print(evidence.distance(ev.break1.start, ev.break2.start))
-        self.assertEqual(1, len(events))
-        self.assertEqual(Breakpoint('7', 55242465, orient='L', strand='+'), events[0].break1)
-        self.assertEqual(Breakpoint('7', 55242481, orient='R', strand='+'), events[0].break2)
+        assert len(events) == 1
+        assert events[0].break1 == Breakpoint('7', 55242465, orient='L', strand='+')
+        assert events[0].break2 == Breakpoint('7', 55242481, orient='R', strand='+')
         print(events[0].contig_alignment.score())
-        self.assertTrue(events[0].contig_alignment.score() > 0.99)
+        assert events[0].contig_alignment.score() > 0.99
 
 
-class TestEventCall(unittest.TestCase):
-    def setUp(self):
-        self.ev1 = GenomeEvidence(
-            Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
-            Breakpoint('reference3', 2187, orient=ORIENT.RIGHT),
-            BAM_CACHE,
-            REFERENCE_GENOME,
-            opposing_strands=True,
-            read_length=125,
-            stdev_fragment_size=100,
-            median_fragment_size=380,
-            stdev_count_abnormal=3,
-            min_flanking_pairs_resolution=3,
-        )
-        self.ev = call.EventCall(
-            Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
-            Breakpoint('reference3', 2187, orient=ORIENT.RIGHT),
-            source_evidence=self.ev1,
-            event_type=SVTYPE.INV,
-            call_method=CALL_METHOD.SPLIT,
-        )
-
+class TestEventCall:
     def test_bad_deletion(self):
         evidence = GenomeEvidence(
             Breakpoint('reference3', 16, orient='L'),
@@ -132,7 +111,7 @@ class TestEventCall(unittest.TestCase):
             stdev_fragment_size=100,
             median_fragment_size=380,
         )
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             call.EventCall(
                 Breakpoint('reference3', 43, orient='L'),
                 Breakpoint('reference3', 44, orient='R'),
@@ -142,12 +121,49 @@ class TestEventCall(unittest.TestCase):
             )
 
     def test_flanking_support_empty(self):
-        self.assertEqual(0, len(self.ev.flanking_pairs))
+
+        ev = call.EventCall(
+            Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
+            Breakpoint('reference3', 2187, orient=ORIENT.RIGHT),
+            source_evidence=GenomeEvidence(
+                Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
+                Breakpoint('reference3', 2187, orient=ORIENT.RIGHT),
+                BAM_CACHE,
+                REFERENCE_GENOME,
+                opposing_strands=True,
+                read_length=125,
+                stdev_fragment_size=100,
+                median_fragment_size=380,
+                stdev_count_abnormal=3,
+                min_flanking_pairs_resolution=3,
+            ),
+            event_type=SVTYPE.INV,
+            call_method=CALL_METHOD.SPLIT,
+        )
+        assert len(ev.flanking_pairs) == 0
 
     def test_flanking_support(self):
         # 1114 ++
         # 2187 ++
-        self.ev.flanking_pairs.add(
+        ev = call.EventCall(
+            Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
+            Breakpoint('reference3', 2187, orient=ORIENT.RIGHT),
+            source_evidence=GenomeEvidence(
+                Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
+                Breakpoint('reference3', 2187, orient=ORIENT.RIGHT),
+                BAM_CACHE,
+                REFERENCE_GENOME,
+                opposing_strands=True,
+                read_length=125,
+                stdev_fragment_size=100,
+                median_fragment_size=380,
+                stdev_count_abnormal=3,
+                min_flanking_pairs_resolution=3,
+            ),
+            event_type=SVTYPE.INV,
+            call_method=CALL_METHOD.SPLIT,
+        )
+        ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     query_name='test1',
@@ -160,7 +176,7 @@ class TestEventCall(unittest.TestCase):
                 MockRead(reference_id=3, reference_start=2200, reference_end=2250, is_reverse=True),
             )
         )
-        self.ev.flanking_pairs.add(
+        ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     query_name='test2',
@@ -173,36 +189,53 @@ class TestEventCall(unittest.TestCase):
                 MockRead(reference_id=3, reference_start=2200, reference_end=2250, is_reverse=True),
             )
         )
-        median, stdev = self.ev.flanking_metrics()
-        self.assertEqual(2, len(self.ev.flanking_pairs))
-        self.assertEqual(530, median)
-        self.assertEqual(30, stdev)
+        median, stdev = ev.flanking_metrics()
+        assert len(ev.flanking_pairs) == 2
+        assert median == 530
+        assert stdev == 30
 
     def test_split_read_support_empty(self):
-        self.assertEqual(0, len(self.ev.break1_split_reads) + len(self.ev.break2_split_reads))
+        ev = call.EventCall(
+            Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
+            Breakpoint('reference3', 2187, orient=ORIENT.RIGHT),
+            source_evidence=GenomeEvidence(
+                Breakpoint('reference3', 1114, orient=ORIENT.RIGHT),
+                Breakpoint('reference3', 2187, orient=ORIENT.RIGHT),
+                BAM_CACHE,
+                REFERENCE_GENOME,
+                opposing_strands=True,
+                read_length=125,
+                stdev_fragment_size=100,
+                median_fragment_size=380,
+                stdev_count_abnormal=3,
+                min_flanking_pairs_resolution=3,
+            ),
+            event_type=SVTYPE.INV,
+            call_method=CALL_METHOD.SPLIT,
+        )
+        assert len(ev.break1_split_reads) + len(ev.break2_split_reads) == 0
 
+    @todo
     def test_call_by_split_delins_del_only(self):
-        raise unittest.SkipTest('TODO')
+        pass
 
+    @todo
     def test_call_by_split_delins_both(self):
-        raise unittest.SkipTest('TODO')
+        pass
 
+    @todo
     def test_call_by_split_delins_ins_only(self):
         # not implemented yet??
-        raise unittest.SkipTest('TODO')
+        pass
 
 
-class TestPullFlankingSupport(unittest.TestCase):
-    def setUp(self):
-        self.bam_cache = BamCache(MockBamFileHandle({'1': 0, '2': 1}))
-        self.REFERENCE_GENOME = None
-
+class TestPullFlankingSupport:
     def build_genome_evidence(self, b1, b2, opposing_strands=False):
         evidence = GenomeEvidence(
             b1,
             b2,
-            self.bam_cache,
-            self.REFERENCE_GENOME,
+            BamCache(MockBamFileHandle({'1': 0, '2': 1})),
+            None,
             opposing_strands=opposing_strands,
             read_length=100,
             median_fragment_size=500,
@@ -230,7 +263,7 @@ class TestPullFlankingSupport(unittest.TestCase):
         )
 
         event.add_flanking_support(flanking_pairs)
-        self.assertEqual(1, len(event.flanking_pairs))
+        assert len(event.flanking_pairs) == 1
 
         # now test one where the read pair type is right but the positioning of the reads doesn't
         # support the current call
@@ -241,7 +274,7 @@ class TestPullFlankingSupport(unittest.TestCase):
             )
         )
         event.add_flanking_support(flanking_pairs)
-        self.assertEqual(1, len(event.flanking_pairs))
+        assert len(event.flanking_pairs) == 1
 
     def test_small_deletion_flanking_for_larger_deletion(self):
         evidence = self.build_genome_evidence(
@@ -262,7 +295,7 @@ class TestPullFlankingSupport(unittest.TestCase):
         )
 
         event.add_flanking_support(flanking_pairs)
-        self.assertEqual(0, len(event.flanking_pairs))
+        assert len(event.flanking_pairs) == 0
 
     def test_insertion(self):
         evidence = self.build_genome_evidence(
@@ -283,7 +316,7 @@ class TestPullFlankingSupport(unittest.TestCase):
             CALL_METHOD.SPLIT,
         )
         event.add_flanking_support(flanking_pairs)
-        self.assertEqual(1, len(event.flanking_pairs))
+        assert len(event.flanking_pairs) == 1
 
     def test_inversion(self):
         evidence = self.build_genome_evidence(
@@ -306,7 +339,7 @@ class TestPullFlankingSupport(unittest.TestCase):
         )
 
         event.add_flanking_support(flanking_pairs)
-        self.assertEqual(1, len(event.flanking_pairs))
+        assert len(event.flanking_pairs) == 1
 
         # test read that is the right type but the positioning does not support the current call
         flanking_pairs.append(
@@ -316,7 +349,7 @@ class TestPullFlankingSupport(unittest.TestCase):
             )
         )
         event.add_flanking_support(flanking_pairs)
-        self.assertEqual(1, len(event.flanking_pairs))
+        assert len(event.flanking_pairs) == 1
 
     def test_inverted_translocation(self):
         evidence = self.build_genome_evidence(
@@ -338,7 +371,7 @@ class TestPullFlankingSupport(unittest.TestCase):
             CALL_METHOD.SPLIT,
         )
         event.add_flanking_support(flanking_pairs)
-        self.assertEqual(1, len(event.flanking_pairs))
+        assert len(event.flanking_pairs) == 1
 
     def test_translocation_rl(self):
         b1 = Breakpoint('11', 128675261, orient=ORIENT.RIGHT, strand=STRAND.POS)
@@ -372,7 +405,7 @@ class TestPullFlankingSupport(unittest.TestCase):
             ),
         ]
         event.add_flanking_support(flanking_pairs)
-        self.assertEqual(len(flanking_pairs), len(event.flanking_pairs))
+        assert len(event.flanking_pairs) == len(flanking_pairs)
 
     def test_translocation_rl_filter_nonsupporting(self):
         evidence = self.build_genome_evidence(
@@ -393,7 +426,7 @@ class TestPullFlankingSupport(unittest.TestCase):
         )
 
         event.add_flanking_support(flanking_pairs)
-        self.assertEqual(1, len(event.flanking_pairs))
+        assert len(event.flanking_pairs) == 1
 
         # test read that is the right type but the positioning does not support the current call
         # the mate is on the wrong chromosome (not sure if this would actually be added as flanking support)
@@ -404,7 +437,7 @@ class TestPullFlankingSupport(unittest.TestCase):
             )
         )
         event.add_flanking_support(flanking_pairs)
-        self.assertEqual(1, len(event.flanking_pairs))
+        assert len(event.flanking_pairs) == 1
 
     def test_duplication(self):
         evidence = self.build_genome_evidence(
@@ -427,23 +460,20 @@ class TestPullFlankingSupport(unittest.TestCase):
         )
 
         event.add_flanking_support(flanking_pairs)
-        self.assertEqual(1, len(event.flanking_pairs))
+        assert len(event.flanking_pairs) == 1
 
+    @todo
     def test_outside_call_range(self):
-        raise unittest.SkipTest('TODO')
+        pass
 
 
-class TestEvidenceConsumption(unittest.TestCase):
-    def setUp(self):
-        self.bam_cache = BamCache(MockBamFileHandle({'1': 0, '2': 1}))
-        self.REFERENCE_GENOME = None
-
+class TestEvidenceConsumption:
     def build_genome_evidence(self, b1, b2, opposing_strands=False):
         evidence = GenomeEvidence(
             b1,
             b2,
-            self.bam_cache,
-            self.REFERENCE_GENOME,
+            BamCache(MockBamFileHandle({'1': 0, '2': 1})),
+            None,
             opposing_strands=opposing_strands,
             read_length=100,
             median_fragment_size=200,
@@ -551,25 +581,25 @@ class TestEvidenceConsumption(unittest.TestCase):
         events = call.call_events(evidence)
         for ev in events:
             print(ev, ev.event_type, ev.call_method)
-        self.assertEqual(4, len(events))
-        self.assertEqual('contig', events[0].call_method)
-        self.assertEqual(100, events[0].break1.start)
-        self.assertEqual(481, events[0].break2.start)
-        self.assertEqual('deletion', events[0].event_type)
-        self.assertEqual('split reads', events[1].call_method)
-        self.assertEqual(120, events[1].break1.start)
-        self.assertEqual(501, events[1].break2.start)
-        self.assertEqual('deletion', events[1].event_type)
-        self.assertEqual('flanking reads', events[2].call_method)
-        self.assertEqual(90, events[2].break1.start)
-        self.assertEqual(299, events[2].break1.end)
-        self.assertEqual(591, events[2].break2.start)
-        self.assertEqual(806, events[2].break2.end)
-        self.assertEqual('deletion', events[2].event_type)
-        self.assertEqual('split reads', events[3].call_method)
-        self.assertEqual(120, events[3].break1.start)
-        self.assertEqual(501, events[3].break2.start)
-        self.assertEqual('insertion', events[3].event_type)
+        assert len(events) == 4
+        assert events[0].call_method == 'contig'
+        assert events[0].break1.start == 100
+        assert events[0].break2.start == 481
+        assert events[0].event_type == 'deletion'
+        assert events[1].call_method == 'split reads'
+        assert events[1].break1.start == 120
+        assert events[1].break2.start == 501
+        assert events[1].event_type == 'deletion'
+        assert events[2].call_method == 'flanking reads'
+        assert events[2].break1.start == 90
+        assert events[2].break1.end == 299
+        assert events[2].break2.start == 591
+        assert events[2].break2.end == 806
+        assert events[2].event_type == 'deletion'
+        assert events[3].call_method == 'split reads'
+        assert events[3].break1.start == 120
+        assert events[3].break2.start == 501
+        assert events[3].event_type == 'insertion'
 
     def test_call_contig_only(self):
         # event should only be 100L+, 501R+ deletion
@@ -660,10 +690,10 @@ class TestEvidenceConsumption(unittest.TestCase):
         events = call.call_events(evidence)
         for ev in events:
             print(ev, ev.event_type, ev.call_method)
-        self.assertEqual(1, len(events))
-        self.assertEqual(100, events[0].break1.start)
-        self.assertEqual(501, events[0].break2.start)
-        self.assertEqual('contig', events[0].call_method)
+        assert len(events) == 1
+        assert events[0].break1.start == 100
+        assert events[0].break2.start == 501
+        assert events[0].call_method == 'contig'
 
     def test_call_contig_and_split(self):
         # contig breakpoint is 100L 501R, split reads is 120L 521R
@@ -748,17 +778,17 @@ class TestEvidenceConsumption(unittest.TestCase):
         events = call.call_events(evidence)
         for ev in events:
             print(ev, ev.event_type, ev.call_method)
-        self.assertEqual(3, len(events))
-        self.assertEqual(100, events[0].break1.start)
-        self.assertEqual(501, events[0].break2.start)
-        self.assertEqual('contig', events[0].call_method)
-        self.assertEqual('split reads', events[1].call_method)
-        self.assertEqual(120, events[1].break1.start)
-        self.assertEqual(521, events[1].break2.start)
-        self.assertEqual('insertion', events[2].event_type)
-        self.assertEqual('split reads', events[2].call_method)
-        self.assertEqual(120, events[2].break1.start)
-        self.assertEqual(521, events[2].break2.start)
+        assert len(events) == 3
+        assert events[0].break1.start == 100
+        assert events[0].break2.start == 501
+        assert events[0].call_method == 'contig'
+        assert events[1].call_method == 'split reads'
+        assert events[1].break1.start == 120
+        assert events[1].break2.start == 521
+        assert events[2].event_type == 'insertion'
+        assert events[2].call_method == 'split reads'
+        assert events[2].break1.start == 120
+        assert events[2].break2.start == 521
 
     def test_call_split_only(self):
         evidence = self.build_genome_evidence(
@@ -795,14 +825,14 @@ class TestEvidenceConsumption(unittest.TestCase):
         events = call.call_events(evidence)
         for ev in events:
             print(ev, ev.event_type, ev.call_method)
-        self.assertEqual(2, len(events))
-        self.assertEqual(170, events[0].break1.start)
-        self.assertEqual(871, events[0].break2.start)
-        self.assertEqual('split reads', events[0].call_method)
-        self.assertEqual('split reads', events[1].call_method)
-        self.assertEqual(170, events[1].break1.start)
-        self.assertEqual(871, events[1].break2.start)
-        self.assertEqual('insertion', events[1].event_type)
+        assert len(events) == 2
+        assert events[0].break1.start == 170
+        assert events[0].break2.start == 871
+        assert events[0].call_method == 'split reads'
+        assert events[1].call_method == 'split reads'
+        assert events[1].break1.start == 170
+        assert events[1].break2.start == 871
+        assert events[1].event_type == 'insertion'
 
     def test_call_flanking_only(self):
         evidence = self.build_genome_evidence(
@@ -833,70 +863,76 @@ class TestEvidenceConsumption(unittest.TestCase):
         events = call.call_events(evidence)
         for ev in events:
             print(ev, ev.event_type, ev.call_method)
-        self.assertEqual(1, len(events))
-        self.assertEqual(140, events[0].break1.start)
-        self.assertEqual(292, events[0].break1.end)
-        self.assertEqual('flanking reads', events[0].call_method)
-        self.assertEqual(656, events[0].break2.start)
-        self.assertEqual(886, events[0].break2.end)
+        assert len(events) == 1
+        assert events[0].break1.start == 140
+        assert events[0].break1.end == 292
+        assert events[0].call_method == 'flanking reads'
+        assert events[0].break2.start == 656
+        assert events[0].break2.end == 886
 
 
-class TestCallBySupportingReads(unittest.TestCase):
-    def setUp(self):
-        self.ev = GenomeEvidence(
-            Breakpoint('fake', 50, 150, orient=ORIENT.RIGHT),
-            Breakpoint('fake', 450, 550, orient=ORIENT.RIGHT),
-            BamCache(MockBamFileHandle()),
-            None,
-            opposing_strands=True,
-            read_length=40,
-            stdev_fragment_size=25,
-            median_fragment_size=100,
-            config={
-                'validate.stdev_count_abnormal': 2,
-                'validate.min_splits_reads_resolution': 1,
-                'validate.min_flanking_pairs_resolution': 1,
-                'validate.min_linking_split_reads': 1,
-                'validate.min_spanning_reads_resolution': 3,
-                'validate. min_call_complexity': 0,
-            },
-        )
-        self.dup = GenomeEvidence(
-            Breakpoint('fake', 50, orient=ORIENT.RIGHT),
-            Breakpoint('fake', 90, orient=ORIENT.LEFT),
-            BamCache(MockBamFileHandle()),
-            None,
-            opposing_strands=False,
-            read_length=40,
-            stdev_fragment_size=25,
-            median_fragment_size=100,
-            config={
-                'validate.stdev_count_abnormal': 2,
-                'validate.min_splits_reads_resolution': 1,
-                'validate.min_flanking_pairs_resolution': 1,
-                'validate.min_linking_split_reads': 1,
-                'validate.min_spanning_reads_resolution': 3,
-                'validate. min_call_complexity': 0,
-            },
-        )
+@pytest.fixture
+def duplication_ev():
+    return GenomeEvidence(
+        Breakpoint('fake', 50, orient=ORIENT.RIGHT),
+        Breakpoint('fake', 90, orient=ORIENT.LEFT),
+        BamCache(MockBamFileHandle()),
+        None,
+        opposing_strands=False,
+        read_length=40,
+        stdev_fragment_size=25,
+        median_fragment_size=100,
+        config={
+            'validate.stdev_count_abnormal': 2,
+            'validate.min_splits_reads_resolution': 1,
+            'validate.min_flanking_pairs_resolution': 1,
+            'validate.min_linking_split_reads': 1,
+            'validate.min_spanning_reads_resolution': 3,
+            'validate. min_call_complexity': 0,
+        },
+    )
 
-    def test_empty(self):
-        with self.assertRaises(AssertionError):
-            bpp = call._call_by_flanking_pairs(self.ev, SVTYPE.INV)[0]
 
-    def test_call_no_duplication_by_split_reads(self):
-        self.dup.split_reads[0].add(
+@pytest.fixture
+def inversion_evidence():
+    return GenomeEvidence(
+        Breakpoint('fake', 50, 150, orient=ORIENT.RIGHT),
+        Breakpoint('fake', 450, 550, orient=ORIENT.RIGHT),
+        BamCache(MockBamFileHandle()),
+        None,
+        opposing_strands=True,
+        read_length=40,
+        stdev_fragment_size=25,
+        median_fragment_size=100,
+        config={
+            'validate.stdev_count_abnormal': 2,
+            'validate.min_splits_reads_resolution': 1,
+            'validate.min_flanking_pairs_resolution': 1,
+            'validate.min_linking_split_reads': 1,
+            'validate.min_spanning_reads_resolution': 3,
+            'validate. min_call_complexity': 0,
+        },
+    )
+
+
+class TestCallBySupportingReads:
+    def test_empty(self, inversion_evidence):
+        with pytest.raises(AssertionError):
+            call._call_by_flanking_pairs(inversion_evidence, SVTYPE.INV)[0]
+
+    def test_call_no_duplication_by_split_reads(self, duplication_ev, inversion_evidence):
+        duplication_ev.split_reads[0].add(
             MockRead(query_name='t1', reference_start=30, cigar=[(CIGAR.EQ, 20), (CIGAR.S, 20)])
         )
-        self.dup.split_reads[1].add(
+        duplication_ev.split_reads[1].add(
             MockRead(query_name='t1', reference_start=90, cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)])
         )
 
-        bpps = call._call_by_split_reads(self.ev, SVTYPE.DUP)
-        self.assertEqual(0, len(bpps))
+        bpps = call._call_by_split_reads(inversion_evidence, SVTYPE.DUP)
+        assert len(bpps) == 0
 
-    def test_by_split_read(self):
-        self.ev.split_reads[0].add(
+    def test_by_split_read(self, inversion_evidence):
+        inversion_evidence.split_reads[0].add(
             MockRead(
                 query_name='t1',
                 reference_start=100,
@@ -904,7 +940,7 @@ class TestCallBySupportingReads(unittest.TestCase):
                 query_sequence='A' * 40,
             )
         )
-        self.ev.split_reads[1].add(
+        inversion_evidence.split_reads[1].add(
             MockRead(
                 query_name='t1',
                 reference_start=500,
@@ -912,7 +948,7 @@ class TestCallBySupportingReads(unittest.TestCase):
                 query_sequence='G' * 40,
             )
         )
-        self.ev.split_reads[0].add(
+        inversion_evidence.split_reads[0].add(
             MockRead(
                 query_name='t2',
                 reference_start=100,
@@ -920,7 +956,7 @@ class TestCallBySupportingReads(unittest.TestCase):
                 query_sequence='C' * 40,
             )
         )
-        self.ev.split_reads[1].add(
+        inversion_evidence.split_reads[1].add(
             MockRead(
                 query_name='t2',
                 reference_start=500,
@@ -929,17 +965,17 @@ class TestCallBySupportingReads(unittest.TestCase):
             )
         )
 
-        events = call._call_by_split_reads(self.ev, SVTYPE.INV)
-        self.assertEqual(1, len(events))
+        events = call._call_by_split_reads(inversion_evidence, SVTYPE.INV)
+        assert len(events) == 1
         event = events[0]
-        self.assertEqual(4, len(event.support()))
-        self.assertEqual(101, event.break1.start)
-        self.assertEqual(101, event.break1.end)
-        self.assertEqual(501, event.break2.start)
-        self.assertEqual(501, event.break2.end)
+        assert len(event.support()) == 4
+        assert event.break1.start == 101
+        assert event.break1.end == 101
+        assert event.break2.start == 501
+        assert event.break2.end == 501
 
-    def test_call_by_split_read_low_resolution(self):
-        self.ev.split_reads[0].add(
+    def test_call_by_split_read_low_resolution(self, inversion_evidence):
+        inversion_evidence.split_reads[0].add(
             MockRead(
                 query_name='t1',
                 reference_start=100,
@@ -947,7 +983,7 @@ class TestCallBySupportingReads(unittest.TestCase):
                 query_sequence='A' * 40,
             )
         )
-        self.ev.split_reads[1].add(
+        inversion_evidence.split_reads[1].add(
             MockRead(
                 query_name='t1',
                 reference_start=500,
@@ -956,17 +992,17 @@ class TestCallBySupportingReads(unittest.TestCase):
             )
         )
 
-        bpp = call._call_by_split_reads(self.ev, SVTYPE.INV)
-        self.assertEqual(1, len(bpp))
+        bpp = call._call_by_split_reads(inversion_evidence, SVTYPE.INV)
+        assert len(bpp) == 1
         bpp = bpp[0]
 
-        self.assertEqual(101, bpp.break1.start)
-        self.assertEqual(101, bpp.break1.end)
-        self.assertEqual(501, bpp.break2.start)
-        self.assertEqual(501, bpp.break2.end)
+        assert bpp.break1.start == 101
+        assert bpp.break1.end == 101
+        assert bpp.break2.start == 501
+        assert bpp.break2.end == 501
 
-    def test_call_by_split_read_resolve_untemp(self):
-        self.ev.split_reads[0].add(
+    def test_call_by_split_read_resolve_untemp(self, inversion_evidence):
+        inversion_evidence.split_reads[0].add(
             MockRead(
                 query_name='t1',
                 reference_start=100,
@@ -974,7 +1010,7 @@ class TestCallBySupportingReads(unittest.TestCase):
                 query_sequence='TCGGCTCCCGTACTTGTGTATAAGGGGCTTCTGATGTTAT',
             )
         )
-        self.ev.split_reads[1].add(
+        inversion_evidence.split_reads[1].add(
             MockRead(
                 query_name='t1',
                 reference_start=500,
@@ -984,16 +1020,16 @@ class TestCallBySupportingReads(unittest.TestCase):
             )
         )
 
-        event = call._call_by_split_reads(self.ev, SVTYPE.INV)[0]
+        event = call._call_by_split_reads(inversion_evidence, SVTYPE.INV)[0]
 
-        self.assertEqual(101, event.break1.start)
-        self.assertEqual(101, event.break1.end)
-        self.assertEqual(501, event.break2.start)
-        self.assertEqual(501, event.break2.end)
-        self.assertEqual('', event.untemplated_seq)
+        assert event.break1.start == 101
+        assert event.break1.end == 101
+        assert event.break2.start == 501
+        assert event.break2.end == 501
+        assert event.untemplated_seq == ''
 
-    def test_call_by_split_read_resolve_untemp_exists(self):
-        self.ev.split_reads[0].add(
+    def test_call_by_split_read_resolve_untemp_exists(self, inversion_evidence):
+        inversion_evidence.split_reads[0].add(
             MockRead(
                 query_name='t1',
                 reference_start=100,
@@ -1001,7 +1037,7 @@ class TestCallBySupportingReads(unittest.TestCase):
                 query_sequence='TCGGCTCCCGTACTTGTGTATAAGGGGCTTCTGATGTTAT',
             )
         )
-        self.ev.split_reads[1].add(
+        inversion_evidence.split_reads[1].add(
             MockRead(
                 query_name='t1',
                 reference_start=500,
@@ -1011,16 +1047,16 @@ class TestCallBySupportingReads(unittest.TestCase):
             )
         )
 
-        event = call._call_by_split_reads(self.ev, SVTYPE.INV)[0]
+        event = call._call_by_split_reads(inversion_evidence, SVTYPE.INV)[0]
 
-        self.assertEqual(101, event.break1.start)
-        self.assertEqual(101, event.break1.end)
-        self.assertEqual(501, event.break2.start)
-        self.assertEqual(501, event.break2.end)
-        self.assertEqual('TA', event.untemplated_seq)
+        assert event.break1.start == 101
+        assert event.break1.end == 101
+        assert event.break2.start == 501
+        assert event.break2.end == 501
+        assert event.untemplated_seq == 'TA'
 
-    def test_call_by_split_read_shift_overlap(self):
-        self.ev.split_reads[0].add(
+    def test_call_by_split_read_shift_overlap(self, inversion_evidence):
+        inversion_evidence.split_reads[0].add(
             MockRead(
                 query_name='t1',
                 reference_start=100,
@@ -1028,7 +1064,7 @@ class TestCallBySupportingReads(unittest.TestCase):
                 query_sequence='TCGGCTCCCGTACTTGTGTATAAGGGGCTTCTGATGTTAT',
             )
         )
-        self.ev.split_reads[1].add(
+        inversion_evidence.split_reads[1].add(
             MockRead(
                 query_name='t1',
                 reference_start=500,
@@ -1038,37 +1074,37 @@ class TestCallBySupportingReads(unittest.TestCase):
             )
         )
 
-        event = call._call_by_split_reads(self.ev, SVTYPE.INV)[0]
+        event = call._call_by_split_reads(inversion_evidence, SVTYPE.INV)[0]
 
-        self.assertEqual(101, event.break1.start)
-        self.assertEqual(101, event.break1.end)
-        self.assertEqual(503, event.break2.start)
-        self.assertEqual(503, event.break2.end)
-        self.assertEqual('', event.untemplated_seq)
+        assert event.break1.start == 101
+        assert event.break1.end == 101
+        assert event.break2.start == 503
+        assert event.break2.end == 503
+        assert event.untemplated_seq == ''
 
-    def test_both_by_flanking_pairs(self):
-        self.ev.flanking_pairs.add(
+    def test_both_by_flanking_pairs(self, inversion_evidence):
+        inversion_evidence.flanking_pairs.add(
             mock_read_pair(
                 MockRead(query_name='t1', reference_id=0, reference_start=150, reference_end=150),
                 MockRead(query_name='t1', reference_id=0, reference_start=500, reference_end=520),
             )
         )
-        self.ev.flanking_pairs.add(
+        inversion_evidence.flanking_pairs.add(
             mock_read_pair(
                 MockRead(query_name='t2', reference_id=0, reference_start=120, reference_end=140),
                 MockRead(query_name='t2', reference_id=0, reference_start=520, reference_end=520),
             )
         )
-        bpp = call._call_by_flanking_pairs(self.ev, SVTYPE.INV)
+        bpp = call._call_by_flanking_pairs(inversion_evidence, SVTYPE.INV)
         # 120-149  ..... 500-519
         # max frag = 150 - 80 = 70
-        self.assertEqual(42, bpp.break1.start)
-        self.assertEqual(120, bpp.break1.end)
-        self.assertEqual(412, bpp.break2.start)  # 70 - 21 = 49
-        self.assertEqual(500, bpp.break2.end)
+        assert bpp.break1.start == 42
+        assert bpp.break1.end == 120
+        assert bpp.break2.start == 412  # 70 - 21 = 49
+        assert bpp.break2.end == 500
 
-    def test_by_split_reads_multiple_calls(self):
-        self.ev.split_reads[0].add(
+    def test_by_split_reads_multiple_calls(self, inversion_evidence):
+        inversion_evidence.split_reads[0].add(
             MockRead(
                 query_name='t1',
                 reference_start=100,
@@ -1076,7 +1112,7 @@ class TestCallBySupportingReads(unittest.TestCase):
                 query_sequence='A' * 40,
             )
         )
-        self.ev.split_reads[1].add(
+        inversion_evidence.split_reads[1].add(
             MockRead(
                 query_name='t1',
                 reference_start=500,
@@ -1084,7 +1120,7 @@ class TestCallBySupportingReads(unittest.TestCase):
                 query_sequence='T' * 40,
             )
         )
-        self.ev.split_reads[0].add(
+        inversion_evidence.split_reads[0].add(
             MockRead(
                 query_name='t2',
                 reference_start=110,
@@ -1092,7 +1128,7 @@ class TestCallBySupportingReads(unittest.TestCase):
                 query_sequence='T' * 40,
             )
         )
-        self.ev.split_reads[1].add(
+        inversion_evidence.split_reads[1].add(
             MockRead(
                 query_name='t2',
                 reference_start=520,
@@ -1101,8 +1137,8 @@ class TestCallBySupportingReads(unittest.TestCase):
             )
         )
 
-        evs = call._call_by_split_reads(self.ev, SVTYPE.INV)
-        self.assertEqual(2, len(evs))
+        evs = call._call_by_split_reads(inversion_evidence, SVTYPE.INV)
+        assert len(evs) == 2
 
     def test_call_by_split_reads_consume_flanking(self):
         evidence = GenomeEvidence(
@@ -1182,36 +1218,38 @@ class TestCallBySupportingReads(unittest.TestCase):
         events = call._call_by_split_reads(evidence, event_type=SVTYPE.INV)
         for ev in events:
             print(ev, ev.event_type, ev.call_method)
-        self.assertEqual(1, len(events))
+        assert len(events) == 1
         event = events[0]
-        self.assertEqual(1, len(event.flanking_pairs))
-        self.assertEqual(2, len(event.break1_split_reads))
-        self.assertEqual(2, len(event.break2_split_reads))
+        assert len(event.flanking_pairs) == 1
+        assert len(event.break1_split_reads) == 2
+        assert len(event.break2_split_reads) == 2
         b1 = set([read.query_name for read in event.break1_split_reads])
         b2 = set([read.query_name for read in event.break2_split_reads])
-        self.assertEqual(1, len(b1 & b2))
+        assert len(b1 & b2) == 1
 
 
-class TestCallByFlankingReadsGenome(unittest.TestCase):
-    def setUp(self):
-        self.ev_LR = GenomeEvidence(
-            Breakpoint('fake', 100, orient=ORIENT.LEFT),
-            Breakpoint('fake', 200, orient=ORIENT.RIGHT),
-            BamCache(MockBamFileHandle()),
-            None,
-            opposing_strands=False,
-            read_length=25,
-            stdev_fragment_size=25,
-            median_fragment_size=100,
-            config={
-                'validate.stdev_count_abnormal': 2,
-                'validate.min_flanking_pairs_resolution': 1,
-                'validate.min_call_complexity': 0,
-            },
-        )
+@pytest.fixture
+def left_right_ev():
+    return GenomeEvidence(
+        Breakpoint('fake', 100, orient=ORIENT.LEFT),
+        Breakpoint('fake', 200, orient=ORIENT.RIGHT),
+        BamCache(MockBamFileHandle()),
+        None,
+        opposing_strands=False,
+        read_length=25,
+        stdev_fragment_size=25,
+        median_fragment_size=100,
+        config={
+            'validate.stdev_count_abnormal': 2,
+            'validate.min_flanking_pairs_resolution': 1,
+            'validate.min_call_complexity': 0,
+        },
+    )
 
+
+class TestCallByFlankingReadsGenome:
     def test_call_coverage_too_large(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             call._call_interval_by_flanking_coverage(
                 Interval(1901459, 1902200),
                 ORIENT.RIGHT,
@@ -1221,13 +1259,13 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
                 Evidence.traverse,
             )
 
-    def test_intrachromosomal_lr(self):
+    def test_intrachromosomal_lr(self, left_right_ev):
         # --LLL-100------------500-RRR-------
         # max fragment size: 100 + 2 * 25 = 150
         # max distance = 150 - read_length = 125
         # coverage ranges: 20->80 (61)   600->675 (76)
-        self.assertEqual(150, self.ev_LR.max_expected_fragment_size)
-        self.ev_LR.flanking_pairs.add(
+        assert left_right_ev.max_expected_fragment_size == 150
+        left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=19,
@@ -1244,7 +1282,7 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
                 ),
             )
         )
-        self.ev_LR.flanking_pairs.add(
+        left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=39,
@@ -1262,7 +1300,7 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
             )
         )
         # add a pair that will be ignored
-        self.ev_LR.flanking_pairs.add(
+        left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=39,
@@ -1279,18 +1317,18 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
                 ),
             )
         )
-        bpp = call._call_by_flanking_pairs(self.ev_LR, SVTYPE.DEL)
+        bpp = call._call_by_flanking_pairs(left_right_ev, SVTYPE.DEL)
         print(bpp, bpp.flanking_pairs)
-        self.assertEqual(80, bpp.break1.start)
-        self.assertEqual(80 + 125 - 45, bpp.break1.end)
-        self.assertEqual(600 - 125 + 75, bpp.break2.start)
-        self.assertEqual(600, bpp.break2.end)
+        assert bpp.break1.start == 80
+        assert bpp.break1.end == 80 + 125 - 45
+        assert bpp.break2.start == 600 - 125 + 75
+        assert bpp.break2.end == 600
 
-    def test_intrachromosomal_lr_coverage_overlaps_range(self):
+    def test_intrachromosomal_lr_coverage_overlaps_range(self, left_right_ev):
         # this test is for ensuring that if a theoretical window calculated for the
         # first breakpoint overlaps the actual coverage for the second breakpoint (or the reverse)
         # that we adjust the theoretical window accordingly
-        self.ev_LR.flanking_pairs.add(
+        left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=21,
@@ -1307,7 +1345,7 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
                 ),
             )
         )
-        self.ev_LR.flanking_pairs.add(
+        left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=41,
@@ -1325,7 +1363,7 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
             )
         )
         # pair to skip
-        self.ev_LR.flanking_pairs.add(
+        left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=39,
@@ -1342,14 +1380,14 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
                 ),
             )
         )
-        break1, break2 = call._call_by_flanking_pairs(self.ev_LR, SVTYPE.INS)
-        self.assertEqual(80, break1.start)
-        self.assertEqual(80, break1.end)  # 119
-        self.assertEqual(81, break2.start)
-        self.assertEqual(81, break2.end)
+        break1, break2 = call._call_by_flanking_pairs(left_right_ev, SVTYPE.INS)
+        assert break1.start == 80
+        assert break1.end == 80  # 119
+        assert break2.start == 81
+        assert break2.end == 81
 
-    def test_intrachromosomal_flanking_coverage_overlap_error(self):
-        self.ev_LR.flanking_pairs.add(
+    def test_intrachromosomal_flanking_coverage_overlap_error(self, left_right_ev):
+        left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=19,
@@ -1365,7 +1403,7 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
                 ),
             )
         )
-        self.ev_LR.flanking_pairs.add(
+        left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=620,
@@ -1381,11 +1419,11 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
                 ),
             )
         )
-        with self.assertRaises(AssertionError):
-            call._call_by_flanking_pairs(self.ev_LR, SVTYPE.DEL)
+        with pytest.raises(AssertionError):
+            call._call_by_flanking_pairs(left_right_ev, SVTYPE.DEL)
 
-    def test_coverage_larger_than_max_expected_variance_error(self):
-        self.ev_LR.flanking_pairs.add(
+    def test_coverage_larger_than_max_expected_variance_error(self, left_right_ev):
+        left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=19,
@@ -1401,7 +1439,7 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
                 ),
             )
         )
-        self.ev_LR.flanking_pairs.add(
+        left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=301,
@@ -1417,10 +1455,10 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
                 ),
             )
         )
-        with self.assertRaises(AssertionError):
-            call._call_by_flanking_pairs(self.ev_LR, SVTYPE.DEL)
+        with pytest.raises(AssertionError):
+            call._call_by_flanking_pairs(left_right_ev, SVTYPE.DEL)
 
-    def test_close_to_zero(self):
+    def test_close_to_zero(self, left_right_ev):
         # this test is for ensuring that if a theoretical window calculated for the
         # first breakpoint overlaps the actual coverage for the second breakpoint (or the reverse)
         # that we adjust the theoretical window accordingly
@@ -1472,12 +1510,12 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
         )
         break1, break2 = call._call_by_flanking_pairs(ev, SVTYPE.INV)
 
-        self.assertEqual(1, break1.start)
-        self.assertEqual(20, break1.end)
-        self.assertEqual(65, break2.start)
-        self.assertEqual(150, break2.end)
+        assert break1.start == 1
+        assert break1.end == 20
+        assert break2.start == 65
+        assert break2.end == 150
 
-    def test_call_with_overlapping_coverage_intervals(self):
+    def test_call_with_overlapping_coverage_intervals(self, left_right_ev):
         evidence = GenomeEvidence(
             Breakpoint('1', 76185710, 76186159, orient=ORIENT.RIGHT),
             Breakpoint('1', 76186430, 76186879, orient=ORIENT.LEFT),
@@ -1505,11 +1543,11 @@ class TestCallByFlankingReadsGenome(unittest.TestCase):
                 ),
             )
         )
-        with self.assertRaises(AssertionError):
-            bpp = call._call_by_flanking_pairs(evidence, SVTYPE.DUP)
+        with pytest.raises(AssertionError):
+            call._call_by_flanking_pairs(evidence, SVTYPE.DUP)
 
 
-class TestCallByFlankingReadsTranscriptome(unittest.TestCase):
+class TestCallByFlankingReadsTranscriptome:
     def build_transcriptome_evidence(self, b1, b2, opposing_strands=False):
         return TranscriptomeEvidence(
             {},  # fake the annotations
@@ -1531,17 +1569,20 @@ class TestCallByFlankingReadsTranscriptome(unittest.TestCase):
             },
         )
 
+    @todo
     def test_call_translocation(self):
         # transcriptome test will use exonic coordinates for the associated transcripts
-        raise unittest.SkipTest('TODO')
+        pass
 
+    @todo
     def test_call_inversion(self):
         # transcriptome test will use exonic coordinates for the associated transcripts
-        raise unittest.SkipTest('TODO')
+        pass
 
+    @todo
     def test_call_inversion_overlapping_breakpoint_calls(self):
         # transcriptome test will use exonic coordinates for the associated transcripts
-        raise unittest.SkipTest('TODO')
+        pass
 
     def test_call_deletion(self):
         # transcriptome test will use exonic coordinates for the associated transcripts
@@ -1562,32 +1603,32 @@ class TestCallByFlankingReadsTranscriptome(unittest.TestCase):
         )
         print(read_pair_type(pair[0]))
         # following help in debugging the mockup
-        self.assertFalse(pair[0].is_reverse)
-        self.assertFalse(pair[0].is_read1)
-        self.assertTrue(pair[0].is_read2)
-        self.assertTrue(pair[1].is_reverse)
-        self.assertTrue(pair[1].is_read1)
-        self.assertFalse(pair[1].is_read2)
-        self.assertEqual(STRAND.POS, sequenced_strand(pair[0], 2))
-        self.assertEqual(STRAND.POS, evidence.decide_sequenced_strand([pair[0]]))
-        self.assertEqual(STRAND.POS, sequenced_strand(pair[1], 2))
-        self.assertEqual(STRAND.POS, evidence.decide_sequenced_strand([pair[1]]))
+        assert not pair[0].is_reverse
+        assert not pair[0].is_read1
+        assert pair[0].is_read2
+        assert pair[1].is_reverse
+        assert pair[1].is_read1
+        assert not pair[1].is_read2
+        assert sequenced_strand(pair[0], 2) == STRAND.POS
+        assert evidence.decide_sequenced_strand([pair[0]]) == STRAND.POS
+        assert sequenced_strand(pair[1], 2) == STRAND.POS
+        assert evidence.decide_sequenced_strand([pair[1]]) == STRAND.POS
         print(evidence.max_expected_fragment_size, evidence.read_length)
         evidence.flanking_pairs.add(pair)
         breakpoint1, breakpoint2 = call._call_by_flanking_pairs(evidence, SVTYPE.DEL)
         print(breakpoint1, breakpoint2)
-        self.assertEqual(Breakpoint('1', 1051, 1351, 'L', '+'), breakpoint1)
-        self.assertEqual(Breakpoint('1', 2000, 2300, 'R', '+'), breakpoint2)
+        assert breakpoint1 == Breakpoint('1', 1051, 1351, 'L', '+')
+        assert breakpoint2 == Breakpoint('1', 2000, 2300, 'R', '+')
 
         # now add the transcript and call again
         evidence.overlapping_transcripts.add(pre_transcript)
         breakpoint1, breakpoint2 = call._call_by_flanking_pairs(evidence, SVTYPE.DEL)
         print(breakpoint1, breakpoint2)
-        self.assertEqual(Breakpoint('1', 1051, 2051, 'L', '+'), breakpoint1)
-        self.assertEqual(Breakpoint('1', 1600, 2300, 'R', '+'), breakpoint2)
+        assert breakpoint1 == Breakpoint('1', 1051, 2051, 'L', '+')
+        assert breakpoint2 == Breakpoint('1', 1600, 2300, 'R', '+')
 
 
-class TestCallBySpanningReads(unittest.TestCase):
+class TestCallBySpanningReads:
     def test_deletion(self):
         # ATCGATCTAGATCTAGGATAGTTCTAGCAGTCATAGCTAT
         ev = GenomeEvidence(
@@ -1623,8 +1664,8 @@ class TestCallBySpanningReads(unittest.TestCase):
         ]
         ev.spanning_reads = set(spanning_reads)
         calls = call._call_by_spanning_reads(ev, set())
-        self.assertEqual(1, len(calls))
-        self.assertEqual(2, len(calls[0].support()))
+        assert len(calls) == 1
+        assert len(calls[0].support()) == 2
 
     def test_insertion(self):
         pass
@@ -1639,7 +1680,7 @@ class TestCallBySpanningReads(unittest.TestCase):
         pass
 
 
-class TestCharacterizeRepeatRegion(unittest.TestCase):
+class TestCharacterizeRepeatRegion:
     def test_bad_deletion_call(self):
         reference_genome = {
             '19': mock.Mock(
@@ -1662,7 +1703,7 @@ class TestCharacterizeRepeatRegion(unittest.TestCase):
             untemplated_seq='',
             event_type=SVTYPE.DEL,
         )
-        self.assertEqual((0, ''), call.EventCall.characterize_repeat_region(bpp, reference_genome))
+        assert call.EventCall.characterize_repeat_region(bpp, reference_genome) == (0, '')
 
     def test_homopolymer_insertion(self):
         bpp = BreakpointPair(
@@ -1679,7 +1720,7 @@ class TestCharacterizeRepeatRegion(unittest.TestCase):
             'upto and including the first breakpoint',
             reference_genome['1'].seq[bpp.break1.start - 10 : bpp.break1.start],
         )
-        self.assertEqual((4, 'T'), call.EventCall.characterize_repeat_region(bpp, reference_genome))
+        assert call.EventCall.characterize_repeat_region(bpp, reference_genome) == (4, 'T')
 
     def test_homopolymer_deletion(self):
         bpp = BreakpointPair(
@@ -1696,7 +1737,7 @@ class TestCharacterizeRepeatRegion(unittest.TestCase):
             'upto and including the first breakpoint',
             reference_genome['1'].seq[bpp.break1.start - 10 : bpp.break1.start],
         )
-        self.assertEqual((4, 'T'), call.EventCall.characterize_repeat_region(bpp, reference_genome))
+        assert call.EventCall.characterize_repeat_region(bpp, reference_genome) == (4, 'T')
 
     def test_homopolymer_duplication(self):
         bpp = BreakpointPair(
@@ -1713,7 +1754,7 @@ class TestCharacterizeRepeatRegion(unittest.TestCase):
             'upto and including the first breakpoint',
             reference_genome['1'].seq[bpp.break1.start - 10 : bpp.break1.start],
         )
-        self.assertEqual((4, 'T'), call.EventCall.characterize_repeat_region(bpp, reference_genome))
+        assert call.EventCall.characterize_repeat_region(bpp, reference_genome) == (4, 'T')
 
     def test_repeat_duplication(self):
         bpp = BreakpointPair(
@@ -1732,9 +1773,7 @@ class TestCharacterizeRepeatRegion(unittest.TestCase):
             'upto and including the first breakpoint',
             reference_genome['1'].seq[bpp.break1.start - 10 : bpp.break1.start],
         )
-        self.assertEqual(
-            (2, 'TAG'), call.EventCall.characterize_repeat_region(bpp, reference_genome)
-        )
+        assert call.EventCall.characterize_repeat_region(bpp, reference_genome) == (2, 'TAG')
 
     def test_repeat_insertion(self):
         bpp = BreakpointPair(
@@ -1753,9 +1792,7 @@ class TestCharacterizeRepeatRegion(unittest.TestCase):
             'upto and including the first breakpoint',
             reference_genome['1'].seq[bpp.break1.start - 10 : bpp.break1.start],
         )
-        self.assertEqual(
-            (3, 'TAG'), call.EventCall.characterize_repeat_region(bpp, reference_genome)
-        )
+        assert call.EventCall.characterize_repeat_region(bpp, reference_genome) == (3, 'TAG')
 
     def test_repeat_deletion(self):
         bpp = BreakpointPair(
@@ -1774,9 +1811,7 @@ class TestCharacterizeRepeatRegion(unittest.TestCase):
             'upto and including the second breakpoint',
             reference_genome['1'].seq[bpp.break2.start - 10 : bpp.break2.start],
         )
-        self.assertEqual(
-            (3, 'TAG'), call.EventCall.characterize_repeat_region(bpp, reference_genome)
-        )
+        assert call.EventCall.characterize_repeat_region(bpp, reference_genome) == (3, 'TAG')
 
     def test_norepeat_insertion(self):
         bpp = BreakpointPair(
@@ -1795,9 +1830,7 @@ class TestCharacterizeRepeatRegion(unittest.TestCase):
             'upto and including the first breakpoint',
             reference_genome['1'].seq[bpp.break1.start - 10 : bpp.break1.start],
         )
-        self.assertEqual(
-            (0, 'TTG'), call.EventCall.characterize_repeat_region(bpp, reference_genome)
-        )
+        assert call.EventCall.characterize_repeat_region(bpp, reference_genome) == (0, 'TTG')
 
     def test_invalid_event_type(self):
         bpp = BreakpointPair(
@@ -1806,9 +1839,5 @@ class TestCharacterizeRepeatRegion(unittest.TestCase):
             untemplated_seq='TTG',
             event_type=SVTYPE.INV,
         )
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             call.EventCall.characterize_repeat_region(bpp, None)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/integration/test_validate_evidence.py
+++ b/tests/integration/test_validate_evidence.py
@@ -1,12 +1,13 @@
-import unittest
+import argparse
 from functools import partial
 
+import pytest
 from mavis.annotate.genomic import Gene, PreTranscript, Transcript
 from mavis.bam import cigar as _cigar
 from mavis.bam.cache import BamCache
 from mavis.bam.read import SamRead
 from mavis.breakpoint import Breakpoint, BreakpointPair
-from mavis.constants import CIGAR, ORIENT, STRAND
+from mavis.constants import ORIENT, STRAND
 from mavis.interval import Interval
 from mavis.schemas import DEFAULTS
 from mavis.validate.base import Evidence
@@ -17,69 +18,73 @@ from . import MockBamFileHandle, MockObject, MockRead, mock_read_pair
 REFERENCE_GENOME = None
 
 
-class TestDistance(unittest.TestCase):
-    def setUp(self):
-        self.transcript = PreTranscript(
-            [(1001, 1100), (1501, 1600), (2001, 2100), (2201, 2300)], strand='+'
-        )
-        for patt in self.transcript.generate_splicing_patterns():
-            self.transcript.transcripts.append(Transcript(self.transcript, patt))
-        self.trans_evidence = MockObject(
-            annotations={},
-            read_length=100,
-            max_expected_fragment_size=550,
-            call_error=11,
-            overlapping_transcripts={self.transcript},
-        )
-        setattr(
-            self.trans_evidence,
-            '_select_transcripts',
-            lambda *pos: self.trans_evidence.overlapping_transcripts,
-        )
-        setattr(
-            self.trans_evidence,
-            'distance',
-            partial(TranscriptomeEvidence.distance, self.trans_evidence),
-        )
+@pytest.fixture
+def distance_setup():
+    n = argparse.Namespace()
+    n.transcript = PreTranscript(
+        [(1001, 1100), (1501, 1600), (2001, 2100), (2201, 2300)], strand='+'
+    )
+    for patt in n.transcript.generate_splicing_patterns():
+        n.transcript.transcripts.append(Transcript(n.transcript, patt))
+    n.trans_evidence = MockObject(
+        annotations={},
+        read_length=100,
+        max_expected_fragment_size=550,
+        call_error=11,
+        overlapping_transcripts={n.transcript},
+    )
+    setattr(
+        n.trans_evidence,
+        '_select_transcripts',
+        lambda *pos: n.trans_evidence.overlapping_transcripts,
+    )
+    setattr(
+        n.trans_evidence,
+        'distance',
+        partial(TranscriptomeEvidence.distance, n.trans_evidence),
+    )
+    return n
 
-    def test_exonic(self):
-        self.assertEqual(Interval(149), self.trans_evidence.distance(1001, 1550))
 
-    def test_intergenic_exonic(self):
-        dist = self.trans_evidence.distance(101, 1550)
-        self.assertEqual(Interval(1049, 1049), dist)
+class TestDistance:
+    def test_exonic(self, distance_setup):
+        assert distance_setup.trans_evidence.distance(1001, 1550) == Interval(149)
 
-    def test_intergenic_intergenic(self):
-        dist = self.trans_evidence.distance(101, 300)
-        self.assertEqual(Interval(199), dist)
+    def test_intergenic_exonic(self, distance_setup):
+        dist = distance_setup.trans_evidence.distance(101, 1550)
+        assert dist == Interval(1049, 1049)
 
-    def test_aligned_intronic(self):
-        dist = self.trans_evidence.distance(1102, 1499)
-        self.assertEqual(Interval(5), dist)
+    def test_intergenic_intergenic(self, distance_setup):
+        dist = distance_setup.trans_evidence.distance(101, 300)
+        assert dist == Interval(199)
 
-    def test_indel_at_exon_boundary(self):
-        self.assertEqual(Interval(2), self.trans_evidence.distance(1101, 1501))
+    def test_aligned_intronic(self, distance_setup):
+        dist = distance_setup.trans_evidence.distance(1102, 1499)
+        assert dist == Interval(5)
 
-    def test_no_annotations(self):
-        dist = self.trans_evidence.distance(101, 300, [])
-        self.assertEqual(Interval(199), dist)
+    def test_indel_at_exon_boundary(self, distance_setup):
+        assert distance_setup.trans_evidence.distance(1101, 1501) == Interval(2)
 
-    def test_intergenic_intronic(self):
-        dist = self.trans_evidence.distance(101, 1400)
-        self.assertEqual(Interval(1101), dist)
+    def test_no_annotations(self, distance_setup):
+        dist = distance_setup.trans_evidence.distance(101, 300, [])
+        assert dist == Interval(199)
 
-    def test_empty_intron(self):
+    def test_intergenic_intronic(self, distance_setup):
+        dist = distance_setup.trans_evidence.distance(101, 1400)
+        assert dist == Interval(1101)
+
+    def test_empty_intron(self, distance_setup):
         t2 = PreTranscript([(1001, 1100), (1501, 1600), (2001, 2200), (2201, 2300)], strand='+')
         for patt in t2.generate_splicing_patterns():
             t2.transcripts.append(Transcript(t2, patt))
         print(t2)
-        print(self.trans_evidence.overlapping_transcripts)
-        self.trans_evidence.overlapping_transcripts.add(t2)
-        dist = self.trans_evidence.distance(1001, 2301)
-        self.assertEqual(Interval(400, 400), dist)
+        print(distance_setup.trans_evidence.overlapping_transcripts)
+        distance_setup.trans_evidence.overlapping_transcripts.add(t2)
+        dist = distance_setup.trans_evidence.distance(1001, 2301)
+        assert dist == Interval(400, 400)
 
 
-class TestTransStandardize(unittest.TestCase):
+class TestTransStandardize:
     def test_shift_overaligned(self):
         # qwertyuiopas---kkkkk------dfghjklzxcvbnm
         # ..........      ................
@@ -106,7 +111,7 @@ class TestTransStandardize(unittest.TestCase):
         )
         evidence.overlapping_transcripts.add(transcript)
         new_read = evidence.standardize_read(read)
-        self.assertEqual(_cigar.convert_string_to_cigar('12=7N14='), new_read.cigar)
+        assert new_read.cigar == _cigar.convert_string_to_cigar('12=7N14=')
 
     def test_shift_overaligned_left(self):
         # qwertyuiopasdf---kkkkkdf------ghjklzxcvbnm
@@ -134,7 +139,7 @@ class TestTransStandardize(unittest.TestCase):
         )
         evidence.overlapping_transcripts.add(transcript)
         new_read = evidence.standardize_read(read)
-        self.assertEqual(_cigar.convert_string_to_cigar('14=7N12='), new_read.cigar)
+        assert new_read.cigar == _cigar.convert_string_to_cigar('14=7N12=')
 
     def test_shift_no_transcripts(self):
         read = SamRead(
@@ -154,296 +159,317 @@ class TestTransStandardize(unittest.TestCase):
             median_fragment_size=220,
         )
         new_cigar = evidence.exon_boundary_shift_cigar(read)
-        self.assertEqual(_cigar.convert_string_to_cigar('14=7D18='), new_cigar)
+        assert new_cigar == _cigar.convert_string_to_cigar('14=7D18=')
 
 
-class TestComputeFragmentSizes(unittest.TestCase):
-    def setUp(self):
-        b1 = Breakpoint('1', 1051, 1051, 'L')
-        b2 = Breakpoint('1', 1551, 1551, 'R')
-        self.read_length = 50
-        self.trans_ev = TranscriptomeEvidence(
-            {},  # fake the annotations
-            b1,
-            b2,
-            None,
-            None,  # bam_cache and reference_genome
-            opposing_strands=False,
-            read_length=self.read_length,
-            stdev_fragment_size=100,
-            median_fragment_size=100,
-            config={'validate.stdev_count_abnormal': 1},
-        )
-        self.genomic_ev = GenomeEvidence(
-            b1,
-            b2,
-            None,
-            None,  # bam_cache and reference_genome
-            opposing_strands=False,
-            read_length=self.read_length,
-            stdev_fragment_size=100,
-            median_fragment_size=100,
-            config={'validate.stdev_count_abnormal': 1},
-        )
+@pytest.fixture
+def read_length():
+    return 50
 
-    def test_genomic_vs_trans_no_annotations(self):
+
+@pytest.fixture
+def trans_evidence(read_length):
+    return TranscriptomeEvidence(
+        {},  # fake the annotations
+        Breakpoint('1', 1051, 1051, 'L'),
+        Breakpoint('1', 1551, 1551, 'R'),
+        None,
+        None,  # bam_cache and reference_genome
+        opposing_strands=False,
+        read_length=read_length,
+        stdev_fragment_size=100,
+        median_fragment_size=100,
+        config={'validate.stdev_count_abnormal': 1},
+    )
+
+
+@pytest.fixture
+def genomic_evidence(read_length):
+    return GenomeEvidence(
+        Breakpoint('1', 1051, 1051, 'L'),
+        Breakpoint('1', 1551, 1551, 'R'),
+        None,
+        None,  # bam_cache and reference_genome
+        opposing_strands=False,
+        read_length=read_length,
+        stdev_fragment_size=100,
+        median_fragment_size=100,
+        config={'validate.stdev_count_abnormal': 1},
+    )
+
+
+class TestComputeFragmentSizes:
+    def test_genomic_vs_trans_no_annotations(self, genomic_evidence, read_length, trans_evidence):
         # should be identical
         read, mate = mock_read_pair(
-            MockRead('name', '1', 1051 - self.read_length + 1, 1051, is_reverse=False),
-            MockRead('name', '1', 2300, 2300 + self.read_length - 1, is_reverse=True),
+            MockRead('name', '1', 1051 - read_length + 1, 1051, is_reverse=False),
+            MockRead('name', '1', 2300, 2300 + read_length - 1, is_reverse=True),
         )
-        self.assertEqual(
-            self.trans_ev.compute_fragment_size(read, mate),
-            self.genomic_ev.compute_fragment_size(read, mate),
-        )
+        assert genomic_evidence.compute_fragment_size(
+            read, mate
+        ) == trans_evidence.compute_fragment_size(read, mate)
 
-    def test_reverse_reads(self):
+    def test_reverse_reads(self, genomic_evidence, trans_evidence):
         read, mate = mock_read_pair(
             MockRead('name', '1', 1001, 1100, is_reverse=False),
             MockRead('name', '1', 2201, 2301, is_reverse=True),
         )
-        self.assertEqual(Interval(1300), self.genomic_ev.compute_fragment_size(read, mate))
-        self.assertEqual(Interval(1300), self.genomic_ev.compute_fragment_size(mate, read))
-        self.assertEqual(Interval(1300), self.trans_ev.compute_fragment_size(read, mate))
-        self.assertEqual(Interval(1300), self.trans_ev.compute_fragment_size(mate, read))
+        assert genomic_evidence.compute_fragment_size(read, mate) == Interval(1300)
+        assert genomic_evidence.compute_fragment_size(mate, read) == Interval(1300)
+        assert trans_evidence.compute_fragment_size(read, mate) == Interval(1300)
+        assert trans_evidence.compute_fragment_size(mate, read) == Interval(1300)
 
 
-class TestTraverse(unittest.TestCase):
-    def setUp(self):
-        self.transcript = PreTranscript(
-            [(1001, 1100), (1301, 1400), (1701, 1800)], strand=STRAND.POS
-        )
-        for patt in self.transcript.generate_splicing_patterns():
-            self.transcript.transcripts.append(Transcript(self.transcript, patt))
+@pytest.fixture
+def traverse_setup():
+    n = argparse.Namespace()
+    n.transcript = PreTranscript([(1001, 1100), (1301, 1400), (1701, 1800)], strand=STRAND.POS)
+    for patt in n.transcript.generate_splicing_patterns():
+        n.transcript.transcripts.append(Transcript(n.transcript, patt))
 
-        self.trans_evidence = MockObject(
-            annotations={},
-            read_length=100,
-            max_expected_fragment_size=550,
-            call_error=11,
-            overlapping_transcripts={self.transcript},
-        )
-        setattr(
-            self.trans_evidence,
-            '_select_transcripts',
-            lambda *pos: self.trans_evidence.overlapping_transcripts,
-        )
-        setattr(
-            self.trans_evidence,
-            'traverse',
-            partial(TranscriptomeEvidence.traverse, self.trans_evidence),
-        )
+    n.trans_evidence = MockObject(
+        annotations={},
+        read_length=100,
+        max_expected_fragment_size=550,
+        call_error=11,
+        overlapping_transcripts={n.transcript},
+    )
+    setattr(
+        n.trans_evidence,
+        '_select_transcripts',
+        lambda *pos: n.trans_evidence.overlapping_transcripts,
+    )
+    setattr(
+        n.trans_evidence,
+        'traverse',
+        partial(TranscriptomeEvidence.traverse, n.trans_evidence),
+    )
+    return n
 
-    def test_left_before_transcript(self):
+
+class TestTraverse:
+    def test_left_before_transcript(self, traverse_setup):
         exp_pos = Evidence.traverse(900, 500 - 1, ORIENT.LEFT)
-        self.assertEqual(exp_pos, self.trans_evidence.traverse(900, 500 - 1, ORIENT.LEFT))
+        assert traverse_setup.trans_evidence.traverse(900, 500 - 1, ORIENT.LEFT) == exp_pos
 
-    def test_left_after_transcript(self):
+    def test_left_after_transcript(self, traverse_setup):
         exp_pos = Evidence.traverse(2200, 100, ORIENT.LEFT)
-        self.assertEqual(exp_pos, self.trans_evidence.traverse(2200, 100, ORIENT.LEFT))
+        assert traverse_setup.trans_evidence.traverse(2200, 100, ORIENT.LEFT) == exp_pos
 
-    def test_left_at_end(self):
-        gpos = self.trans_evidence.traverse(1900, 500, ORIENT.LEFT)
-        self.assertEqual(Interval(900), gpos)
+    def test_left_at_end(self, traverse_setup):
+        gpos = traverse_setup.trans_evidence.traverse(1900, 500, ORIENT.LEFT)
+        assert gpos == Interval(900)
 
-    def test_left_within_transcript_exonic(self):
-        gpos = self.trans_evidence.traverse(1750, 200 - 1, ORIENT.LEFT)
-        self.assertEqual(Interval(1051), gpos)
+    def test_left_within_transcript_exonic(self, traverse_setup):
+        gpos = traverse_setup.trans_evidence.traverse(1750, 200 - 1, ORIENT.LEFT)
+        assert gpos == Interval(1051)
 
-    def test_left_within_exon(self):
-        gpos = self.trans_evidence.traverse(1750, 20 - 1, ORIENT.LEFT)
-        self.assertEqual(1731, gpos.start)
-        self.assertEqual(1731, gpos.end)
+    def test_left_within_exon(self, traverse_setup):
+        gpos = traverse_setup.trans_evidence.traverse(1750, 20 - 1, ORIENT.LEFT)
+        assert gpos.start == 1731
+        assert gpos.end == 1731
 
-    def test_left_within_transcript_intronic(self):
-        gpos = self.trans_evidence.traverse(1600, 150 - 1, ORIENT.LEFT)
-        self.assertEqual(Interval(1451), gpos)
+    def test_left_within_transcript_intronic(self, traverse_setup):
+        gpos = traverse_setup.trans_evidence.traverse(1600, 150 - 1, ORIENT.LEFT)
+        assert gpos == Interval(1451)
 
-    def test_right_before_transcript(self):
-        gpos = self.trans_evidence.traverse(500, 100 - 1, ORIENT.RIGHT)
-        self.assertEqual(Interval(599), gpos)
+    def test_right_before_transcript(self, traverse_setup):
+        gpos = traverse_setup.trans_evidence.traverse(500, 100 - 1, ORIENT.RIGHT)
+        assert gpos == Interval(599)
 
-    def test_right_before_transcript2(self):
-        gpos = self.trans_evidence.traverse(901, 500 - 1, ORIENT.RIGHT)
-        self.assertEqual(Interval(1900), gpos)
+    def test_right_before_transcript2(self, traverse_setup):
+        gpos = traverse_setup.trans_evidence.traverse(901, 500 - 1, ORIENT.RIGHT)
+        assert gpos == Interval(1900)
 
-    def test_right_after_transcript(self):
-        gpos = self.trans_evidence.traverse(2201, 100 - 1, ORIENT.RIGHT)
-        self.assertEqual(Interval(2300), gpos)
+    def test_right_after_transcript(self, traverse_setup):
+        gpos = traverse_setup.trans_evidence.traverse(2201, 100 - 1, ORIENT.RIGHT)
+        assert gpos == Interval(2300)
 
-    def test_right_within_transcript(self):
-        gpos = self.trans_evidence.traverse(1351, 100 - 1, ORIENT.RIGHT)
-        self.assertEqual(Interval(1750), gpos)
+    def test_right_within_transcript(self, traverse_setup):
+        gpos = traverse_setup.trans_evidence.traverse(1351, 100 - 1, ORIENT.RIGHT)
+        assert gpos == Interval(1750)
 
-    def test_right_within_exon(self):
-        gpos = self.trans_evidence.traverse(1351, 10 - 1, ORIENT.RIGHT)
-        self.assertEqual(Interval(1360), gpos)
-
-
-class TestTraverseTransRev(unittest.TestCase):
-    def setUp(self):
-        self.transcript = PreTranscript(
-            [(1001, 1100), (1301, 1400), (1701, 1800)], strand=STRAND.NEG
-        )
-        for patt in self.transcript.generate_splicing_patterns():
-            self.transcript.transcripts.append(Transcript(self.transcript, patt))
-
-        self.trans_evidence = MockObject(
-            annotations={},
-            read_length=100,
-            max_expected_fragment_size=550,
-            call_error=11,
-            overlapping_transcripts={self.transcript},
-        )
-        setattr(
-            self.trans_evidence,
-            '_select_transcripts',
-            lambda *pos: self.trans_evidence.overlapping_transcripts,
-        )
-        setattr(
-            self.trans_evidence,
-            'traverse',
-            partial(TranscriptomeEvidence.traverse, self.trans_evidence),
-        )
-
-    def test_left_before_transcript(self):
-        gpos = self.trans_evidence.traverse(900, 500 - 1, ORIENT.LEFT)
-        self.assertEqual(Interval(401), gpos)
-        self.assertEqual(gpos, GenomeEvidence.traverse(900, 500 - 1, ORIENT.LEFT))
-
-    def test_left_after_transcript(self):
-        gpos = self.trans_evidence.traverse(2200, 100, ORIENT.LEFT)
-        self.assertEqual(gpos, GenomeEvidence.traverse(2200, 100, ORIENT.LEFT))
-        self.assertEqual(Interval(2100), gpos)
-
-    def test_left_after_transcript2(self):
-        gpos = self.trans_evidence.traverse(1900, 500 - 1, ORIENT.LEFT)
-        self.assertEqual(Interval(901), gpos)
-
-    def test_left_within_transcript_exonic(self):
-        gpos = self.trans_evidence.traverse(1750, 200 - 1, ORIENT.LEFT)
-        self.assertEqual(Interval(1051), gpos)
-
-    def test_left_within_exon(self):
-        gpos = self.trans_evidence.traverse(1750, 20 - 1, ORIENT.LEFT)
-        self.assertEqual(1731, gpos.start)
-        self.assertEqual(1731, gpos.end)
-
-    def test_left_within_transcript_intronic(self):
-        gpos = self.trans_evidence.traverse(1600, 150 - 1, ORIENT.LEFT)
-        self.assertEqual(Interval(1451), gpos)
-
-    def test_right_before_transcript(self):
-        gpos = self.trans_evidence.traverse(500, 100 - 1, ORIENT.RIGHT)
-        self.assertEqual(Interval(599), gpos)
-
-    def test_right_before_transcript2(self):
-        gpos = self.trans_evidence.traverse(901, 500 - 1, ORIENT.RIGHT)
-        self.assertEqual(Interval(1900), gpos)
-
-    def test_right_after_transcript(self):
-        gpos = self.trans_evidence.traverse(2201, 100 - 1, ORIENT.RIGHT)
-        self.assertEqual(Interval(2300), gpos)
-
-    def test_right_within_transcript(self):
-        gpos = self.trans_evidence.traverse(1351, 100 - 1, ORIENT.RIGHT)
-        self.assertEqual(Interval(1750), gpos)
-
-    def test_right_within_exon(self):
-        gpos = self.trans_evidence.traverse(1351, 10 - 1, ORIENT.RIGHT)
-        self.assertEqual(Interval(1360), gpos)
+    def test_right_within_exon(self, traverse_setup):
+        gpos = traverse_setup.trans_evidence.traverse(1351, 10 - 1, ORIENT.RIGHT)
+        assert gpos == Interval(1360)
 
 
-class TestTranscriptomeEvidenceWindow(unittest.TestCase):
-    def setUp(self):
-        gene = Gene('1', 1, 9999, name='KRAS', strand=STRAND.POS)
-        self.pre_transcript = PreTranscript(
-            gene=gene, exons=[(1001, 1100), (1401, 1500), (1701, 1750), (3001, 4000)]
-        )
-        gene.unspliced_transcripts.append(self.pre_transcript)
-        for spl in self.pre_transcript.generate_splicing_patterns():
-            self.pre_transcript.transcripts.append(Transcript(self.pre_transcript, spl))
-        self.annotations = {gene.chr: [gene]}
-        self.genome_evidence = MockObject(
-            annotations={},
-            read_length=100,
-            max_expected_fragment_size=550,
-            config={**DEFAULTS, 'validate.call_error': 11},
-        )
-        self.trans_evidence = MockObject(
-            annotations={},
-            read_length=100,
-            max_expected_fragment_size=550,
-            overlapping_transcripts={self.pre_transcript},
-            config={**DEFAULTS, 'validate.call_error': 11},
-        )
-        setattr(
-            self.trans_evidence,
-            '_select_transcripts',
-            lambda *pos: self.trans_evidence.overlapping_transcripts,
-        )
-        setattr(
-            self.trans_evidence,
-            'traverse',
-            partial(TranscriptomeEvidence.traverse, self.trans_evidence),
-        )
+@pytest.fixture
+def tranverse_trans_rev_setup():
+    n = argparse.Namespace()
+    n.transcript = PreTranscript([(1001, 1100), (1301, 1400), (1701, 1800)], strand=STRAND.NEG)
+    for patt in n.transcript.generate_splicing_patterns():
+        n.transcript.transcripts.append(Transcript(n.transcript, patt))
 
-    def transcriptome_window(self, breakpoint, transcripts=None):
-        if transcripts:
-            self.trans_evidence.overlapping_transcripts.update(transcripts)
-        return TranscriptomeEvidence.generate_window(self.trans_evidence, breakpoint)
+    n.trans_evidence = MockObject(
+        annotations={},
+        read_length=100,
+        max_expected_fragment_size=550,
+        call_error=11,
+        overlapping_transcripts={n.transcript},
+    )
+    setattr(
+        n.trans_evidence,
+        '_select_transcripts',
+        lambda *pos: n.trans_evidence.overlapping_transcripts,
+    )
+    setattr(
+        n.trans_evidence,
+        'traverse',
+        partial(TranscriptomeEvidence.traverse, n.trans_evidence),
+    )
+    return n
 
-    def genome_window(self, breakpoint):
-        return GenomeEvidence.generate_window(self.genome_evidence, breakpoint)
 
-    def test_before_start(self):
+class TestTraverseTransRev:
+    def test_left_before_transcript(self, tranverse_trans_rev_setup):
+        gpos = tranverse_trans_rev_setup.trans_evidence.traverse(900, 500 - 1, ORIENT.LEFT)
+        assert gpos == Interval(401)
+        assert GenomeEvidence.traverse(900, 500 - 1, ORIENT.LEFT) == gpos
+
+    def test_left_after_transcript(self, tranverse_trans_rev_setup):
+        gpos = tranverse_trans_rev_setup.trans_evidence.traverse(2200, 100, ORIENT.LEFT)
+        assert GenomeEvidence.traverse(2200, 100, ORIENT.LEFT) == gpos
+        assert gpos == Interval(2100)
+
+    def test_left_after_transcript2(self, tranverse_trans_rev_setup):
+        gpos = tranverse_trans_rev_setup.trans_evidence.traverse(1900, 500 - 1, ORIENT.LEFT)
+        assert gpos == Interval(901)
+
+    def test_left_within_transcript_exonic(self, tranverse_trans_rev_setup):
+        gpos = tranverse_trans_rev_setup.trans_evidence.traverse(1750, 200 - 1, ORIENT.LEFT)
+        assert gpos == Interval(1051)
+
+    def test_left_within_exon(self, tranverse_trans_rev_setup):
+        gpos = tranverse_trans_rev_setup.trans_evidence.traverse(1750, 20 - 1, ORIENT.LEFT)
+        assert gpos.start == 1731
+        assert gpos.end == 1731
+
+    def test_left_within_transcript_intronic(self, tranverse_trans_rev_setup):
+        gpos = tranverse_trans_rev_setup.trans_evidence.traverse(1600, 150 - 1, ORIENT.LEFT)
+        assert gpos == Interval(1451)
+
+    def test_right_before_transcript(self, tranverse_trans_rev_setup):
+        gpos = tranverse_trans_rev_setup.trans_evidence.traverse(500, 100 - 1, ORIENT.RIGHT)
+        assert gpos == Interval(599)
+
+    def test_right_before_transcript2(self, tranverse_trans_rev_setup):
+        gpos = tranverse_trans_rev_setup.trans_evidence.traverse(901, 500 - 1, ORIENT.RIGHT)
+        assert gpos == Interval(1900)
+
+    def test_right_after_transcript(self, tranverse_trans_rev_setup):
+        gpos = tranverse_trans_rev_setup.trans_evidence.traverse(2201, 100 - 1, ORIENT.RIGHT)
+        assert gpos == Interval(2300)
+
+    def test_right_within_transcript(self, tranverse_trans_rev_setup):
+        gpos = tranverse_trans_rev_setup.trans_evidence.traverse(1351, 100 - 1, ORIENT.RIGHT)
+        assert gpos == Interval(1750)
+
+    def test_right_within_exon(self, tranverse_trans_rev_setup):
+        gpos = tranverse_trans_rev_setup.trans_evidence.traverse(1351, 10 - 1, ORIENT.RIGHT)
+        assert gpos == Interval(1360)
+
+
+@pytest.fixture
+def trans_window_setup():
+    n = argparse.Namespace()
+    gene = Gene('1', 1, 9999, name='KRAS', strand=STRAND.POS)
+    n.pre_transcript = PreTranscript(
+        gene=gene, exons=[(1001, 1100), (1401, 1500), (1701, 1750), (3001, 4000)]
+    )
+    gene.unspliced_transcripts.append(n.pre_transcript)
+    for spl in n.pre_transcript.generate_splicing_patterns():
+        n.pre_transcript.transcripts.append(Transcript(n.pre_transcript, spl))
+    n.annotations = {gene.chr: [gene]}
+    n.genome_evidence = MockObject(
+        annotations={},
+        read_length=100,
+        max_expected_fragment_size=550,
+        config={**DEFAULTS, 'validate.call_error': 11},
+    )
+    n.trans_evidence = MockObject(
+        annotations={},
+        read_length=100,
+        max_expected_fragment_size=550,
+        overlapping_transcripts={n.pre_transcript},
+        config={**DEFAULTS, 'validate.call_error': 11},
+    )
+    setattr(
+        n.trans_evidence,
+        '_select_transcripts',
+        lambda *pos: n.trans_evidence.overlapping_transcripts,
+    )
+    setattr(
+        n.trans_evidence,
+        'traverse',
+        partial(TranscriptomeEvidence.traverse, n.trans_evidence),
+    )
+    return n
+
+
+def transcriptome_window(ev, breakpoint, transcripts=None):
+    if transcripts:
+        ev.overlapping_transcripts.update(transcripts)
+    return TranscriptomeEvidence.generate_window(ev, breakpoint)
+
+
+class TestTranscriptomeEvidenceWindow:
+    def test_before_start(self, trans_window_setup):
         b = Breakpoint(chr='1', start=100, orient=ORIENT.RIGHT)
-        self.assertEqual(self.genome_window(b), self.transcriptome_window(b))
+        assert transcriptome_window(
+            trans_window_setup.trans_evidence, b
+        ) == GenomeEvidence.generate_window(trans_window_setup.genome_evidence, b)
 
         b = Breakpoint(chr='1', start=500, orient=ORIENT.RIGHT)
-        self.assertEqual(self.genome_window(b), self.transcriptome_window(b))
+        assert transcriptome_window(
+            trans_window_setup.trans_evidence, b
+        ) == GenomeEvidence.generate_window(trans_window_setup.genome_evidence, b)
 
-    def test_after_end(self):
+    def test_after_end(self, trans_window_setup):
         b = Breakpoint(chr='1', start=6000, orient=ORIENT.RIGHT)
-        self.assertEqual(self.genome_window(b), self.transcriptome_window(b))
+        assert transcriptome_window(
+            trans_window_setup.trans_evidence, b
+        ) == GenomeEvidence.generate_window(trans_window_setup.genome_evidence, b)
 
-    def test_exonic_long_exon(self):
+    def test_exonic_long_exon(self, trans_window_setup):
         b = Breakpoint(chr='1', start=3200, orient=ORIENT.RIGHT)
-        self.assertEqual(self.genome_window(b), self.transcriptome_window(b))
+        assert transcriptome_window(
+            trans_window_setup.trans_evidence, b
+        ) == GenomeEvidence.generate_window(trans_window_setup.genome_evidence, b)
 
-    def test_intronic_long_exon(self):
+    def test_intronic_long_exon(self, trans_window_setup):
         b = Breakpoint(chr='1', start=2970, orient=ORIENT.RIGHT)
-        self.assertEqual(self.genome_window(b), self.transcriptome_window(b))
+        assert transcriptome_window(
+            trans_window_setup.trans_evidence, b
+        ) == GenomeEvidence.generate_window(trans_window_setup.genome_evidence, b)
 
-    def test_intronic_long_intron(self):
+    def test_intronic_long_intron(self, trans_window_setup):
         b = Breakpoint(chr='1', start=1800, orient=ORIENT.RIGHT)
-        print(self.genome_window(b))
-        self.assertEqual(Interval(1490, 2360), self.transcriptome_window(b))
+        assert transcriptome_window(trans_window_setup.trans_evidence, b) == Interval(1490, 2360)
 
-    def test_intronic_short_exon_right(self):
+    def test_intronic_short_exon_right(self, trans_window_setup):
         b = Breakpoint(chr='1', start=1690, orient=ORIENT.RIGHT)
-        print(self.genome_window(b))
-        self.assertEqual(Interval(1580, 3500), self.transcriptome_window(b))
+        assert transcriptome_window(trans_window_setup.trans_evidence, b) == Interval(1580, 3500)
 
-    def test_intronic_short_exon_left(self):
+    def test_intronic_short_exon_left(self, trans_window_setup):
         b = Breakpoint(chr='1', start=2200, orient=ORIENT.LEFT)
-        self.assertEqual(Interval(1440, 2310), self.transcriptome_window(b))
+        assert transcriptome_window(trans_window_setup.trans_evidence, b) == Interval(1440, 2310)
 
-    def test_multiple_transcripts(self):
+    def test_multiple_transcripts(self, trans_window_setup):
         #  [(1001, 1100), (1401, 1500), (1701, 1750), (3001, 4000)])
         b = Breakpoint(chr='1', start=1150, orient=ORIENT.RIGHT)
-        gene = self.annotations['1'][0]
+        gene = trans_window_setup.annotations['1'][0]
         t2 = PreTranscript(gene=gene, exons=[(1001, 1100), (1200, 1300), (2100, 2200)])
         for patt in t2.generate_splicing_patterns():
             t2.transcripts.append(Transcript(t2, patt))
         gene.transcripts.append(t2)
         # 989 - 2561
         # 989 - 3411
-        self.assertEqual(
-            Interval(1040, 3160), self.transcriptome_window(b, [self.pre_transcript, t2])
-        )
+        assert transcriptome_window(
+            trans_window_setup.trans_evidence, b, [trans_window_setup.pre_transcript, t2]
+        ) == Interval(1040, 3160)
 
-    def test_many_small_exons(self):
+    def test_many_small_exons(self, trans_window_setup):
         g = Gene('fake', 17271277, 17279592, strand='+')
         pre_transcript = PreTranscript(
             gene=g,
@@ -463,48 +489,45 @@ class TestTranscriptomeEvidenceWindow(unittest.TestCase):
         for patt in pre_transcript.generate_splicing_patterns():
             pre_transcript.transcripts.append(Transcript(pre_transcript, patt))
         b = Breakpoint(chr='fake', start=17279591, orient=ORIENT.LEFT)
-        self.assertEqual(
-            Interval(17277321, 17279701), self.transcriptome_window(b, [pre_transcript])
-        )
+        assert transcriptome_window(
+            trans_window_setup.trans_evidence, b, [pre_transcript]
+        ) == Interval(17277321, 17279701)
 
 
-class TestNetSizeTrans(unittest.TestCase):
-    def setUp(self):
-        self.transcript = PreTranscript(
-            [(1001, 1100), (1301, 1400), (1701, 1800)], strand=STRAND.POS
-        )
-        for patt in self.transcript.generate_splicing_patterns():
-            self.transcript.transcripts.append(Transcript(self.transcript, patt))
-        self.trans_evidence = MockObject(
+class TestNetSizeTrans:
+    def test_net_zero(self):
+        transcript = PreTranscript([(1001, 1100), (1301, 1400), (1701, 1800)], strand=STRAND.POS)
+        for patt in transcript.generate_splicing_patterns():
+            transcript.transcripts.append(Transcript(transcript, patt))
+        trans_evidence = MockObject(
             annotations={},
             read_length=100,
             max_expected_fragment_size=550,
             call_error=11,
-            overlapping_transcripts={self.transcript},
+            overlapping_transcripts={transcript},
         )
         setattr(
-            self.trans_evidence,
+            trans_evidence,
             '_select_transcripts',
-            lambda *pos: self.trans_evidence.overlapping_transcripts,
+            lambda *pos: trans_evidence.overlapping_transcripts,
         )
         setattr(
-            self.trans_evidence,
+            trans_evidence,
             'distance',
-            partial(TranscriptomeEvidence.distance, self.trans_evidence),
+            partial(TranscriptomeEvidence.distance, trans_evidence),
         )
 
-    def test_net_zero(self):
         bpp = BreakpointPair(
             Breakpoint('1', 1099, orient=ORIENT.LEFT),
             Breakpoint('1', 1302, orient=ORIENT.RIGHT),
             untemplated_seq='TT',
         )
-        dist = partial(TranscriptomeEvidence.distance, self.trans_evidence)
-        self.assertEqual(Interval(-200), bpp.net_size())
-        self.assertEqual(Interval(0), bpp.net_size(dist))
+        dist = partial(TranscriptomeEvidence.distance, trans_evidence)
+        assert bpp.net_size() == Interval(-200)
+        assert bpp.net_size(dist) == Interval(0)
 
 
-class TestGenomeEvidenceWindow(unittest.TestCase):
+class TestGenomeEvidenceWindow:
     def test_orient_ns(self):
         bpp = Breakpoint(chr='1', start=1000, end=1000, orient=ORIENT.NS)
         window = GenomeEvidence.generate_window(
@@ -515,9 +538,9 @@ class TestGenomeEvidenceWindow(unittest.TestCase):
             ),
             bpp,
         )
-        self.assertEqual(440, window.start)
-        self.assertEqual(1560, window.end)
-        self.assertEqual(1121, len(window))
+        assert window.start == 440
+        assert window.end == 1560
+        assert len(window) == 1121
 
     def test_orient_left(self):
         bpp = Breakpoint(chr='1', start=1000, end=1000, orient=ORIENT.LEFT)
@@ -529,9 +552,9 @@ class TestGenomeEvidenceWindow(unittest.TestCase):
             ),
             bpp,
         )
-        self.assertEqual(440, window.start)
-        self.assertEqual(1110, window.end)
-        self.assertEqual(671, len(window))
+        assert window.start == 440
+        assert window.end == 1110
+        assert len(window) == 671
 
     def test_orient_right(self):
         bpp = Breakpoint(chr='1', start=1000, end=1000, orient=ORIENT.RIGHT)
@@ -543,9 +566,9 @@ class TestGenomeEvidenceWindow(unittest.TestCase):
             ),
             bpp,
         )
-        self.assertEqual(890, window.start)
-        self.assertEqual(1560, window.end)
-        self.assertEqual(671, len(window))
+        assert window.start == 890
+        assert window.end == 1560
+        assert len(window) == 671
 
     def test_window_accessors(self):
         ge = GenomeEvidence(
@@ -559,87 +582,89 @@ class TestGenomeEvidenceWindow(unittest.TestCase):
             median_fragment_size=100,
             config={'validate.stdev_count_abnormal': 1, 'validate.call_error': 0},
         )
-        self.assertEqual(901, ge.outer_window1.start)
-        self.assertEqual(1649, ge.outer_window1.end)
-        self.assertEqual(6600, ge.outer_window2.end)
-        self.assertEqual(5852, ge.outer_window2.start)
+        assert ge.outer_window1.start == 901
+        assert ge.outer_window1.end == 1649
+        assert ge.outer_window2.end == 6600
+        assert ge.outer_window2.start == 5852
 
-        self.assertEqual(1351, ge.inner_window1.start)
-        self.assertEqual(1649, ge.inner_window1.end)
-        self.assertEqual(6150, ge.inner_window2.end)
-        self.assertEqual(5852, ge.inner_window2.start)
+        assert ge.inner_window1.start == 1351
+        assert ge.inner_window1.end == 1649
+        assert ge.inner_window2.end == 6150
+        assert ge.inner_window2.start == 5852
 
 
-class TestGenomeEvidenceAddReads(unittest.TestCase):
-    def setUp(self):
-        self.ge = GenomeEvidence(
-            Breakpoint('1', 1500, orient=ORIENT.LEFT),
-            Breakpoint('1', 6001, orient=ORIENT.RIGHT),
-            BamCache(MockBamFileHandle({'1': 0})),
-            None,  # reference_genome
-            opposing_strands=False,
-            read_length=150,
-            stdev_fragment_size=500,
-            median_fragment_size=100,
-            config={'validate.stdev_count_abnormal': 1, 'validate.call_error': 0},
-        )
-        # outer windows (901, 1649)  (5852, 6600)
-        # inner windows (1351, 1649)  (5852, 6150)
+@pytest.fixture
+def flanking_ge(read_length):
+    return GenomeEvidence(
+        Breakpoint('1', 1500, orient=ORIENT.LEFT),
+        Breakpoint('1', 6001, orient=ORIENT.RIGHT),
+        BamCache(MockBamFileHandle({'1': 0})),
+        None,  # reference_genome
+        opposing_strands=False,
+        read_length=150,
+        stdev_fragment_size=500,
+        median_fragment_size=100,
+        config={'validate.stdev_count_abnormal': 1, 'validate.call_error': 0},
+    )
+    # outer windows (901, 1649)  (5852, 6600)
+    # inner windows (1351, 1649)  (5852, 6150)
 
-    def test_collect_flanking_pair_error_unmapped_read(self):
+
+class TestGenomeEvidenceAddReads:
+    def test_collect_flanking_pair_error_unmapped_read(self, flanking_ge):
         read, mate = mock_read_pair(
             MockRead('test', 0, 900, 1000, is_reverse=False),
             MockRead('test', 0, 6000, 6099, is_reverse=True),
         )
         read.is_unmapped = True
-        with self.assertRaises(ValueError):
-            self.ge.collect_flanking_pair(read, mate)
+        with pytest.raises(ValueError):
+            flanking_ge.collect_flanking_pair(read, mate)
 
-    def test_collect_flanking_pair_error_mate_unmapped(self):
+    def test_collect_flanking_pair_error_mate_unmapped(self, flanking_ge):
         read, mate = mock_read_pair(
             MockRead('test', 0, 900, 1000, is_reverse=False),
             MockRead('test', 0, 6000, 6099, is_reverse=True),
         )
         mate.is_unmapped = True
-        with self.assertRaises(ValueError):
-            self.ge.collect_flanking_pair(read, mate)
+        with pytest.raises(ValueError):
+            flanking_ge.collect_flanking_pair(read, mate)
 
-    def test_collect_flanking_pair_error_query_names_dont_match(self):
+    def test_collect_flanking_pair_error_query_names_dont_match(self, flanking_ge):
         read, mate = mock_read_pair(
             MockRead('test1', 0, 900, 1000, is_reverse=False),
             MockRead('test', 0, 6000, 6099, is_reverse=True),
         )
-        with self.assertRaises(ValueError):
-            self.ge.collect_flanking_pair(read, mate)
+        with pytest.raises(ValueError):
+            flanking_ge.collect_flanking_pair(read, mate)
 
-    def test_collect_flanking_pair_error_template_lengths_dont_match(self):
+    def test_collect_flanking_pair_error_template_lengths_dont_match(self, flanking_ge):
         read, mate = mock_read_pair(
             MockRead('test', 0, 900, 1000, is_reverse=False, template_length=50),
             MockRead('test', 0, 6000, 6099, is_reverse=True),
         )
         mate.template_length = 55
-        with self.assertRaises(ValueError):
-            self.ge.collect_flanking_pair(read, mate)
+        with pytest.raises(ValueError):
+            flanking_ge.collect_flanking_pair(read, mate)
 
-    def test_collect_flanking_pair_read_low_mq(self):
+    def test_collect_flanking_pair_read_low_mq(self, flanking_ge):
         read, mate = mock_read_pair(
             MockRead('test', 0, 900, 1000, is_reverse=False),
             MockRead('test', 0, 6000, 6099, is_reverse=True),
         )
         read.mapping_quality = 0
-        self.assertFalse(self.ge.collect_flanking_pair(read, mate))
+        assert not flanking_ge.collect_flanking_pair(read, mate)
 
-    def test_collect_flanking_pair_mate_low_mq(self):
+    def test_collect_flanking_pair_mate_low_mq(self, flanking_ge):
         read, mate = mock_read_pair(
             MockRead('test', 0, 900, 1000, is_reverse=False),
             MockRead('test', 0, 6000, 6099, is_reverse=True),
         )
         mate.mapping_quality = 0
-        self.assertFalse(self.ge.collect_flanking_pair(read, mate))
+        assert not flanking_ge.collect_flanking_pair(read, mate)
 
-    def test_collect_flanking_pair_interchromosomal(self):
+    def test_collect_flanking_pair_interchromosomal(self, flanking_ge):
         read, mate = mock_read_pair(
             MockRead('test', 1, 900, 1000, is_reverse=False),
             MockRead('test', 0, 6000, 6099, is_reverse=True),
         )
-        self.assertFalse(self.ge.collect_flanking_pair(read, mate))
+        assert not flanking_ge.collect_flanking_pair(read, mate)

--- a/tests/unit/test_annotate.py
+++ b/tests/unit/test_annotate.py
@@ -1,18 +1,16 @@
 import itertools
 import os
-import unittest
 
-from mavis.annotate.base import ReferenceName
-from mavis.annotate.protein import calculate_orf, Domain, DomainRegion
-from mavis.annotate.variant import IndelCall
+import pytest
 import timeout_decorator
-
-from .mock import Mock, MockFunction
+from mavis.annotate.base import ReferenceName
+from mavis.annotate.protein import Domain, DomainRegion, calculate_orf
+from mavis.annotate.variant import IndelCall
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
 
-class TestDomainAlignSeq(unittest.TestCase):
+class TestDomainAlignSeq:
     def test_large_combinations_finishes_with_error(self):
         input_seq = (
             'MADDEDYEEVVEYYTEEVVYEEVPGETITKIYETTTTRTSDYEQSETSKPALAQPALAQPASAKPVERRKVIRKKVDPSK'
@@ -273,100 +271,98 @@ class TestDomainAlignSeq(unittest.TestCase):
             regions.append(DomainRegion(p, p + len(seq) - 1, seq=seq))
             p += len(seq)
         d = Domain('name', regions=regions)
-        with self.assertRaises(UserWarning):
+        with pytest.raises(UserWarning):
             d.align_seq(input_seq)
 
 
-class TestCalculateORF(unittest.TestCase):
-    def setUp(self):
-        # load the sequence
-        with open(os.path.join(DATA_DIR, 'calc_orf_test_sequence.fa'), 'r') as fh:
-            self.seq = fh.readlines()[0].strip()
-
+class TestCalculateORF:
     @timeout_decorator.timeout(20)
     def test_very_long(self):
-        calculate_orf(self.seq, 300)
+        # load the sequence
+        with open(os.path.join(DATA_DIR, 'calc_orf_test_sequence.fa'), 'r') as fh:
+            seq = fh.readlines()[0].strip()
+        calculate_orf(seq, 300)
 
 
-class TestReferenceName(unittest.TestCase):
+class TestReferenceName:
     def test_naked_vs_naked_str(self):
-        self.assertEqual('1', ReferenceName('1'))
-        self.assertNotEqual('2', ReferenceName('1'))
-        self.assertTrue(ReferenceName('1') == '1')
-        self.assertTrue(ReferenceName('1') != '2')
+        assert ReferenceName('1') == '1'
+        assert ReferenceName('1') != '2'
+        assert ReferenceName('1') == '1'
+        assert ReferenceName('1') != '2'
 
     def test_naked_vs_prefixed_str(self):
-        self.assertEqual('chr1', ReferenceName('1'))
-        self.assertNotEqual('chr2', ReferenceName('1'))
-        self.assertTrue(ReferenceName('1') == 'chr1')
-        self.assertTrue(ReferenceName('1') != 'chr2')
+        assert ReferenceName('1') == 'chr1'
+        assert ReferenceName('1') != 'chr2'
+        assert ReferenceName('1') == 'chr1'
+        assert ReferenceName('1') != 'chr2'
 
     def test_prefixed_vs_prefixed_str(self):
-        self.assertEqual('chr1', ReferenceName('chr1'))
-        self.assertNotEqual('chr2', ReferenceName('chr1'))
-        self.assertTrue(ReferenceName('chr1') == 'chr1')
-        self.assertTrue(ReferenceName('chr1') != 'chr2')
+        assert ReferenceName('chr1') == 'chr1'
+        assert ReferenceName('chr1') != 'chr2'
+        assert ReferenceName('chr1') == 'chr1'
+        assert ReferenceName('chr1') != 'chr2'
 
     def test_prefixed_vs_naked_str(self):
-        self.assertEqual('1', ReferenceName('chr1'))
-        self.assertNotEqual('2', ReferenceName('chr1'))
-        self.assertTrue(ReferenceName('chr1') == '1')
+        assert ReferenceName('chr1') == '1'
+        assert ReferenceName('chr1') != '2'
+        assert ReferenceName('chr1') == '1'
 
     def test_obj_comparison(self):
         r = ReferenceName('1')
         rprefix = ReferenceName('chr1')
         r2 = ReferenceName('2')
         r2prefix = ReferenceName('chr2')
-        self.assertEqual(r, rprefix)
-        self.assertEqual(rprefix, r)
-        self.assertEqual(rprefix, ReferenceName('chr1'))
-        self.assertEqual(r, ReferenceName('1'))
-        self.assertNotEqual(r2, rprefix)
-        self.assertNotEqual(r2prefix, rprefix)
-        self.assertNotEqual(r2, r)
-        self.assertNotEqual(r2prefix, r)
-        self.assertTrue(r == rprefix)
-        self.assertTrue(r != r2prefix)
-        self.assertFalse(r != rprefix)
+        assert rprefix == r
+        assert r == rprefix
+        assert ReferenceName('chr1') == rprefix
+        assert ReferenceName('1') == r
+        assert rprefix != r2
+        assert rprefix != r2prefix
+        assert r != r2
+        assert r != r2prefix
+        assert r == rprefix
+        assert r != r2prefix
+        assert not r != rprefix
 
     def test_lt(self):
         r = ReferenceName('1')
         rprefix = ReferenceName('chr1')
         r2 = ReferenceName('2')
         r2prefix = ReferenceName('chr2')
-        self.assertTrue(r <= rprefix)
-        self.assertFalse(r < rprefix)
-        self.assertFalse(rprefix < r)
-        self.assertTrue(rprefix <= r)
+        assert r <= rprefix
+        assert not r < rprefix
+        assert not rprefix < r
+        assert rprefix <= r
         for chr1, chr2 in itertools.product([r, rprefix], [r2, r2prefix]):
-            self.assertTrue(chr1 < chr2)
-            self.assertTrue(chr1 <= chr2)
+            assert chr1 < chr2
+            assert chr1 <= chr2
 
     def test_alpha_sort(self):
-        self.assertTrue(ReferenceName('10') < ReferenceName('3'))
-        self.assertTrue(ReferenceName('10') < ReferenceName('chr3'))
-        self.assertTrue(ReferenceName('chr10') < ReferenceName('3'))
-        self.assertTrue(ReferenceName('chr10') < ReferenceName('chr3'))
+        assert ReferenceName('10') < ReferenceName('3')
+        assert ReferenceName('10') < ReferenceName('chr3')
+        assert ReferenceName('chr10') < ReferenceName('3')
+        assert ReferenceName('chr10') < ReferenceName('chr3')
 
     def test_gt(self):
         r = ReferenceName('1')
         rprefix = ReferenceName('chr1')
         r2 = ReferenceName('2')
         r2prefix = ReferenceName('chr2')
-        self.assertTrue(rprefix >= r)
-        self.assertTrue(r >= rprefix)
-        self.assertFalse(r > rprefix)
-        self.assertFalse(rprefix > r)
+        assert rprefix >= r
+        assert r >= rprefix
+        assert not r > rprefix
+        assert not rprefix > r
         for chr1, chr2 in itertools.product([r, rprefix], [r2, r2prefix]):
-            self.assertTrue(chr2 > chr1)
-            self.assertTrue(chr2 >= chr1)
+            assert chr2 > chr1
+            assert chr2 >= chr1
 
     def test_hash(self):
-        self.assertTrue(ReferenceName('3') in {ReferenceName('3')})
-        self.assertTrue(ReferenceName('3') in {ReferenceName('chr3')})
+        assert ReferenceName('3') in {ReferenceName('3')}
+        assert ReferenceName('3') in {ReferenceName('chr3')}
 
 
-class TestIndelCall(unittest.TestCase):
+class TestIndelCall:
     def test_duplication_in_repeat(self):
         ref = 'ASFHGHGSFSFSLLLLLL' 'FLLLLSFSLMVPWSFKW'
         mut = 'ASFHGHGSFSFSLLLLLLL' 'FLLLLSFSLMVPWSFKW'
@@ -374,11 +370,11 @@ class TestIndelCall(unittest.TestCase):
         call = IndelCall(ref, mut)
         print(call)
 
-        self.assertEqual(18, call.nterm_aligned)
-        self.assertEqual(len(ref) - 13 + 1, call.cterm_aligned)
-        self.assertTrue(call.is_dup)
+        assert call.nterm_aligned == 18
+        assert call.cterm_aligned == len(ref) - 13 + 1
+        assert call.is_dup
 
-        self.assertEqual('p.L18dupL', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.L18dupL'
 
     def test_nterminal_extension(self):
 
@@ -387,13 +383,13 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertFalse(call.nterm_aligned)
-        self.assertEqual(len(call.ref_seq) - 1 + 1, call.cterm_aligned)
-        self.assertFalse(call.is_dup)
-        self.assertEqual('MAF', call.ins_seq)
-        self.assertEqual('', call.del_seq)
+        assert not call.nterm_aligned
+        assert call.cterm_aligned == len(call.ref_seq) - 1 + 1
+        assert not call.is_dup
+        assert call.ins_seq == 'MAF'
+        assert call.del_seq == ''
 
-        self.assertEqual('p.M1ext-3', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.M1ext-3'
 
     def test_nterminal_deletion(self):
         ref = 'MABCDEFGH'
@@ -401,13 +397,13 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertFalse(call.nterm_aligned)
-        self.assertEqual(len(call.ref_seq) - 4 + 1, call.cterm_aligned)
-        self.assertFalse(call.is_dup)
-        self.assertEqual('', call.ins_seq)
-        self.assertEqual('MAB', call.del_seq)
+        assert not call.nterm_aligned
+        assert call.cterm_aligned == len(call.ref_seq) - 4 + 1
+        assert not call.is_dup
+        assert call.ins_seq == ''
+        assert call.del_seq == 'MAB'
 
-        self.assertEqual('p.M1_B3delMAB', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.M1_B3delMAB'
 
     def test_cterminal_deletion(self):
         ref = 'MABCDEFGH'
@@ -415,13 +411,13 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertEqual(6, call.nterm_aligned)
-        self.assertFalse(call.cterm_aligned)
-        self.assertFalse(call.is_dup)
-        self.assertEqual('', call.ins_seq)
-        self.assertEqual('FGH', call.del_seq)
+        assert call.nterm_aligned == 6
+        assert not call.cterm_aligned
+        assert not call.is_dup
+        assert call.ins_seq == ''
+        assert call.del_seq == 'FGH'
 
-        self.assertEqual('p.F7_H9delFGH', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.F7_H9delFGH'
 
     def test_cterminal_extension(self):
         ref = 'MABCDEFGH'
@@ -429,13 +425,13 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertEqual(9, call.nterm_aligned)
-        self.assertFalse(call.cterm_aligned)
-        self.assertFalse(call.is_dup)
-        self.assertEqual('IJK', call.ins_seq)
-        self.assertEqual('', call.del_seq)
+        assert call.nterm_aligned == 9
+        assert not call.cterm_aligned
+        assert not call.is_dup
+        assert call.ins_seq == 'IJK'
+        assert call.del_seq == ''
 
-        self.assertEqual('p.H9ext3', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.H9ext3'
 
     def test_cterminal_stop_extension(self):
         ref = 'MABCDEFGH*'
@@ -443,13 +439,13 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertEqual(9, call.nterm_aligned)
-        self.assertFalse(call.cterm_aligned)
-        self.assertFalse(call.is_dup)
-        self.assertEqual('IJK', call.ins_seq)
-        self.assertEqual('', call.del_seq)
+        assert call.nterm_aligned == 9
+        assert not call.cterm_aligned
+        assert not call.is_dup
+        assert call.ins_seq == 'IJK'
+        assert call.del_seq == ''
 
-        self.assertEqual('p.*10ext*3', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.*10ext*3'
 
     def test_cterminal_no_orf_ext(self):
         ref = 'MABCDEFGH'
@@ -457,13 +453,13 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertEqual(9, call.nterm_aligned)
-        self.assertFalse(call.cterm_aligned)
-        self.assertFalse(call.is_dup)
-        self.assertEqual('IJK*', call.ins_seq)
-        self.assertEqual('', call.del_seq)
+        assert call.nterm_aligned == 9
+        assert not call.cterm_aligned
+        assert not call.is_dup
+        assert call.ins_seq == 'IJK*'
+        assert call.del_seq == ''
 
-        self.assertEqual('p.H9ext*4', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.H9ext*4'
 
     def test_single_aa_insertion(self):
         ref = 'MABCDEFGH'
@@ -471,13 +467,13 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertEqual(4, call.nterm_aligned)
-        self.assertEqual(len(call.ref_seq) - 5 + 1, call.cterm_aligned)
-        self.assertFalse(call.is_dup)
-        self.assertEqual('K', call.ins_seq)
-        self.assertEqual('', call.del_seq)
+        assert call.nterm_aligned == 4
+        assert call.cterm_aligned == len(call.ref_seq) - 5 + 1
+        assert not call.is_dup
+        assert call.ins_seq == 'K'
+        assert call.del_seq == ''
 
-        self.assertEqual('p.C4_D5insK', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.C4_D5insK'
 
     def test_insertion(self):
         ref = 'MABCDEFGH'
@@ -485,13 +481,13 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertEqual(4, call.nterm_aligned)
-        self.assertEqual(len(call.ref_seq) - 5 + 1, call.cterm_aligned)
-        self.assertFalse(call.is_dup)
-        self.assertEqual('KA', call.ins_seq)
-        self.assertEqual('', call.del_seq)
+        assert call.nterm_aligned == 4
+        assert call.cterm_aligned == len(call.ref_seq) - 5 + 1
+        assert not call.is_dup
+        assert call.ins_seq == 'KA'
+        assert call.del_seq == ''
 
-        self.assertEqual('p.C4_D5insKA', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.C4_D5insKA'
 
     def test_single_aa_deletion(self):
         ref = 'MABCDEFGH'
@@ -499,13 +495,13 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertEqual(4, call.nterm_aligned)
-        self.assertEqual(len(call.ref_seq) - 6 + 1, call.cterm_aligned)
-        self.assertFalse(call.is_dup)
-        self.assertEqual('', call.ins_seq)
-        self.assertEqual('D', call.del_seq)
+        assert call.nterm_aligned == 4
+        assert call.cterm_aligned == len(call.ref_seq) - 6 + 1
+        assert not call.is_dup
+        assert call.ins_seq == ''
+        assert call.del_seq == 'D'
 
-        self.assertEqual('p.D5delD', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.D5delD'
 
     def test_deletion(self):
         ref = 'MABCDEFGH'
@@ -513,13 +509,13 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertEqual(4, call.nterm_aligned)
-        self.assertEqual(len(call.ref_seq) - 7 + 1, call.cterm_aligned)
-        self.assertFalse(call.is_dup)
-        self.assertEqual('', call.ins_seq)
-        self.assertEqual('DE', call.del_seq)
+        assert call.nterm_aligned == 4
+        assert call.cterm_aligned == len(call.ref_seq) - 7 + 1
+        assert not call.is_dup
+        assert call.ins_seq == ''
+        assert call.del_seq == 'DE'
 
-        self.assertEqual('p.D5_E6delDE', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.D5_E6delDE'
 
     def test_deletion_in_repeat(self):
         ref = 'MABCDEEEEEEFGH'
@@ -527,13 +523,13 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertEqual(9, call.nterm_aligned)
-        self.assertEqual(len(call.ref_seq) - 8 + 1, call.cterm_aligned)
-        self.assertFalse(call.is_dup)
-        self.assertEqual('', call.ins_seq)
-        self.assertEqual('EE', call.del_seq)
+        assert call.nterm_aligned == 9
+        assert call.cterm_aligned == len(call.ref_seq) - 8 + 1
+        assert not call.is_dup
+        assert call.ins_seq == ''
+        assert call.del_seq == 'EE'
 
-        self.assertEqual('p.E10_E11delEE', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.E10_E11delEE'
 
     def test_insertion_in_repeat(self):
         ref = 'MABCDEEEEFGH'
@@ -541,10 +537,10 @@ class TestIndelCall(unittest.TestCase):
 
         call = IndelCall(ref, mut)
         print(call)
-        self.assertEqual(9, call.nterm_aligned)
-        self.assertEqual(len(call.ref_seq) - 6 + 1, call.cterm_aligned)
-        self.assertTrue(call.is_dup)
-        self.assertEqual('EE', call.ins_seq)
-        self.assertEqual('', call.del_seq)
+        assert call.nterm_aligned == 9
+        assert call.cterm_aligned == len(call.ref_seq) - 6 + 1
+        assert call.is_dup
+        assert call.ins_seq == 'EE'
+        assert call.del_seq == ''
 
-        self.assertEqual('p.E8_E9dupEE', call.hgvs_protein_notation())
+        assert call.hgvs_protein_notation() == 'p.E8_E9dupEE'

--- a/tests/unit/test_assemble.py
+++ b/tests/unit/test_assemble.py
@@ -1,81 +1,82 @@
 import itertools
-import random
 import os
-import unittest
-import pytest
+import random
 
-from mavis.assemble import assemble, Contig, DeBruijnGraph, filter_contigs, kmers
+import pytest
+from mavis.assemble import Contig, DeBruijnGraph, assemble, filter_contigs, kmers
 from mavis.constants import DNA_ALPHABET
+
+from ..util import long_running_test
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
 
-class TestModule(unittest.TestCase):
+class TestModule:
     """
     test class for functions in the validate namespace
     that are not associated with a class
     """
 
     def test_alphabet_matching(self):
-        self.assertTrue(DNA_ALPHABET.match('N', 'A'))
-        self.assertTrue(DNA_ALPHABET.match('A', 'N'))
+        assert DNA_ALPHABET.match('N', 'A')
+        assert DNA_ALPHABET.match('A', 'N')
 
     def test_kmers(self):
         k = kmers('ABCDEFG', 2)
-        self.assertEqual(['AB', 'BC', 'CD', 'DE', 'EF', 'FG'], k)
+        assert k == ['AB', 'BC', 'CD', 'DE', 'EF', 'FG']
         k = kmers('ABCDEFG', 3)
-        self.assertEqual(['ABC', 'BCD', 'CDE', 'DEF', 'EFG'], k)
+        assert k == ['ABC', 'BCD', 'CDE', 'DEF', 'EFG']
 
     def test_assemble(self):
         sequences = ['ABCD', 'BCDE', 'CDEF', 'ABCDE', 'DEFG']
         c = assemble(sequences, 3, min_edge_trim_weight=1, remap_min_exact_match=1)
-        self.assertEqual(1, len(c))
-        self.assertEqual('ABCDEFG', c[0].seq)
-        self.assertEqual(5, c[0].remap_score())
+        assert len(c) == 1
+        assert c[0].seq == 'ABCDEFG'
+        assert c[0].remap_score() == 5
 
     def test_assemble_empty_list(self):
-        self.assertEqual([], assemble([], 1))
+        assert assemble([], 1) == []
 
     def test_repeat_region_assembly(self):
         rep = 'ABCDEF'
         seqs = kmers(rep + rep, len(rep))
         contigs = assemble(seqs, len(rep) - 1, remap_min_exact_match=1)
-        self.assertEqual(0, len(contigs))
+        assert len(contigs) == 0
 
 
-class TestFilterContigs(unittest.TestCase):
+class TestFilterContigs:
     def test_drop_reverse_complement(self):
         c1 = Contig('atcgatcgatcgatcgatcgatcgatatagggcatcagc', 1)
         c2 = Contig('gctgatgccctatatcgatcgatcgatcgatcgatcgat', 1)
         result = filter_contigs([c2, c1], 0.10)
-        self.assertEqual(1, len(result))
-        self.assertEqual(c1.seq, result[0].seq)
+        assert len(result) == 1
+        assert result[0].seq == c1.seq
 
     def test_drop_alt_allele_alphabetically(self):
         c1 = Contig('atcgatcgatcgatcgatcgatcgatatagggcatcagc', 1)
         c2 = Contig('atcgatcgatcgatcgatctatcgatatagggcatcagc', 1)
         result = filter_contigs([c2, c1], 0.10)
-        self.assertEqual(1, len(result))
-        self.assertEqual(c1.seq, result[0].seq)
+        assert len(result) == 1
+        assert result[0].seq == c1.seq
 
     def test_drop_alt_allele_by_score(self):
         c1 = Contig('atcgatcgatcgatcgatcgatcgatatagggcatcagc', 2)
         c2 = Contig('atcgatcgatcgatcgatctatcgatatagggcatcagc', 1)
         result = filter_contigs([c2, c1], 0.10)
-        self.assertEqual(1, len(result))
-        self.assertEqual(c1.seq, result[0].seq)
+        assert len(result) == 1
+        assert result[0].seq == c1.seq
 
     def test_retain_disimilar(self):
         c1 = Contig('atcgatcgatcgatcgatcgatcgatatagggcatcagc', 2)
         c2 = Contig('atcgadatcgatcgatcgatctgtdstcgatatagggca', 1)
         result = filter_contigs([c2, c1], 0.10)
-        self.assertEqual(2, len(result))
+        assert len(result) == 2
 
     def test_retain_disimilar_different_lengths(self):
         c1 = Contig('atcgatcgatcgatcgatcgatcgatatagggcatcagc', 2)
         c2 = Contig('atcgatcgatcgatcgatcgatcccgtgatatagggcatcagc', 1)
         result = filter_contigs([c2, c1], 0.10)
-        self.assertEqual(2, len(result))
+        assert len(result) == 2
 
     def test_drop_similar_different_lengths(self):
         c1 = Contig(
@@ -87,12 +88,12 @@ class TestFilterContigs(unittest.TestCase):
             1,
         )
         result = filter_contigs([c2, c1], 0.10)
-        self.assertEqual(1, len(result))
-        self.assertEqual(c1.seq, result[0].seq)
+        assert len(result) == 1
+        assert result[0].seq == c1.seq
 
 
-class TestDeBruijnGraph(unittest.TestCase):
-    @pytest.mark.skipif(os.environ.get('RUN_FULL', '0') != '1', reason='running short tests only')
+class TestDeBruijnGraph:
+    @long_running_test
     def test_trim_tails_by_freq_forks(self):
         g = DeBruijnGraph()
         for s, t in itertools.combinations([1, 2, 3, 4, 5, 6], 2):
@@ -104,7 +105,7 @@ class TestDeBruijnGraph(unittest.TestCase):
         g.add_edge(8, 7)
         g.add_edge(9, 8)
         g.trim_tails_by_freq(2)
-        self.assertEqual([1, 2, 3, 4, 5, 6], sorted(g.nodes()))
+        assert sorted(g.nodes()) == [1, 2, 3, 4, 5, 6]
 
         g = DeBruijnGraph()
         for s, t in itertools.combinations([1, 2, 3, 4, 5, 6], 2):
@@ -116,7 +117,7 @@ class TestDeBruijnGraph(unittest.TestCase):
         g.add_edge(8, 7)
         g.add_edge(9, 8)
         g.trim_tails_by_freq(2)
-        self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8], sorted(g.nodes()))
+        assert sorted(g.nodes()) == [1, 2, 3, 4, 5, 6, 7, 8]
 
         g = DeBruijnGraph()
         for s, t in itertools.combinations([1, 2, 3, 4, 5, 6], 2):
@@ -127,16 +128,16 @@ class TestDeBruijnGraph(unittest.TestCase):
         g.add_edge(7, 8)
         g.add_edge(9, 8)
         g.trim_tails_by_freq(2)
-        self.assertEqual([1, 2, 3, 4, 5, 6], sorted(g.nodes()))
+        assert sorted(g.nodes()) == [1, 2, 3, 4, 5, 6]
 
     def test_add_edge(self):
         g = DeBruijnGraph()
         g.add_edge(1, 2)
-        self.assertEqual(1, g.get_edge_freq(1, 2))
+        assert g.get_edge_freq(1, 2) == 1
         g.add_edge(1, 2)
-        self.assertEqual(2, g.get_edge_freq(1, 2))
+        assert g.get_edge_freq(1, 2) == 2
         g.add_edge(1, 2, 5)
-        self.assertEqual(7, g.get_edge_freq(1, 2))
+        assert g.get_edge_freq(1, 2) == 7
 
     def test_trim_noncutting_paths_by_freq_degree_stop(self):
         g = DeBruijnGraph()
@@ -150,7 +151,7 @@ class TestDeBruijnGraph(unittest.TestCase):
         for edge in g.edges():
             print(edge)
         g.trim_noncutting_paths_by_freq(3)
-        self.assertEqual(list(range(1, 9)) + path1[1:-1], g.nodes())
+        assert g.nodes() == list(range(1, 9)) + path1[1:-1]
 
         # add an equal weight path to force namesorting
         path2 = [5, 13, 14, 15, 16, 1]
@@ -158,14 +159,14 @@ class TestDeBruijnGraph(unittest.TestCase):
             g.add_edge(s, t)
 
         g.trim_noncutting_paths_by_freq(3)
-        self.assertEqual(list(range(1, 9)) + path2[1:-1], g.nodes())
+        assert g.nodes() == list(range(1, 9)) + path2[1:-1]
 
         # add back the original path with a higher (but still low) weight
         for s, t in zip(path1, path1[1:]):
             g.add_edge(s, t, freq=2)
 
         g.trim_noncutting_paths_by_freq(3)
-        self.assertEqual(list(range(1, 9)) + path1[1:-1], g.nodes())
+        assert g.nodes() == list(range(1, 9)) + path1[1:-1]
 
         # add the second path with 1 high weight edge
         path2 = [5, 13, 14, 15, 16, 1]
@@ -174,28 +175,31 @@ class TestDeBruijnGraph(unittest.TestCase):
         g.add_edge(14, 15, freq=6)
 
         g.trim_noncutting_paths_by_freq(3)
-        self.assertEqual(list(range(1, 9)) + path2[1:-1], g.nodes())
+        assert g.nodes() == list(range(1, 9)) + path2[1:-1]
 
 
-class TestFullAssemly(unittest.TestCase):
-    def setUp(self):
-        # load the sequences
-        with open(os.path.join(DATA_DIR, 'test_assembly_sequences.txt')) as fh:
-            self.seq = [i.strip() for i in fh.readlines()]
+@pytest.fixture
+def assembly_sequences():
+    # load the sequences
+    with open(os.path.join(DATA_DIR, 'test_assembly_sequences.txt')) as fh:
+        seq = [i.strip() for i in fh.readlines()]
+    return seq
 
-    @pytest.mark.skipif(os.environ.get('RUN_FULL', '0') != '1', reason='running short tests only')
-    def test_deterministic_assembly(self):
+
+class TestFullAssemly:
+    @long_running_test
+    def test_deterministic_assembly(self, assembly_sequences):
         contig_sequences = set()
         for i in range(20):
-            random.shuffle(self.seq)
+            random.shuffle(assembly_sequences)
             contigs = assemble(
-                self.seq,
+                assembly_sequences,
                 111,
                 min_edge_trim_weight=3,
                 assembly_max_paths=8,
                 assembly_min_uniq=0.1,
                 min_complexity=0.1,
             )
-            self.assertEqual(1, len(contigs))
+            assert len(contigs) == 1
             contig_sequences.add(contigs[0].seq)
-        self.assertEqual(1, len(contig_sequences))
+        assert len(contig_sequences) == 1

--- a/tests/unit/test_blat.py
+++ b/tests/unit/test_blat.py
@@ -1,12 +1,11 @@
-import unittest
-
+import pytest
 from mavis.blat import Blat
 from mavis.constants import CIGAR, reverse_complement
 
 from .mock import Mock, MockFunction, MockLongString
 
 
-class TestConvertPslxToPysam(unittest.TestCase):
+class TestConvertPslxToPysam:
     def test_simple(self):
         row = {
             'match': 142,
@@ -50,10 +49,10 @@ class TestConvertPslxToPysam(unittest.TestCase):
         }
         cache = Mock(reference_id=MockFunction(16))
         read = Blat.pslx_row_to_pysam(row, cache, refseq)
-        self.assertEqual(16, read.reference_id)
-        self.assertEqual('17', read.reference_name)
-        self.assertEqual(row['qseq_full'], reverse_complement(read.query_sequence))
-        self.assertEqual([(CIGAR.S, 62), (CIGAR.EQ, 142)], read.cigar)
+        assert read.reference_id == 16
+        assert read.reference_name == '17'
+        assert reverse_complement(read.query_sequence) == row['qseq_full']
+        assert read.cigar == [(CIGAR.S, 62), (CIGAR.EQ, 142)]
 
     def test_overlapping_blat_blocks_error(self):
         row = {
@@ -72,5 +71,5 @@ class TestConvertPslxToPysam(unittest.TestCase):
             ),
         }
         cache = Mock(reference_id=MockFunction(6))
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             Blat.pslx_row_to_pysam(row, cache, None)

--- a/tests/unit/test_breakpoint.py
+++ b/tests/unit/test_breakpoint.py
@@ -1,17 +1,16 @@
-import unittest
 from unittest.mock import Mock
 
+import pytest
 from mavis.breakpoint import Breakpoint, BreakpointPair
-from mavis.constants import COLUMNS, ORIENT, STRAND, SVTYPE
+from mavis.constants import ORIENT, STRAND, SVTYPE
 from mavis.error import InvalidRearrangement, NotSpecifiedError
 from mavis.interval import Interval
-from mavis.util import read_bpp_from_input_file
 
 
-class TestBreakpoint(unittest.TestCase):
+class TestBreakpoint:
     def test___eq__(self):
-        self.assertNotEqual(Breakpoint('1', 1), None)
-        self.assertEqual(Breakpoint('1', 1), Breakpoint('1', 1))
+        assert Breakpoint('1', 1) != None  # noqa: E711
+        assert Breakpoint('1', 1) == Breakpoint('1', 1)
 
     def test___hash__(self):
         b = Breakpoint('1', 1, 2)
@@ -22,44 +21,44 @@ class TestBreakpoint(unittest.TestCase):
         temp.add(b)
         temp.add(c)
         temp.add(d)
-        self.assertEqual(2, len(temp))
+        assert len(temp) == 2
 
         temp = dict()
         temp[b] = None
         temp[c] = None
         temp[d] = None
-        self.assertEqual(2, len(temp.keys()))
+        assert len(temp.keys()) == 2
 
     def test___len__(self):
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             Breakpoint('11', 87042760, 87041922, orient=ORIENT.LEFT, strand=STRAND.NS)
 
     def test_inherited_interval_methods(self):
         b = Breakpoint('1', 1, 10)
-        self.assertEqual(1, b[0])
-        self.assertEqual(10, b[1])
-        self.assertEqual(10, len(b))
+        assert b[0] == 1
+        assert b[1] == 10
+        assert len(b) == 10
 
     def test_breakpoint_constructor(self):
         b = Breakpoint('1', 10, 50)
-        self.assertEqual(10, b[0])
-        self.assertEqual(50, b[1])
-        self.assertTrue(Interval.overlaps((1, 10), b))
-        self.assertTrue(Interval.overlaps((50, 55), b))
-        self.assertFalse(Interval.overlaps((1, 9), b))
+        assert b[0] == 10
+        assert b[1] == 50
+        assert Interval.overlaps((1, 10), b)
+        assert Interval.overlaps((50, 55), b)
+        assert not Interval.overlaps((1, 9), b)
 
 
-class TestBreakpointPair(unittest.TestCase):
+class TestBreakpointPair:
     def test___eq__(self):
         b = BreakpointPair(Breakpoint('1', 1), Breakpoint('1', 3), opposing_strands=True)
         c = BreakpointPair(Breakpoint('1', 1), Breakpoint('1', 3), opposing_strands=True)
-        self.assertFalse(b is c)
-        self.assertEqual(b, c)
+        assert b is not c
+        assert c == b
         d = BreakpointPair(
             Breakpoint('1', 1), Breakpoint('1', 3), opposing_strands=True, untemplated_seq=''
         )
-        self.assertNotEqual(b, d)
-        self.assertNotEqual(b, None)
+        assert d != b
+        assert None != b  # noqa: E711
 
     def test___hash__(self):
         b = BreakpointPair(Breakpoint('1', 1), Breakpoint('1', 3), opposing_strands=True)
@@ -67,31 +66,31 @@ class TestBreakpointPair(unittest.TestCase):
         d = BreakpointPair(
             Breakpoint('1', 1), Breakpoint('1', 3), opposing_strands=True, untemplated_seq=''
         )
-        self.assertFalse(b is c)
+        assert b is not c
         temp = dict()
         temp[b] = None
         temp[d] = None
         temp[c] = None
-        self.assertEqual(2, len(temp.keys()))
+        assert len(temp.keys()) == 2
 
         temp = set()
         temp.add(b)
         temp.add(c)
         temp.add(d)
-        self.assertEqual(2, len(temp))
+        assert len(temp) == 2
 
     def test___init__swap_break_order(self):
         b1 = Breakpoint('1', 1)
         b2 = Breakpoint('1', 50)
         bpp = BreakpointPair(b1, b2, opposing_strands=True)
-        self.assertEqual(bpp.break1, b1)
-        self.assertEqual(bpp.break2, b2)
+        assert b1 == bpp.break1
+        assert b2 == bpp.break2
         bpp = BreakpointPair(b2, b1, opposing_strands=True)
-        self.assertEqual(bpp.break1, b1)
-        self.assertEqual(bpp.break2, b2)
+        assert b1 == bpp.break1
+        assert b2 == bpp.break2
 
     def test___init__opstrand_conflict(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             BreakpointPair(
                 Breakpoint('1', 1, strand=STRAND.POS),
                 Breakpoint('1', 2, strand=STRAND.POS),
@@ -100,16 +99,16 @@ class TestBreakpointPair(unittest.TestCase):
 
     def test___init__opstrand_indv_not_specified(self):
         bpp = BreakpointPair(Breakpoint('test', 1), Breakpoint('test', 10), opposing_strands=True)
-        self.assertTrue(bpp.opposing_strands)
+        assert bpp.opposing_strands
         bpp = BreakpointPair(Breakpoint('test', 1), Breakpoint('test', 10), opposing_strands=False)
-        self.assertFalse(bpp.opposing_strands)
+        assert not bpp.opposing_strands
 
     def test___init__opstrand_not_specified(self):
-        with self.assertRaises(NotSpecifiedError):
+        with pytest.raises(NotSpecifiedError):
             BreakpointPair(Breakpoint('1', 1), Breakpoint('1', 2))
 
     def test___init__stranded(self):
-        with self.assertRaises(NotSpecifiedError):
+        with pytest.raises(NotSpecifiedError):
             BreakpointPair(
                 Breakpoint('1', 1), Breakpoint('1', 2), stranded=True, opposing_strands=True
             )
@@ -118,25 +117,25 @@ class TestBreakpointPair(unittest.TestCase):
         bp1 = Breakpoint(1, 1, 2, ORIENT.LEFT)
         bp2 = Breakpoint(2, 1, 2, ORIENT.LEFT)
         bpp = BreakpointPair(bp1, bp2, opposing_strands=True)
-        self.assertEqual(bpp[0], bp1)
-        self.assertEqual(bpp[1], bp2)
-        with self.assertRaises(IndexError):
+        assert bp1 == bpp[0]
+        assert bp2 == bpp[1]
+        with pytest.raises(IndexError):
             bpp['?']
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             bpp[2]
 
     def test_interchromosomal(self):
         bp1 = Breakpoint(1, 1, 2, ORIENT.LEFT)
         bp2 = Breakpoint(2, 1, 2, ORIENT.LEFT)
         bpp = BreakpointPair(bp1, bp2, opposing_strands=True)
-        self.assertTrue(bpp.interchromosomal)
+        assert bpp.interchromosomal
         bp1 = Breakpoint(1, 1, 2, ORIENT.LEFT)
         bp2 = Breakpoint(1, 7, 8, ORIENT.LEFT)
         bpp = BreakpointPair(bp1, bp2, opposing_strands=True)
-        self.assertFalse(bpp.interchromosomal)
+        assert not bpp.interchromosomal
 
     def test___init__invalid_intra_rprp(self):
-        with self.assertRaises(InvalidRearrangement):
+        with pytest.raises(InvalidRearrangement):
             BreakpointPair(
                 Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
                 Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.RIGHT),
@@ -144,7 +143,7 @@ class TestBreakpointPair(unittest.TestCase):
             )
 
     def test___init__invalid_intra_rnrn(self):
-        with self.assertRaises(InvalidRearrangement):
+        with pytest.raises(InvalidRearrangement):
             BreakpointPair(
                 Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.RIGHT),
                 Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.RIGHT),
@@ -152,7 +151,7 @@ class TestBreakpointPair(unittest.TestCase):
             )
 
     def test___init__invalid_intra_rpln(self):
-        with self.assertRaises(InvalidRearrangement):
+        with pytest.raises(InvalidRearrangement):
             BreakpointPair(
                 Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
                 Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.LEFT),
@@ -160,7 +159,7 @@ class TestBreakpointPair(unittest.TestCase):
             )
 
     def test___init__invalid_intra_lprn(self):
-        with self.assertRaises(InvalidRearrangement):
+        with pytest.raises(InvalidRearrangement):
             BreakpointPair(
                 Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.LEFT),
                 Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.RIGHT),
@@ -168,7 +167,7 @@ class TestBreakpointPair(unittest.TestCase):
             )
 
     def test___init__invalid_intra_rnlp(self):
-        with self.assertRaises(InvalidRearrangement):
+        with pytest.raises(InvalidRearrangement):
             BreakpointPair(
                 Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.RIGHT),
                 Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.LEFT),
@@ -176,7 +175,7 @@ class TestBreakpointPair(unittest.TestCase):
             )
 
     def test___init__invalid_intra_lnrp(self):
-        with self.assertRaises(InvalidRearrangement):
+        with pytest.raises(InvalidRearrangement):
             BreakpointPair(
                 Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.LEFT),
                 Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.RIGHT),
@@ -184,7 +183,7 @@ class TestBreakpointPair(unittest.TestCase):
             )
 
     def test___init__invalid_inter_rl_opp(self):
-        with self.assertRaises(InvalidRearrangement):
+        with pytest.raises(InvalidRearrangement):
             BreakpointPair(
                 Breakpoint(1, 1, 2, ORIENT.RIGHT),
                 Breakpoint(2, 1, 2, ORIENT.LEFT),
@@ -192,7 +191,7 @@ class TestBreakpointPair(unittest.TestCase):
             )
 
     def test___init__invalid_inter_lr_opp(self):
-        with self.assertRaises(InvalidRearrangement):
+        with pytest.raises(InvalidRearrangement):
             BreakpointPair(
                 Breakpoint(1, 1, 2, ORIENT.LEFT),
                 Breakpoint(2, 1, 2, ORIENT.RIGHT),
@@ -200,7 +199,7 @@ class TestBreakpointPair(unittest.TestCase):
             )
 
 
-class TestClassifyBreakpointPair(unittest.TestCase):
+class TestClassifyBreakpointPair:
     def test_inverted_translocation(self):
         b = BreakpointPair(
             Breakpoint(1, 1, 2, ORIENT.LEFT),
@@ -222,116 +221,116 @@ class TestClassifyBreakpointPair(unittest.TestCase):
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.RIGHT),
         )
-        self.assertEqual({SVTYPE.INV}, BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == {SVTYPE.INV}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.RIGHT),
         )
-        self.assertEqual({SVTYPE.INV}, BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == {SVTYPE.INV}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.NS),
         )
-        self.assertEqual({SVTYPE.INV}, BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == {SVTYPE.INV}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.NS),
         )
-        self.assertEqual({SVTYPE.INV}, BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == {SVTYPE.INV}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.LEFT),
         )
-        self.assertEqual({SVTYPE.INV}, BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == {SVTYPE.INV}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.LEFT),
         )
-        self.assertEqual({SVTYPE.INV}, BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == {SVTYPE.INV}
 
     def test_duplication(self):
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.LEFT),
         )
-        self.assertEqual({SVTYPE.DUP}, BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == {SVTYPE.DUP}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.LEFT),
         )
-        self.assertEqual({SVTYPE.DUP}, BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == {SVTYPE.DUP}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.LEFT),
         )
-        self.assertEqual({SVTYPE.DUP}, BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == {SVTYPE.DUP}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.NS),
         )
-        self.assertEqual({SVTYPE.DUP}, BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == {SVTYPE.DUP}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.NS),
         )
-        self.assertEqual({SVTYPE.DUP}, BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == {SVTYPE.DUP}
 
     def test_deletion_or_insertion(self):
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.RIGHT),
         )
-        self.assertEqual(sorted([SVTYPE.DEL, SVTYPE.INS]), sorted(BreakpointPair.classify(b)))
+        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NS, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        self.assertEqual(sorted([SVTYPE.DEL, SVTYPE.INS]), sorted(BreakpointPair.classify(b)))
+        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.RIGHT),
         )
-        self.assertEqual(sorted([SVTYPE.DEL, SVTYPE.INS]), sorted(BreakpointPair.classify(b)))
+        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NS, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        self.assertEqual(sorted([SVTYPE.DEL, SVTYPE.INS]), sorted(BreakpointPair.classify(b)))
+        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        self.assertEqual(sorted([SVTYPE.DEL, SVTYPE.INS]), sorted(BreakpointPair.classify(b)))
+        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        self.assertEqual(sorted([SVTYPE.DEL, SVTYPE.INS]), sorted(BreakpointPair.classify(b)))
+        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NS, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        self.assertEqual(sorted([SVTYPE.DEL, SVTYPE.INS]), sorted(BreakpointPair.classify(b)))
+        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
     def test_insertion(self):
         b = BreakpointPair(
@@ -339,7 +338,7 @@ class TestClassifyBreakpointPair(unittest.TestCase):
             Breakpoint(1, 2, 2, strand=STRAND.NS, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        self.assertEqual(sorted([SVTYPE.INS]), sorted(BreakpointPair.classify(b)))
+        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.INS])
 
     def test_no_type(self):
         b = BreakpointPair(
@@ -348,7 +347,7 @@ class TestClassifyBreakpointPair(unittest.TestCase):
             opposing_strands=False,
             untemplated_seq='',
         )
-        self.assertEqual(set(), BreakpointPair.classify(b))
+        assert BreakpointPair.classify(b) == set()
 
     def test_deletion(self):
         b = BreakpointPair(
@@ -357,7 +356,7 @@ class TestClassifyBreakpointPair(unittest.TestCase):
             opposing_strands=False,
             untemplated_seq='',
         )
-        self.assertEqual(sorted([SVTYPE.DEL]), sorted(BreakpointPair.classify(b)))
+        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL])
 
     def test_deletion_with_useq(self):
         bpp = BreakpointPair(
@@ -366,30 +365,30 @@ class TestClassifyBreakpointPair(unittest.TestCase):
             opposing=False,
             untemplated_seq='CCCT',
         )
-        self.assertEqual(sorted([SVTYPE.DEL, SVTYPE.INS]), sorted(BreakpointPair.classify(bpp)))
+        assert sorted(BreakpointPair.classify(bpp)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         def distance(x, y):
             return Interval(abs(x - y))
 
         net_size = BreakpointPair.net_size(bpp, distance)
-        self.assertEqual(Interval(-71), net_size)
-        self.assertEqual(sorted([SVTYPE.DEL]), sorted(BreakpointPair.classify(bpp, distance)))
+        assert net_size == Interval(-71)
+        assert sorted(BreakpointPair.classify(bpp, distance)) == sorted([SVTYPE.DEL])
 
     def test_deletion_no_distance_error(self):
         bpp = BreakpointPair(
             Breakpoint('1', 7039, orient='L'), Breakpoint('1', 7040, orient='R'), opposing=False
         )
-        self.assertEqual(sorted([SVTYPE.INS]), sorted(BreakpointPair.classify(bpp)))
+        assert sorted(BreakpointPair.classify(bpp)) == sorted([SVTYPE.INS])
 
 
-class TestNetSize(unittest.TestCase):
+class TestNetSize:
     def test_indel(self):
         bpp = BreakpointPair(
             Breakpoint('1', 13, orient=ORIENT.RIGHT),
             Breakpoint('1', 10, orient=ORIENT.LEFT),
             untemplated_seq='TTT',
         )
-        self.assertEqual(Interval(1), bpp.net_size())
+        assert bpp.net_size() == Interval(1)
 
     def test_large_indel(self):
         bpp = BreakpointPair(
@@ -397,7 +396,7 @@ class TestNetSize(unittest.TestCase):
             Breakpoint('1', 101, orient=ORIENT.RIGHT),
             untemplated_seq='TTT',
         )
-        self.assertEqual(Interval(-87), bpp.net_size())
+        assert bpp.net_size() == Interval(-87)
 
     def test_insertion(self):
         bpp = BreakpointPair(
@@ -405,14 +404,14 @@ class TestNetSize(unittest.TestCase):
             Breakpoint('1', 10, orient=ORIENT.LEFT),
             untemplated_seq='T',
         )
-        self.assertEqual(Interval(1), bpp.net_size())
+        assert bpp.net_size() == Interval(1)
 
         bpp = BreakpointPair(
             Breakpoint('1', 11, orient=ORIENT.RIGHT),
             Breakpoint('1', 10, orient=ORIENT.LEFT),
             untemplated_seq='TT',
         )
-        self.assertEqual(Interval(2), bpp.net_size())
+        assert bpp.net_size() == Interval(2)
 
     def test_duplication_with_insertion(self):
         bpp = BreakpointPair(
@@ -420,7 +419,7 @@ class TestNetSize(unittest.TestCase):
             Breakpoint('1', 15, orient=ORIENT.LEFT),
             untemplated_seq='TTT',
         )
-        self.assertEqual(Interval(9), bpp.net_size())
+        assert bpp.net_size() == Interval(9)
 
     def test_deletion(self):
         bpp = BreakpointPair(
@@ -428,7 +427,7 @@ class TestNetSize(unittest.TestCase):
             Breakpoint('1', 15, orient=ORIENT.RIGHT),
             untemplated_seq='',
         )
-        self.assertEqual(Interval(-4), bpp.net_size())
+        assert bpp.net_size() == Interval(-4)
 
     def test_inversion(self):
         bpp = BreakpointPair(
@@ -436,7 +435,7 @@ class TestNetSize(unittest.TestCase):
             Breakpoint('1', 15, orient=ORIENT.LEFT),
             untemplated_seq='',
         )
-        self.assertEqual(Interval(0), bpp.net_size())
+        assert bpp.net_size() == Interval(0)
 
     def test_inversion_insertion(self):
         bpp = BreakpointPair(
@@ -444,10 +443,10 @@ class TestNetSize(unittest.TestCase):
             Breakpoint('1', 15, orient=ORIENT.LEFT),
             untemplated_seq='TT',
         )
-        self.assertEqual(Interval(2), bpp.net_size())
+        assert bpp.net_size() == Interval(2)
 
 
-class TestUntemplatedShift(unittest.TestCase):
+class TestUntemplatedShift:
     def test_indel(self):
         ref = {
             '1': Mock(
@@ -461,4 +460,4 @@ class TestUntemplatedShift(unittest.TestCase):
         )
         result = bpp.untemplated_shift(ref)
         print(result)
-        self.assertEqual((0, 1), result)
+        assert result == (0, 1)

--- a/tests/unit/test_call_indels.py
+++ b/tests/unit/test_call_indels.py
@@ -1,134 +1,133 @@
-import unittest
-
+import pytest
 from mavis.annotate.variant import IndelCall, call_protein_indel
 
 from .mock import Mock, MockFunction
 
 
-class TestIndelCall(unittest.TestCase):
+class TestIndelCall:
     def test_deletion(self):
         refseq = 'asdfghjkl'
         mutseq = 'asdfkl'
         indel = IndelCall(refseq, mutseq)
-        self.assertEqual(4, indel.nterm_aligned)
-        self.assertEqual(len(indel.ref_seq) - 8 + 1, indel.cterm_aligned)
-        self.assertEqual('ghj', indel.del_seq)
-        self.assertEqual('', indel.ins_seq)
-        self.assertFalse(indel.is_dup)
+        assert indel.nterm_aligned == 4
+        assert indel.cterm_aligned == len(indel.ref_seq) - 8 + 1
+        assert indel.del_seq == 'ghj'
+        assert indel.ins_seq == ''
+        assert not indel.is_dup
 
     def test_insertion(self):
         refseq = 'asdfghjkl'
         mutseq = 'asdfmmmghjkl'
         indel = IndelCall(refseq, mutseq)
-        self.assertEqual(4, indel.nterm_aligned)
-        self.assertEqual(len(indel.ref_seq) - 5 + 1, indel.cterm_aligned)
-        self.assertEqual('', indel.del_seq)
-        self.assertEqual('mmm', indel.ins_seq)
-        self.assertFalse(indel.is_dup)
+        assert indel.nterm_aligned == 4
+        assert indel.cterm_aligned == len(indel.ref_seq) - 5 + 1
+        assert indel.del_seq == ''
+        assert indel.ins_seq == 'mmm'
+        assert not indel.is_dup
 
     def test_dup(self):
         refseq = 'asdfghjkl'
         mutseq = 'asdfsdfghjkl'
         indel = IndelCall(refseq, mutseq)
         print(indel)
-        self.assertEqual(4, indel.nterm_aligned)
-        self.assertEqual(len(indel.ref_seq) - 2 + 1, indel.cterm_aligned)
-        self.assertEqual('', indel.del_seq)
-        self.assertEqual('sdf', indel.ins_seq)
-        self.assertTrue(indel.is_dup)
+        assert indel.nterm_aligned == 4
+        assert indel.cterm_aligned == len(indel.ref_seq) - 2 + 1
+        assert indel.del_seq == ''
+        assert indel.ins_seq == 'sdf'
+        assert indel.is_dup
 
     def test_delins(self):
         refseq = 'asdfghjkl'
         mutseq = 'asdfmmmkl'
         indel = IndelCall(refseq, mutseq)
-        self.assertEqual(4, indel.nterm_aligned)
-        self.assertEqual(len(indel.ref_seq) - 8 + 1, indel.cterm_aligned)
-        self.assertEqual('ghj', indel.del_seq)
-        self.assertEqual('mmm', indel.ins_seq)
-        self.assertFalse(indel.is_dup)
+        assert indel.nterm_aligned == 4
+        assert indel.cterm_aligned == len(indel.ref_seq) - 8 + 1
+        assert indel.del_seq == 'ghj'
+        assert indel.ins_seq == 'mmm'
+        assert not indel.is_dup
 
     def test_delete_start(self):
         refseq = 'asdfghjkl'
         mutseq = 'fghjkl'
         indel = IndelCall(refseq, mutseq)
-        self.assertEqual(0, indel.nterm_aligned)
-        self.assertEqual(6, indel.cterm_aligned)
-        self.assertEqual('asd', indel.del_seq)
-        self.assertEqual('', indel.ins_seq)
-        self.assertFalse(indel.is_dup)
+        assert indel.nterm_aligned == 0
+        assert indel.cterm_aligned == 6
+        assert indel.del_seq == 'asd'
+        assert indel.ins_seq == ''
+        assert not indel.is_dup
 
     def test_delete_start_repetition(self):
         refseq = 'asdafghjkl'
         mutseq = 'afghjkl'
         indel = IndelCall(refseq, mutseq)
-        self.assertEqual(0, indel.nterm_aligned)
-        self.assertEqual(7, indel.cterm_aligned)
-        self.assertEqual('asd', indel.del_seq)
-        self.assertEqual('', indel.ins_seq)
-        self.assertFalse(indel.is_dup)
+        assert indel.nterm_aligned == 0
+        assert indel.cterm_aligned == 7
+        assert indel.del_seq == 'asd'
+        assert indel.ins_seq == ''
+        assert not indel.is_dup
 
     def test_delete_end(self):
         refseq = 'asdfghjkl'
         mutseq = 'asdfgh'
         indel = IndelCall(refseq, mutseq)
-        self.assertEqual(6, indel.nterm_aligned)
-        self.assertEqual(0, indel.cterm_aligned)
-        self.assertEqual('jkl', indel.del_seq)
-        self.assertEqual('', indel.ins_seq)
-        self.assertFalse(indel.is_dup)
+        assert indel.nterm_aligned == 6
+        assert indel.cterm_aligned == 0
+        assert indel.del_seq == 'jkl'
+        assert indel.ins_seq == ''
+        assert not indel.is_dup
 
     def test_ins_start(self):
         refseq = 'asdfghjkl'
         mutseq = 'mmasdfghjkl'
         indel = IndelCall(refseq, mutseq)
-        self.assertEqual(0, indel.nterm_aligned)
-        self.assertEqual(9, indel.cterm_aligned)
-        self.assertEqual('', indel.del_seq)
-        self.assertEqual('mm', indel.ins_seq)
-        self.assertFalse(indel.is_dup)
+        assert indel.nterm_aligned == 0
+        assert indel.cterm_aligned == 9
+        assert indel.del_seq == ''
+        assert indel.ins_seq == 'mm'
+        assert not indel.is_dup
 
     def test_ins_end(self):
         refseq = 'asdfghjkl'
         mutseq = 'asdfghjklmmm'
         indel = IndelCall(refseq, mutseq)
-        self.assertEqual(9, indel.nterm_aligned)
-        self.assertEqual(0, indel.cterm_aligned)
-        self.assertEqual('', indel.del_seq)
-        self.assertEqual('mmm', indel.ins_seq)
-        self.assertFalse(indel.is_dup)
+        assert indel.nterm_aligned == 9
+        assert indel.cterm_aligned == 0
+        assert indel.del_seq == ''
+        assert indel.ins_seq == 'mmm'
+        assert not indel.is_dup
 
     def test_delins_start(self):
         refseq = 'asdfghjkl'
         mutseq = 'mmfghjkl'
         indel = IndelCall(refseq, mutseq)
-        self.assertEqual(0, indel.nterm_aligned)
-        self.assertEqual(6, indel.cterm_aligned)
-        self.assertEqual('asd', indel.del_seq)
-        self.assertEqual('mm', indel.ins_seq)
-        self.assertFalse(indel.is_dup)
+        assert indel.nterm_aligned == 0
+        assert indel.cterm_aligned == 6
+        assert indel.del_seq == 'asd'
+        assert indel.ins_seq == 'mm'
+        assert not indel.is_dup
 
     def test_delins_end(self):
         refseq = 'asdfghjkl'
         mutseq = 'asdfghjmmm'
         indel = IndelCall(refseq, mutseq)
-        self.assertEqual(7, indel.nterm_aligned)
-        self.assertEqual(0, indel.cterm_aligned)
-        self.assertEqual('kl', indel.del_seq)
-        self.assertEqual('mmm', indel.ins_seq)
-        self.assertFalse(indel.is_dup)
+        assert indel.nterm_aligned == 7
+        assert indel.cterm_aligned == 0
+        assert indel.del_seq == 'kl'
+        assert indel.ins_seq == 'mmm'
+        assert not indel.is_dup
 
 
-class TestHgvsProteinNotation(unittest.TestCase):
+class TestHgvsProteinNotation:
     def test_homopolymer(self):
         indel = IndelCall('ASDFGHJKKLQWERTYUIOP', 'ASDFGHJKKKKLQWERTYUIOP').hgvs_protein_notation()
-        self.assertEqual('p.K8_K9dupKK', indel)
+        assert indel == 'p.K8_K9dupKK'
 
     def test_dup(self):
         indel = IndelCall('ASDFGHJKL', 'ASDFSDFGHJKL').hgvs_protein_notation()
-        self.assertEqual('p.S2_F4dupSDF', indel)
+        assert indel == 'p.S2_F4dupSDF'
 
 
-class TestCallProteinIndel(unittest.TestCase):
+class TestCallProteinIndel:
     def test_large_start_deletion(self):
         ref_translation = Mock(
             get_aa_seq=MockFunction(
@@ -159,44 +158,43 @@ class TestCallProteinIndel(unittest.TestCase):
             )
         )
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual(
+        assert notation == (
             'ref:p.M1_Y227del'
             'MGLKAAQKTLFPLRSIDDVVRLFAAELGREEPDLVLLSLVLGFVEHFLAVNRVIPTNVPE'
             'LTFQPSPAPDPPGGLTYFPVADLSIIAALYARFTAQIRGAVDLSLYPREGGVSSRELVKK'
             'VSDVIWNSLSRSYFKDRAHIQSLFSFITGTKLDSSGVAFAVVGACQALGLRDVHLALSED'
-            'HAWVVFGPNGEQTAEVTWHGKGNEDRRGQTVNAGVAERSWLYLKGSY',
-            notation,
+            'HAWVVFGPNGEQTAEVTWHGKGNEDRRGQTVNAGVAERSWLYLKGSY'
         )
 
     def test_deletion_rep_at_breaks(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ABCDEFKJFEDAGFLKJ'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ABCDE' 'AGFLKJ'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.F6_D11delFKJFED', notation)
+        assert notation == 'ref:p.F6_D11delFKJFED'
 
     def test_insertion(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKIIILQWERTYUIOP'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.K8_L9insIII', notation)
+        assert notation == 'ref:p.K8_L9insIII'
 
     def test_deletion(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJQWERTYUIOP'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.K8_L9delKL', notation)
+        assert notation == 'ref:p.K8_L9delKL'
 
     def test_synonymous(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual(None, notation)
+        assert notation is None
 
     def test_delins(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJIIIQWERTYUIOP'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.K8_L9delKLinsIII', notation)
+        assert notation == 'ref:p.K8_L9delKLinsIII'
 
     def test_transcript_name(self):
         ref_translation = Mock(
@@ -206,77 +204,77 @@ class TestCallProteinIndel(unittest.TestCase):
         )
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJIIIQWERTYUIOP'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('reft:p.K8_L9delKLinsIII', notation)
+        assert notation == 'reft:p.K8_L9delKLinsIII'
 
     def test_delete_start(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('FGHJKLQWERTYUIOP'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.A1_D3delASD', notation)
+        assert notation == 'ref:p.A1_D3delASD'
 
     def test_delete_single_aa_start(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('SDFGHJKLQWERTYUIOP'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.A1delA', notation)
+        assert notation == 'ref:p.A1delA'
 
     def test_delete_end(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYU'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.I17_P19delIOP', notation)
+        assert notation == 'ref:p.I17_P19delIOP'
 
     def test_delete_single_aa_end(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIO'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.P19delP', notation)
+        assert notation == 'ref:p.P19delP'
 
     def test_ins_start(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('IIASDFGHJKLQWERTYUIOP'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.A1ext-2', notation)
+        assert notation == 'ref:p.A1ext-2'
 
     def test_ins_end(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOPII'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.P19ext2', notation)
+        assert notation == 'ref:p.P19ext2'
 
     def test_no_reference_obj(self):
         ref_translation = Mock(
             get_aa_seq=MockFunction('ASDFGHJKLQWERTYUIOP'), name=None, reference_object='thing'
         )
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJIIIQWERTYUIOP'))
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             call_protein_indel(ref_translation, mut_translation)
 
     def test_fs(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKL'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJMMM'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.K8Mfs', notation)
+        assert notation == 'ref:p.K8Mfs'
 
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKL'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJCMMEF'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.K8Cfs', notation)
+        assert notation == 'ref:p.K8Cfs'
 
     def test_fs_with_stops(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLT*'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJMMMHGFTTSBF*TUHG*'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.K8Mfs*12', notation)
+        assert notation == 'ref:p.K8Mfs*12'
 
     def test_fs_immeadiate_stop(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDFGHJKLT*'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('ASDFGHJMMMHGFTTSBF*'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.K8Mfs*12', notation)
+        assert notation == 'ref:p.K8Mfs*12'
 
     def test_delete_start_with_rep(self):
         ref_translation = Mock(get_aa_seq=MockFunction('ASDAFGHJKL'), name='ref')
         mut_translation = Mock(get_aa_seq=MockFunction('AFGHJKL'))
         notation = call_protein_indel(ref_translation, mut_translation)
-        self.assertEqual('ref:p.A1_D3delASD', notation)
+        assert notation == 'ref:p.A1_D3delASD'

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1,29 +1,30 @@
 import unittest
 
+import pytest
 from mavis.cluster.cluster import merge_integer_intervals
 from mavis.interval import Interval
 
 
-class TestMergeIntegerIntervals(unittest.TestCase):
+class TestMergeIntegerIntervals:
     def test_varying_lengths(self):
         m = merge_integer_intervals((1, 2), (1, 9), (2, 10), weight_adjustment=0)
-        self.assertEqual(Interval(1, 4), m)
+        assert m == Interval(1, 4)
 
     def test_same_length(self):
         m = merge_integer_intervals((1, 1), (10, 10))
-        self.assertEqual(Interval(6), m)
+        assert m == Interval(6)
 
     def test_empty_list_error(self):
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             merge_integer_intervals()
 
     def test_identical_even_length(self):
         m = merge_integer_intervals((1, 2), (1, 2), (1, 2))
-        self.assertEqual(Interval(1, 2), m)
+        assert m == Interval(1, 2)
 
     def test_identical_odd_length(self):
         m = merge_integer_intervals((1, 3), (1, 3), (1, 3))
-        self.assertEqual(Interval(1, 3), m)
+        assert m == Interval(1, 3)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -1,54 +1,47 @@
-import unittest
-
-from mavis.constants import (
-    COLUMNS,
-    ORIENT,
-    STRAND,
-    MavisNamespace,
-    reverse_complement,
-    sort_columns,
-    translate,
-)
+from mavis.constants import COLUMNS, ORIENT, STRAND, reverse_complement, sort_columns, translate
 
 
-class TestConstants(unittest.TestCase):
+class TestConstants:
     def test_strand_compare(self):
-        self.assertTrue(STRAND.compare(STRAND.NS, STRAND.POS))
-        self.assertTrue(STRAND.compare(STRAND.NS, STRAND.NEG))
-        self.assertTrue(STRAND.compare(STRAND.POS, STRAND.POS))
-        self.assertTrue(STRAND.compare(STRAND.NEG, STRAND.NEG))
-        self.assertFalse(STRAND.compare(STRAND.POS, STRAND.NEG))
-        self.assertFalse(STRAND.compare(STRAND.NEG, STRAND.POS))
+        assert STRAND.compare(STRAND.NS, STRAND.POS)
+        assert STRAND.compare(STRAND.NS, STRAND.NEG)
+        assert STRAND.compare(STRAND.POS, STRAND.POS)
+        assert STRAND.compare(STRAND.NEG, STRAND.NEG)
+        assert not STRAND.compare(STRAND.POS, STRAND.NEG)
+        assert not STRAND.compare(STRAND.NEG, STRAND.POS)
 
     def test_orient_compare(self):
-        self.assertTrue(ORIENT.compare(ORIENT.NS, ORIENT.RIGHT))
-        self.assertTrue(ORIENT.compare(ORIENT.NS, ORIENT.LEFT))
-        self.assertTrue(ORIENT.compare(ORIENT.RIGHT, ORIENT.RIGHT))
-        self.assertTrue(ORIENT.compare(ORIENT.LEFT, ORIENT.LEFT))
-        self.assertFalse(ORIENT.compare(ORIENT.RIGHT, ORIENT.LEFT))
-        self.assertFalse(ORIENT.compare(ORIENT.LEFT, ORIENT.RIGHT))
+        assert ORIENT.compare(ORIENT.NS, ORIENT.RIGHT)
+        assert ORIENT.compare(ORIENT.NS, ORIENT.LEFT)
+        assert ORIENT.compare(ORIENT.RIGHT, ORIENT.RIGHT)
+        assert ORIENT.compare(ORIENT.LEFT, ORIENT.LEFT)
+        assert not ORIENT.compare(ORIENT.RIGHT, ORIENT.LEFT)
+        assert not ORIENT.compare(ORIENT.LEFT, ORIENT.RIGHT)
 
     def test_reverse_complement(self):
-        self.assertEqual('ATCG', reverse_complement('CGAT'))
-        self.assertEqual('', reverse_complement(''))
+        assert reverse_complement('CGAT') == 'ATCG'
+        assert reverse_complement('') == ''
 
     def test_translate(self):
         seq = 'ATG' 'AAT' 'TCT' 'GGA' 'TGA'
         translated_seq = translate(seq, 0)
-        self.assertEqual('MNSG*', translated_seq)  # ATG AAT TCT GGA TGA
+        assert translated_seq == 'MNSG*'  # ATG AAT TCT GGA TGA
         translated_seq = translate(seq, 1)
-        self.assertEqual('*ILD', translated_seq)  # A TGA ATT CTG GAT GA
+        assert translated_seq == '*ILD'  # A TGA ATT CTG GAT GA
         translated_seq = translate(seq, 2)
-        self.assertEqual('EFWM', translated_seq)  # AT GAA TTC TGG ATG A
+        assert translated_seq == 'EFWM'  # AT GAA TTC TGG ATG A
 
     def test_sort_columns(self):
         temp = ['NEW', 'NEW2', COLUMNS.break1_seq, COLUMNS.break2_seq, COLUMNS.break1_chromosome]
-        self.assertEqual(
-            [COLUMNS.break1_chromosome, COLUMNS.break1_seq, COLUMNS.break2_seq, 'NEW', 'NEW2'],
-            sort_columns(temp),
-        )
+        assert sort_columns(temp) == [
+            COLUMNS.break1_chromosome,
+            COLUMNS.break1_seq,
+            COLUMNS.break2_seq,
+            'NEW',
+            'NEW2',
+        ]
 
     def test_column_matches_column_name(self):
-        self.assertEqual(COLUMNS.library, COLUMNS.library)
+        assert COLUMNS.library == COLUMNS.library
         s = set([COLUMNS.library, COLUMNS.library])
-        self.assertEqual(1, len(s))
+        assert len(s) == 1

--- a/tests/unit/test_illustrate.py
+++ b/tests/unit/test_illustrate.py
@@ -1,9 +1,8 @@
-import unittest
 from mavis.illustrate.util import generate_interval_mapping
 from mavis.interval import Interval
 
 
-class TestGenerateIntervalMapping(unittest.TestCase):
+class TestGenerateIntervalMapping:
     def test_single_bp_window(self):
         regions = [
             Interval(4222347, 4222347),
@@ -20,7 +19,7 @@ class TestGenerateIntervalMapping(unittest.TestCase):
         mapping = generate_interval_mapping(
             regions, target, ratio, min_width, buffer_, start, end, min_inter
         )
-        self.assertEqual(7, len(mapping.keys()))
+        assert len(mapping.keys()) == 7
 
     def test_no_input_intervals(self):
         target = 911.9921875
@@ -33,4 +32,4 @@ class TestGenerateIntervalMapping(unittest.TestCase):
         mapping = generate_interval_mapping(
             [], target, ratio, min_width, buffer_, start, end, min_inter
         )
-        self.assertEqual(1, len(mapping.keys()))
+        assert len(mapping.keys()) == 1

--- a/tests/unit/test_interval.py
+++ b/tests/unit/test_interval.py
@@ -1,175 +1,173 @@
-import unittest
+import pytest
 from mavis.interval import Interval, IntervalMapping
 
 
-class TestInterval(unittest.TestCase):
+class TestInterval:
     def test___init__error(self):
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             Interval(4, 3)
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             Interval(3, 4, 0)
 
     def test___contains__(self):
-        self.assertTrue(Interval(1, 2) in Interval(1, 7))
-        self.assertFalse(Interval(1, 7) in Interval(1, 2))
-        self.assertTrue(Interval(1.0, 2) in Interval(1.0, 7))
-        self.assertFalse(Interval(1, 7) in Interval(1, 2))
-        self.assertTrue(1 in Interval(1, 7))
-        self.assertFalse(0 in Interval(1, 7))
+        assert Interval(1, 2) in Interval(1, 7)
+        assert not Interval(1, 7) in Interval(1, 2)
+        assert Interval(1.0, 2) in Interval(1.0, 7)
+        assert not Interval(1, 7) in Interval(1, 2)
+        assert 1 in Interval(1, 7)
+        assert 0 not in Interval(1, 7)
 
     def test_eq(self):
-        self.assertEqual(Interval(1, 2), Interval(1, 2))
-        self.assertEqual(Interval(1, 2), Interval(1, 2))
+        assert Interval(1, 2) == Interval(1, 2)
+        assert Interval(1, 2) == Interval(1, 2)
 
     def test_ne(self):
-        self.assertNotEqual(Interval(1, 2), Interval(1, 3))
-        self.assertNotEqual(Interval(1, 2), Interval(1, 3))
+        assert Interval(1, 2) != Interval(1, 3)
+        assert Interval(1, 2) != Interval(1, 3)
 
     def test___get_item__(self):
         temp = Interval(1, 2, 3)
-        self.assertEqual(1, temp[0])
-        self.assertEqual(2, temp[1])
-        with self.assertRaises(IndexError):
+        assert temp[0] == 1
+        assert temp[1] == 2
+        with pytest.raises(IndexError):
             temp[3]
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             temp[-1]
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             temp['1b']
 
     def test___gt__(self):
-        self.assertTrue(Interval(10) > Interval(1))
-        self.assertFalse(Interval(1) > Interval(10))
-        self.assertTrue(Interval(10) > Interval(1))
-        self.assertFalse(Interval(1) > Interval(1.01))
+        assert Interval(10) > Interval(1)
+        assert not Interval(1) > Interval(10)
+        assert Interval(10) > Interval(1)
+        assert not Interval(1) > Interval(1.01)
 
     def test_overlaps(self):
         left = Interval(-4, 1)
         middle = Interval(0, 10)
         right = Interval(5, 12)
-        self.assertFalse(Interval.overlaps(left, right))
-        self.assertFalse(Interval.overlaps(right, left))
-        self.assertTrue(Interval.overlaps(left, middle))
-        self.assertTrue(Interval.overlaps(right, middle))
-        self.assertTrue(Interval.overlaps(middle, left))
-        self.assertTrue(Interval.overlaps(middle, right))
-        self.assertTrue(Interval.overlaps((1, 2), (2, 5)))
+        assert not Interval.overlaps(left, right)
+        assert not Interval.overlaps(right, left)
+        assert Interval.overlaps(left, middle)
+        assert Interval.overlaps(right, middle)
+        assert Interval.overlaps(middle, left)
+        assert Interval.overlaps(middle, right)
+        assert Interval.overlaps((1, 2), (2, 5))
         left = Interval(1148432, 1149343)
         right = Interval(1149493, 1150024)
-        self.assertFalse(Interval.overlaps(left, right))
+        assert not Interval.overlaps(left, right)
 
         left = Interval(-4, 0.1)
         middle = Interval(0, 10)
         right = Interval(0.11, 12)
-        self.assertFalse(Interval.overlaps(left, right))
-        self.assertFalse(Interval.overlaps(right, left))
-        self.assertTrue(Interval.overlaps(left, middle))
-        self.assertTrue(Interval.overlaps(right, middle))
-        self.assertTrue(Interval.overlaps(middle, left))
-        self.assertTrue(Interval.overlaps(middle, right))
+        assert not Interval.overlaps(left, right)
+        assert not Interval.overlaps(right, left)
+        assert Interval.overlaps(left, middle)
+        assert Interval.overlaps(right, middle)
+        assert Interval.overlaps(middle, left)
+        assert Interval.overlaps(middle, right)
 
     def test___len__(self):
-        self.assertEqual(5, len(Interval(1, 5)))
-        with self.assertRaises(TypeError):
+        assert len(Interval(1, 5)) == 5
+        with pytest.raises(TypeError):
             len(Interval(1, 5.0))
-        self.assertEqual(4.0, Interval(1, 5.0).length())
+        assert Interval(1, 5.0).length() == 4.0
 
     def test___lt__(self):
-        self.assertTrue(Interval(1) < Interval(10))
-        self.assertFalse(Interval(10) < Interval(1))
+        assert Interval(1) < Interval(10)
+        assert not Interval(10) < Interval(1)
 
     def test___and__(self):
-        self.assertEqual(None, Interval(1, 1) & Interval(2))
+        assert Interval(1, 1) & Interval(2) is None
 
     def test___sub__(self):
         # x in y
-        self.assertEqual([Interval(0, 4), Interval(7, 10)], Interval(0, 10) - Interval(5, 6))
+        assert Interval(0, 10) - Interval(5, 6) == [Interval(0, 4), Interval(7, 10)]
         # x overlaps the start of y
-        self.assertEqual([Interval(7, 10)], Interval(0, 10) - Interval(-1, 6))
+        assert Interval(0, 10) - Interval(-1, 6) == [Interval(7, 10)]
         # x overlaps the end of y
-        self.assertEqual([Interval(0, 4)], Interval(0, 10) - Interval(5, 11))
+        assert Interval(0, 10) - Interval(5, 11) == [Interval(0, 4)]
         # x overlaps all of y
-        self.assertEqual([], Interval(0, 10) - Interval(-1, 11))
+        assert Interval(0, 10) - Interval(-1, 11) == []
         # x does not overlap y
-        self.assertEqual([Interval(0, 10)], Interval(0, 10) - Interval(11, 15))
+        assert Interval(0, 10) - Interval(11, 15) == [Interval(0, 10)]
 
     def test___xor__(self):
         # x in y
-        self.assertEqual([], Interval(0, 10) ^ Interval(0, 10))
+        assert Interval(0, 10) ^ Interval(0, 10) == []
         # x overlaps the start of y
-        self.assertEqual([Interval(7, 10), Interval(-1, -1)], Interval(0, 10) ^ Interval(-1, 6))
+        assert Interval(0, 10) ^ Interval(-1, 6) == [Interval(7, 10), Interval(-1, -1)]
         # x overlaps the end of y
-        self.assertEqual([Interval(0, 4), Interval(11, 11)], Interval(0, 10) ^ Interval(5, 11))
+        assert Interval(0, 10) ^ Interval(5, 11) == [Interval(0, 4), Interval(11, 11)]
         # x overlaps all of y
-        self.assertEqual([Interval(-1, -1), Interval(11, 11)], Interval(0, 10) ^ Interval(-1, 11))
+        assert Interval(0, 10) ^ Interval(-1, 11) == [Interval(-1, -1), Interval(11, 11)]
         # x does not overlap y
-        self.assertEqual([Interval(0, 10), Interval(11, 15)], Interval(0, 10) ^ Interval(11, 15))
+        assert Interval(0, 10) ^ Interval(11, 15) == [Interval(0, 10), Interval(11, 15)]
 
     def test_center(self):
-        self.assertEqual(3, Interval(1, 5).center)
-        self.assertEqual(3.5, Interval(2, 5).center)
+        assert Interval(1, 5).center == 3
+        assert Interval(2, 5).center == 3.5
 
     def test_position_in_range(self):
         pos = (12, 12)
-        self.assertEqual((2, False), Interval.position_in_range([(1, 2), (3, 6), (7, 15)], pos))
-        self.assertEqual(
-            (3, True), Interval.position_in_range([(1, 2), (3, 6), (7, 10), (14, 16)], pos)
-        )
-        self.assertEqual((3, False), Interval.position_in_range([(1, 2), (3, 6), (7, 10)], pos))
-        self.assertEqual((0, True), Interval.position_in_range([(15, 16), (17, 19)], pos))
+        assert Interval.position_in_range([(1, 2), (3, 6), (7, 15)], pos) == (2, False)
+        assert Interval.position_in_range([(1, 2), (3, 6), (7, 10), (14, 16)], pos) == (3, True)
+        assert Interval.position_in_range([(1, 2), (3, 6), (7, 10)], pos) == (3, False)
+        assert Interval.position_in_range([(15, 16), (17, 19)], pos) == (0, True)
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             Interval.position_in_range([], 1)
 
     def test_convert_pos(self):
         mapping = {(1, 10): (101, 110), (21, 30): (201, 210), (41, 50): (301, 310)}
 
-        self.assertEqual(105, Interval.convert_pos(mapping, 5))
-        self.assertEqual(101, Interval.convert_pos(mapping, 1))
-        self.assertEqual(310, Interval.convert_pos(mapping, 50))
+        assert Interval.convert_pos(mapping, 5) == 105
+        assert Interval.convert_pos(mapping, 1) == 101
+        assert Interval.convert_pos(mapping, 50) == 310
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             Interval.convert_pos(mapping, 15)
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             Interval.convert_pos(mapping, 0)
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             Interval.convert_pos(mapping, 80)
 
     def test_convert_pos_forward_to_reverse(self):
         mapping = {(41, 50): (101, 110), (21, 30): (201, 210), (1, 10): (301, 310)}
 
-        self.assertEqual(306, Interval.convert_pos(mapping, 5))
-        self.assertEqual(110, Interval.convert_pos(mapping, 41))
-        self.assertEqual(210, Interval.convert_pos(mapping, 21))
-        self.assertEqual(310, Interval.convert_pos(mapping, 1))
-        self.assertEqual(309, Interval.convert_pos(mapping, 2))
+        assert Interval.convert_pos(mapping, 5) == 306
+        assert Interval.convert_pos(mapping, 41) == 110
+        assert Interval.convert_pos(mapping, 21) == 210
+        assert Interval.convert_pos(mapping, 1) == 310
+        assert Interval.convert_pos(mapping, 2) == 309
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             Interval.convert_pos(mapping, 15)
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             Interval.convert_pos(mapping, 51)
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             Interval.convert_pos(mapping, 0)
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             Interval.convert_pos(mapping, 31)
 
     def test_convert_pos_input_errors(self):
         # test input errors
-        with self.assertRaises(AttributeError):  # unequal length
+        with pytest.raises(AttributeError):  # unequal length
             Interval.convert_pos({(1, 10): (4, 5)}, 3)
 
-        with self.assertRaises(AttributeError):  # overlapping ranges
+        with pytest.raises(AttributeError):  # overlapping ranges
             Interval.convert_pos({(1, 10): (11, 20), (5, 14): (21, 30)}, 6)
 
-        with self.assertRaises(AttributeError):  # range not increasing or decreasing
+        with pytest.raises(AttributeError):  # range not increasing or decreasing
             mapping = {(1, 2): (1, 2), (3, 4): (4, 5), (5, 6): (3, 3)}
             Interval.convert_pos(mapping, 10)
 
-        with self.assertRaises(AttributeError):  # range not increasing or decreasing
+        with pytest.raises(AttributeError):  # range not increasing or decreasing
             mapping = {(1, 2): (4, 5), (3, 4): (1, 2), (5, 6): (3, 3)}
             Interval.convert_pos(mapping, 10)
 
@@ -179,7 +177,7 @@ class TestInterval(unittest.TestCase):
             s = x * 10 + 1
             mapping[Interval(s, s + 9)] = Interval(s, s + 9)
         for pos in range(1, 101):
-            self.assertEqual(pos, Interval.convert_pos(mapping, pos))
+            assert Interval.convert_pos(mapping, pos) == pos
 
     def test_convert_pos_ratioed_intervals(self):
         mapping = {
@@ -189,59 +187,59 @@ class TestInterval(unittest.TestCase):
             (601.0, 900): (52, 57.0),
             (901.0, 1100): (58.0, 100),
         }
-        self.assertEqual(Interval(1), Interval.convert_ratioed_pos(mapping, 1))
-        self.assertEqual(Interval(20), Interval.convert_ratioed_pos(mapping, 100))
-        self.assertEqual(Interval(100, 100), Interval.convert_ratioed_pos(mapping, 1100))
+        assert Interval.convert_ratioed_pos(mapping, 1) == Interval(1)
+        assert Interval.convert_ratioed_pos(mapping, 100) == Interval(20)
+        assert Interval.convert_ratioed_pos(mapping, 1100) == Interval(100, 100)
 
         mapping = {(1, 100): (1, 1), (101, 500): (21, 30)}
-        self.assertEqual(Interval(1, 1), Interval.convert_ratioed_pos(mapping, 1))
-        self.assertEqual(Interval(1, 1), Interval.convert_ratioed_pos(mapping, 100))
+        assert Interval.convert_ratioed_pos(mapping, 1) == Interval(1, 1)
+        assert Interval.convert_ratioed_pos(mapping, 100) == Interval(1, 1)
 
         mapping = {(1, 100.0): (20.0, 30), (100.1, 500): (1.0, 1.0)}
-        self.assertEqual(Interval(1, 1), Interval.convert_ratioed_pos(mapping, 101))
-        self.assertEqual(Interval(1, 1), Interval.convert_ratioed_pos(mapping, 500))
-        self.assertEqual(Interval(25, 25), Interval.convert_ratioed_pos(mapping, 50))
+        assert Interval.convert_ratioed_pos(mapping, 101) == Interval(1, 1)
+        assert Interval.convert_ratioed_pos(mapping, 500) == Interval(1, 1)
+        assert Interval.convert_ratioed_pos(mapping, 50) == Interval(25, 25)
 
     def test_union(self):
         interval_list = [Interval(1, 10), Interval(5, 7), Interval(7)]
-        self.assertEqual(Interval(1, 10), Interval.union(*interval_list))
+        assert Interval.union(*interval_list) == Interval(1, 10)
         m = interval_list + [Interval(11)]
-        self.assertEqual(Interval(1, 11), Interval.union(*m))
+        assert Interval.union(*m) == Interval(1, 11)
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             Interval.union()
 
     def test_intersection(self):
         interval_list = [Interval(1, 10), Interval(5, 7), Interval(7)]
-        self.assertEqual(Interval(7), Interval.intersection(*interval_list))
+        assert Interval.intersection(*interval_list) == Interval(7)
         interval_list.append(Interval(11))
-        self.assertEqual(None, Interval.intersection(*interval_list))
+        assert Interval.intersection(*interval_list) is None
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             Interval.intersection()
 
     def test_dist(self):
         x = Interval(1, 4)
         y = Interval(-1, 0)
         z = Interval(0, 3)
-        self.assertEqual(1, Interval.dist(x, y))
-        self.assertEqual(-1, Interval.dist(y, x))
-        self.assertEqual(0, Interval.dist(x, z))
-        self.assertEqual(0, Interval.dist(z, x))
-        self.assertEqual(0, Interval.dist(y, z))
-        self.assertEqual(0, Interval.dist(z, y))
-        self.assertEqual(-6, Interval.dist((1, 4), (10, 12)))
+        assert Interval.dist(x, y) == 1
+        assert Interval.dist(y, x) == -1
+        assert Interval.dist(x, z) == 0
+        assert Interval.dist(z, x) == 0
+        assert Interval.dist(y, z) == 0
+        assert Interval.dist(z, y) == 0
+        assert Interval.dist((1, 4), (10, 12)) == -6
 
     def test_min_nonoverlapping(self):
         r = Interval.min_nonoverlapping(Interval(1, 2), Interval(4, 7), Interval(8, 9))
-        self.assertEqual(3, len(r))
+        assert len(r) == 3
         r = Interval.min_nonoverlapping(Interval(1, 5), Interval(4, 7), Interval(8, 9))
-        self.assertEqual(2, len(r))
+        assert len(r) == 2
         r = Interval.min_nonoverlapping(Interval(1, 5), Interval(4, 7), Interval(7, 9))
-        self.assertEqual([Interval(1, 9)], r)
+        assert r == [Interval(1, 9)]
         r = Interval.min_nonoverlapping((1, 2), (2, 4))
-        self.assertEqual([Interval(1, 4)], r)
-        self.assertEqual([], Interval.min_nonoverlapping())
+        assert r == [Interval(1, 4)]
+        assert Interval.min_nonoverlapping() == []
 
     def test_split_overlapping_no_weight(self):
         input_intervals = [Interval(1, 10), Interval(2, 11), Interval(4, 5), Interval(4, 8)]
@@ -257,7 +255,7 @@ class TestInterval(unittest.TestCase):
         result = Interval.split_overlap(*input_intervals)
         result = sorted(result)
         print('found', result)
-        self.assertEqual(exp, result)
+        assert result == exp
 
     def test_split_overlapping_weighted(self):
         input_intervals = [Interval(1, 10), Interval(2, 11), Interval(4, 5), Interval(4, 8)]
@@ -271,12 +269,12 @@ class TestInterval(unittest.TestCase):
             Interval(10, 11): 4,
         }
         result = Interval.split_overlap(*input_intervals, weight_mapping=weights)
-        self.assertEqual(sorted(exp), sorted(result))
+        assert sorted(result) == sorted(exp)
         for itvl in exp:
-            self.assertEqual(exp[itvl], result[itvl])
+            assert result[itvl] == exp[itvl]
 
 
-class TestIntervalMapping(unittest.TestCase):
+class TestIntervalMapping:
     def test_convert_pos_ratioed(self):
         mapping = IntervalMapping(
             {
@@ -287,37 +285,37 @@ class TestIntervalMapping(unittest.TestCase):
                 (901.0, 1100): (58.0, 100),
             }
         )
-        self.assertEqual(1, mapping.convert_pos(1))
-        self.assertEqual(1, mapping.convert_ratioed_pos(1).start)
-        self.assertAlmostEqual(1.191919191919, mapping.convert_ratioed_pos(1).end)
-        self.assertEqual(20, mapping.convert_pos(100))
-        self.assertEqual(20, mapping.convert_ratioed_pos(100).start)
-        self.assertEqual(100, mapping.convert_pos(1100))
-        self.assertEqual(100, mapping.convert_ratioed_pos(1100).start)
+        assert mapping.convert_pos(1) == 1
+        assert mapping.convert_ratioed_pos(1).start == 1
+        assert pytest.approx(mapping.convert_ratioed_pos(1).end) == 1.191919191919
+        assert mapping.convert_pos(100) == 20
+        assert mapping.convert_ratioed_pos(100).start == 20
+        assert mapping.convert_pos(1100) == 100
+        assert mapping.convert_ratioed_pos(1100).start == 100
 
         mapping = IntervalMapping({(1, 100): (1, 1.0), (101, 500): (21.0, 30)})
-        self.assertEqual(1, mapping.convert_pos(1))
-        self.assertEqual(1, mapping.convert_pos(100))
+        assert mapping.convert_pos(1) == 1
+        assert mapping.convert_pos(100) == 1
 
         mapping = IntervalMapping({(1, 100.0): (20.0, 30), (100.1, 500): (1.0, 1.0)})
-        self.assertEqual(1, mapping.convert_pos(101))
-        self.assertEqual(1, mapping.convert_pos(500))
-        self.assertEqual(25, mapping.convert_pos(50))
+        assert mapping.convert_pos(101) == 1
+        assert mapping.convert_pos(500) == 1
+        assert mapping.convert_pos(50) == 25
 
     def test_convert_pos(self):
         mapping = IntervalMapping({(1, 10): (101, 110), (21, 30): (201, 210), (41, 50): (301, 310)})
 
-        self.assertEqual(105, mapping.convert_pos(5))
-        self.assertEqual(101, mapping.convert_pos(1))
-        self.assertEqual(310, mapping.convert_pos(50))
+        assert mapping.convert_pos(5) == 105
+        assert mapping.convert_pos(1) == 101
+        assert mapping.convert_pos(50) == 310
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             mapping.convert_pos(15)
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             mapping.convert_pos(0)
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             mapping.convert_pos(80)
 
     def test_convert_pos_forward_to_reverse(self):
@@ -326,22 +324,22 @@ class TestIntervalMapping(unittest.TestCase):
             opposing=[(41, 50), (21, 30), (1, 10)],
         )
 
-        self.assertEqual(306, mapping.convert_pos(5))
-        self.assertEqual(110, mapping.convert_pos(41))
-        self.assertEqual(210, mapping.convert_pos(21))
-        self.assertEqual(310, mapping.convert_pos(1))
-        self.assertEqual(309, mapping.convert_pos(2))
+        assert mapping.convert_pos(5) == 306
+        assert mapping.convert_pos(41) == 110
+        assert mapping.convert_pos(21) == 210
+        assert mapping.convert_pos(1) == 310
+        assert mapping.convert_pos(2) == 309
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             mapping.convert_pos(15)
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             mapping.convert_pos(51)
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             mapping.convert_pos(0)
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             mapping.convert_pos(31)
 
     def test_convert_pos_one_to_one(self):
@@ -351,4 +349,4 @@ class TestIntervalMapping(unittest.TestCase):
             mapping[Interval(s, s + 9)] = Interval(s, s + 9)
         mapping = IntervalMapping(mapping)
         for pos in range(1, 101):
-            self.assertEqual(pos, mapping.convert_pos(pos))
+            assert mapping.convert_pos(pos) == pos

--- a/tests/unit/test_summary.py
+++ b/tests/unit/test_summary.py
@@ -1,146 +1,176 @@
-import unittest
-
+import pytest
 from mavis.breakpoint import Breakpoint, BreakpointPair
 from mavis.constants import CALL_METHOD, COLUMNS, PROTOCOL, STRAND, SVTYPE
 from mavis.summary.summary import filter_by_annotations
 
+from ..util import todo
 
-class TestFilterByAnnotations(unittest.TestCase):
-    def setUp(self):
-        self.gev1 = BreakpointPair(
-            Breakpoint('1', 1),
-            Breakpoint('1', 10),
-            opposing_strands=True,
-            **{
-                COLUMNS.event_type: SVTYPE.DEL,
-                COLUMNS.call_method: CALL_METHOD.CONTIG,
-                COLUMNS.fusion_sequence_fasta_id: None,
-                COLUMNS.protocol: PROTOCOL.GENOME,
-                COLUMNS.fusion_cdna_coding_end: None,
-                COLUMNS.fusion_cdna_coding_start: None,
-            }
-        )
-        self.gev2 = BreakpointPair(
-            Breakpoint('1', 1),
-            Breakpoint('1', 100),
-            opposing_strands=True,
-            **{
-                COLUMNS.event_type: SVTYPE.DEL,
-                COLUMNS.call_method: CALL_METHOD.CONTIG,
-                COLUMNS.fusion_sequence_fasta_id: None,
-                COLUMNS.protocol: PROTOCOL.GENOME,
-                COLUMNS.fusion_cdna_coding_start: None,
-                COLUMNS.fusion_cdna_coding_end: None,
-            }
-        )
-        self.best_transcripts = {'ABCA': True, 'ABCD': True}
 
-    def test_filter_by_annotations_two_best_transcripts(self):
-        self.gev1.data[COLUMNS.gene1] = 'ABC'
-        self.gev1.data[COLUMNS.gene2] = 'ABC'
-        self.gev1.data[COLUMNS.transcript1] = 'ABCA'
-        self.gev1.data[COLUMNS.transcript2] = 'ABCA'
-        self.gev2.data[COLUMNS.gene1] = 'ABC'
-        self.gev2.data[COLUMNS.gene2] = 'ABC'
-        self.gev2.data[COLUMNS.transcript1] = 'ABCD'
-        self.gev2.data[COLUMNS.transcript2] = 'ABCD'
-        result, removed = filter_by_annotations([self.gev1, self.gev2], self.best_transcripts)
+@pytest.fixture
+def genomic_event1():
+    return BreakpointPair(
+        Breakpoint('1', 1),
+        Breakpoint('1', 10),
+        opposing_strands=True,
+        **{
+            COLUMNS.event_type: SVTYPE.DEL,
+            COLUMNS.call_method: CALL_METHOD.CONTIG,
+            COLUMNS.fusion_sequence_fasta_id: None,
+            COLUMNS.protocol: PROTOCOL.GENOME,
+            COLUMNS.fusion_cdna_coding_end: None,
+            COLUMNS.fusion_cdna_coding_start: None,
+        }
+    )
+
+
+@pytest.fixture
+def genomic_event2():
+    return BreakpointPair(
+        Breakpoint('1', 1),
+        Breakpoint('1', 100),
+        opposing_strands=True,
+        **{
+            COLUMNS.event_type: SVTYPE.DEL,
+            COLUMNS.call_method: CALL_METHOD.CONTIG,
+            COLUMNS.fusion_sequence_fasta_id: None,
+            COLUMNS.protocol: PROTOCOL.GENOME,
+            COLUMNS.fusion_cdna_coding_start: None,
+            COLUMNS.fusion_cdna_coding_end: None,
+        }
+    )
+
+
+@pytest.fixture
+def best_transcripts():
+    return {'ABCA': True, 'ABCD': True}
+
+
+class TestFilterByAnnotations:
+    def test_filter_by_annotations_two_best_transcripts(
+        self, genomic_event1, genomic_event2, best_transcripts
+    ):
+        genomic_event1.data[COLUMNS.gene1] = 'ABC'
+        genomic_event1.data[COLUMNS.gene2] = 'ABC'
+        genomic_event1.data[COLUMNS.transcript1] = 'ABCA'
+        genomic_event1.data[COLUMNS.transcript2] = 'ABCA'
+        genomic_event2.data[COLUMNS.gene1] = 'ABC'
+        genomic_event2.data[COLUMNS.gene2] = 'ABC'
+        genomic_event2.data[COLUMNS.transcript1] = 'ABCD'
+        genomic_event2.data[COLUMNS.transcript2] = 'ABCD'
+        result, removed = filter_by_annotations([genomic_event1, genomic_event2], best_transcripts)
         bpp = result[0]
         print(bpp.data)
-        self.assertEqual(self.gev1, bpp)
-        self.assertEqual('ABCA', bpp.data[COLUMNS.transcript1])
+        assert bpp == genomic_event1
+        assert bpp.data[COLUMNS.transcript1] == 'ABCA'
 
-    def test_filter_by_annotations_two_transcripts(self):
-        self.gev1.data[COLUMNS.gene1] = 'XYZ'
-        self.gev1.data[COLUMNS.gene2] = 'XYS'
-        self.gev1.data[COLUMNS.transcript1] = 'XYZB'
-        self.gev1.data[COLUMNS.transcript2] = 'XYSZ'
-        self.gev2.data[COLUMNS.gene1] = 'XYZ'
-        self.gev2.data[COLUMNS.gene2] = 'XYS'
-        self.gev2.data[COLUMNS.transcript1] = 'XYZA'
-        self.gev2.data[COLUMNS.transcript2] = 'XYSB'
-        bpps, removed = filter_by_annotations([self.gev1, self.gev2], self.best_transcripts)
+    def test_filter_by_annotations_two_transcripts(
+        self, genomic_event1, genomic_event2, best_transcripts
+    ):
+        genomic_event1.data[COLUMNS.gene1] = 'XYZ'
+        genomic_event1.data[COLUMNS.gene2] = 'XYS'
+        genomic_event1.data[COLUMNS.transcript1] = 'XYZB'
+        genomic_event1.data[COLUMNS.transcript2] = 'XYSZ'
+        genomic_event2.data[COLUMNS.gene1] = 'XYZ'
+        genomic_event2.data[COLUMNS.gene2] = 'XYS'
+        genomic_event2.data[COLUMNS.transcript1] = 'XYZA'
+        genomic_event2.data[COLUMNS.transcript2] = 'XYSB'
+        bpps, removed = filter_by_annotations([genomic_event1, genomic_event2], best_transcripts)
         print(bpps)
         bpp = bpps[0]
         print(bpp, bpp.data)
-        self.assertEqual(self.gev2, bpp)
-        self.assertEqual('XYZA', bpp.data[COLUMNS.transcript1])
+        assert bpp == genomic_event2
+        assert bpp.data[COLUMNS.transcript1] == 'XYZA'
 
-    def test_filter_by_annotations_two_fusion_cdna(self):
-        self.gev1.data[COLUMNS.gene1] = 'XYZ'
-        self.gev1.data[COLUMNS.gene2] = 'XYS'
-        self.gev1.data[COLUMNS.transcript1] = 'XYZB'
-        self.gev1.data[COLUMNS.transcript2] = 'XYSZ'
-        self.gev2.data[COLUMNS.gene1] = 'XYZ'
-        self.gev2.data[COLUMNS.gene2] = 'XYS'
-        self.gev2.data[COLUMNS.transcript1] = 'XYZB'
-        self.gev2.data[COLUMNS.transcript2] = 'XYSZ'
-        self.gev1.data[COLUMNS.fusion_cdna_coding_start] = 1
-        self.gev1.data[COLUMNS.fusion_cdna_coding_end] = 20
-        self.gev2.data[COLUMNS.fusion_cdna_coding_start] = 1
-        self.gev2.data[COLUMNS.fusion_cdna_coding_end] = 40
-        result, removed = filter_by_annotations([self.gev1, self.gev2], self.best_transcripts)
+    def test_filter_by_annotations_two_fusion_cdna(
+        self, genomic_event1, genomic_event2, best_transcripts
+    ):
+        genomic_event1.data[COLUMNS.gene1] = 'XYZ'
+        genomic_event1.data[COLUMNS.gene2] = 'XYS'
+        genomic_event1.data[COLUMNS.transcript1] = 'XYZB'
+        genomic_event1.data[COLUMNS.transcript2] = 'XYSZ'
+        genomic_event2.data[COLUMNS.gene1] = 'XYZ'
+        genomic_event2.data[COLUMNS.gene2] = 'XYS'
+        genomic_event2.data[COLUMNS.transcript1] = 'XYZB'
+        genomic_event2.data[COLUMNS.transcript2] = 'XYSZ'
+        genomic_event1.data[COLUMNS.fusion_cdna_coding_start] = 1
+        genomic_event1.data[COLUMNS.fusion_cdna_coding_end] = 20
+        genomic_event2.data[COLUMNS.fusion_cdna_coding_start] = 1
+        genomic_event2.data[COLUMNS.fusion_cdna_coding_end] = 40
+        result, removed = filter_by_annotations([genomic_event1, genomic_event2], best_transcripts)
         bpp = result[0]
-        self.assertEqual(self.gev2, bpp)
+        assert bpp == genomic_event2
 
-    def test_filter_by_annotations_one_transcript(self):
-        self.gev1.data[COLUMNS.gene1] = None
-        self.gev1.data[COLUMNS.gene2] = 'XYS'
-        self.gev1.data[COLUMNS.transcript1] = None
-        self.gev1.data[COLUMNS.transcript2] = 'XYSZ'
-        self.gev2.data[COLUMNS.gene1] = 'XYZ'
-        self.gev2.data[COLUMNS.gene2] = 'XYS'
-        self.gev2.data[COLUMNS.transcript1] = 'XYZA'
-        self.gev2.data[COLUMNS.transcript2] = 'XYSB'
-        result, removed = filter_by_annotations([self.gev1, self.gev2], self.best_transcripts)
+    def test_filter_by_annotations_one_transcript(
+        self, genomic_event1, genomic_event2, best_transcripts
+    ):
+        genomic_event1.data[COLUMNS.gene1] = None
+        genomic_event1.data[COLUMNS.gene2] = 'XYS'
+        genomic_event1.data[COLUMNS.transcript1] = None
+        genomic_event1.data[COLUMNS.transcript2] = 'XYSZ'
+        genomic_event2.data[COLUMNS.gene1] = 'XYZ'
+        genomic_event2.data[COLUMNS.gene2] = 'XYS'
+        genomic_event2.data[COLUMNS.transcript1] = 'XYZA'
+        genomic_event2.data[COLUMNS.transcript2] = 'XYSB'
+        result, removed = filter_by_annotations([genomic_event1, genomic_event2], best_transcripts)
         bpp = result[0]
-        self.assertEqual(self.gev2, bpp)
+        assert bpp == genomic_event2
 
-    def test_filter_by_annotations_one_best_transcripts(self):
-        self.gev1.data[COLUMNS.gene1] = 'XYZ'
-        self.gev1.data[COLUMNS.gene2] = 'ABC'
-        self.gev1.data[COLUMNS.transcript1] = 'XYZB'
-        self.gev1.data[COLUMNS.transcript2] = 'ABCA'
-        self.gev2.data[COLUMNS.gene1] = 'XYZ'
-        self.gev2.data[COLUMNS.gene2] = 'ABC'
-        self.gev2.data[COLUMNS.transcript1] = 'XYZA'
-        self.gev2.data[COLUMNS.transcript2] = 'ABCB'
-        result, removed = filter_by_annotations([self.gev1, self.gev2], self.best_transcripts)
+    def test_filter_by_annotations_one_best_transcripts(
+        self, genomic_event1, genomic_event2, best_transcripts
+    ):
+        genomic_event1.data[COLUMNS.gene1] = 'XYZ'
+        genomic_event1.data[COLUMNS.gene2] = 'ABC'
+        genomic_event1.data[COLUMNS.transcript1] = 'XYZB'
+        genomic_event1.data[COLUMNS.transcript2] = 'ABCA'
+        genomic_event2.data[COLUMNS.gene1] = 'XYZ'
+        genomic_event2.data[COLUMNS.gene2] = 'ABC'
+        genomic_event2.data[COLUMNS.transcript1] = 'XYZA'
+        genomic_event2.data[COLUMNS.transcript2] = 'ABCB'
+        result, removed = filter_by_annotations([genomic_event1, genomic_event2], best_transcripts)
         bpp = result[0]
-        self.assertEqual(self.gev1, bpp)
-        self.assertEqual('XYZB', bpp.data[COLUMNS.transcript1])
+        assert bpp == genomic_event1
+        assert bpp.data[COLUMNS.transcript1] == 'XYZB'
 
-    def test_filter_by_annotations_no_transcripts(self):
-        self.gev1.data[COLUMNS.gene1] = None
-        self.gev1.data[COLUMNS.gene2] = None
-        self.gev1.data[COLUMNS.transcript1] = None
-        self.gev1.data[COLUMNS.transcript2] = None
-        self.gev2.data[COLUMNS.gene1] = None
-        self.gev2.data[COLUMNS.gene2] = None
-        self.gev2.data[COLUMNS.transcript1] = None
-        self.gev2.data[COLUMNS.transcript2] = None
-        self.gev1.break1.strand = STRAND.POS
-        result, removed = filter_by_annotations([self.gev1, self.gev2], self.best_transcripts)
+    def test_filter_by_annotations_no_transcripts(
+        self, genomic_event1, genomic_event2, best_transcripts
+    ):
+        genomic_event1.data[COLUMNS.gene1] = None
+        genomic_event1.data[COLUMNS.gene2] = None
+        genomic_event1.data[COLUMNS.transcript1] = None
+        genomic_event1.data[COLUMNS.transcript2] = None
+        genomic_event2.data[COLUMNS.gene1] = None
+        genomic_event2.data[COLUMNS.gene2] = None
+        genomic_event2.data[COLUMNS.transcript1] = None
+        genomic_event2.data[COLUMNS.transcript2] = None
+        genomic_event1.break1.strand = STRAND.POS
+        result, removed = filter_by_annotations([genomic_event1, genomic_event2], best_transcripts)
         bpp = result[0]
-        self.assertEqual(None, bpp.data[COLUMNS.transcript1])
+        assert bpp.data[COLUMNS.transcript1] is None
 
+    @todo
     def test_combine_events(self):
-        raise unittest.SkipTest('TODO')
+        pass
 
+    @todo
     def test_filtering_events_contigs(self):
-        raise unittest.SkipTest('TODO')
+        pass
 
+    @todo
     def test_filtering_events_none(self):
-        raise unittest.SkipTest('TODO')
+        pass
 
+    @todo
     def test_filtering_events_flanking(self):
-        raise unittest.SkipTest('TODO')
+        pass
 
+    @todo
     def test_filtering_events_spanning(self):
-        raise unittest.SkipTest('TODO')
+        pass
 
+    @todo
     def test_filtering_events_split(self):
-        raise unittest.SkipTest('TODO')
+        pass
 
+    @todo
     def test_get_pairing_state(self):
-        raise unittest.SkipTest('TODO')
+        pass

--- a/tests/unit/test_tool.py
+++ b/tests/unit/test_tool.py
@@ -39,14 +39,14 @@ class TestDelly:
         assert bpp.break2.strand == STRAND.NS
         assert bpp.break2.chr == '1'
         assert bpp.event_type == SVTYPE.INS
-        assert bpp.untemplated_seq == None
+        assert bpp.untemplated_seq is None
 
         bpp_list = _convert_tool_row(
             _parse_vcf_record(row)[0], SUPPORTED_TOOL.DELLY, False, assume_no_untemplated=True
         )
         assert len(bpp_list) == 1
         bpp = bpp_list[0]
-        assert bpp.untemplated_seq == None
+        assert bpp.untemplated_seq is None
         assert bpp.untemplated_seq != ''
 
     def test_convert_convert_translocation(self):
@@ -118,8 +118,8 @@ class TestStarFusion:
         assert bpp.break2.chr == 'chr13'
         assert bpp.break1.start == 114529969
         assert bpp.break2.start == 114751269
-        assert bpp.opposing_strands == False
-        assert bpp.stranded == True
+        assert bpp.opposing_strands is False
+        assert bpp.stranded is True
 
     def test_convert_translocation(self):
         row = {
@@ -135,8 +135,8 @@ class TestStarFusion:
         assert bpp.break2.chr == 'chr20'
         assert bpp.break1.start == 59445688
         assert bpp.break2.start == 49411710
-        assert bpp.opposing_strands == False
-        assert bpp.stranded == True
+        assert bpp.opposing_strands is False
+        assert bpp.stranded is True
 
     def test_malformed(self):
         row = {'FusionName': 'BCAS4--BCAS3', 'LeftBreakpoint': '', 'RightBreakpoint': None}
@@ -163,8 +163,8 @@ class TestTransAbyss:
         assert bpp.break1.start == 10015
         assert bpp.break2.start == 10016
         assert bpp.event_type == SVTYPE.INS
-        assert bpp.opposing_strands == False
-        assert bpp.stranded == True
+        assert bpp.opposing_strands is False
+        assert bpp.stranded is True
         assert bpp.untemplated_seq == 'AAT'
 
     def test_convert_indel_deletion(self):
@@ -206,8 +206,8 @@ class TestTransAbyss:
         assert bpp.event_type == SVTYPE.INS
         assert bpp.break1.strand == STRAND.NS
         assert bpp.break2.strand == STRAND.NS
-        assert bpp.stranded == False
-        assert bpp.opposing_strands == False
+        assert bpp.stranded is False
+        assert bpp.opposing_strands is False
         assert bpp.untemplated_seq == 'TT'
 
     def test_convert_indel_duplication(self):
@@ -229,8 +229,8 @@ class TestTransAbyss:
         assert bpp.event_type == SVTYPE.DUP
         assert bpp.break1.strand == STRAND.NS
         assert bpp.break2.strand == STRAND.NS
-        assert bpp.stranded == False
-        assert bpp.opposing_strands == False
+        assert bpp.stranded is False
+        assert bpp.opposing_strands is False
         assert bpp.untemplated_seq == ''
 
     def test_convert_translocation(self):
@@ -379,11 +379,11 @@ class TestDefuse:
         assert bpp.break2.chr == 'X'
         assert bpp.break1.start == 50294136
         assert bpp.break2.start == 153063989
-        assert bpp.event_type == None
-        assert bpp.opposing_strands == False
+        assert bpp.event_type is None
+        assert bpp.opposing_strands is False
         assert bpp.break1.orient == ORIENT.RIGHT
         assert bpp.break2.orient == ORIENT.LEFT
-        assert bpp.stranded == False
+        assert bpp.stranded is False
         assert bpp.data['tracking_id'] == 'defuse-1'
 
     def test_convert_translocation(self):
@@ -403,11 +403,11 @@ class TestDefuse:
         assert bpp.break2.chr == 'X'
         assert bpp.break1.start == 50294136
         assert bpp.break2.start == 153063989
-        assert bpp.event_type == None
-        assert bpp.opposing_strands == True
+        assert bpp.event_type is None
+        assert bpp.opposing_strands is True
         assert bpp.break1.orient == ORIENT.LEFT
         assert bpp.break2.orient == ORIENT.LEFT
-        assert bpp.stranded == False
+        assert bpp.stranded is False
         assert bpp.data['tracking_id'] == 'defuse-1'
 
     def test_convert_indel(self):
@@ -427,11 +427,11 @@ class TestDefuse:
         assert bpp.break2.chr == '1'
         assert bpp.break1.start == 1663681
         assert bpp.break2.start == 151732089
-        assert bpp.event_type == None
-        assert bpp.opposing_strands == False
+        assert bpp.event_type is None
+        assert bpp.opposing_strands is False
         assert bpp.break1.orient == ORIENT.LEFT
         assert bpp.break2.orient == ORIENT.RIGHT
-        assert bpp.stranded == False
+        assert bpp.stranded is False
         assert bpp.data['tracking_id'] == 'defuse-1'
 
     def test_convert_inversion(self):
@@ -451,11 +451,11 @@ class TestDefuse:
         assert bpp.break2.chr == '1'
         assert bpp.break1.start == 144898348
         assert bpp.break2.start == 235294748
-        assert bpp.event_type == None
-        assert bpp.opposing_strands == True
+        assert bpp.event_type is None
+        assert bpp.opposing_strands is True
         assert bpp.break1.orient == ORIENT.LEFT
         assert bpp.break2.orient == ORIENT.LEFT
-        assert bpp.stranded == False
+        assert bpp.stranded is False
         assert bpp.data['tracking_id'] == 'defuse-1'
 
 
@@ -480,10 +480,10 @@ class TestChimerascan:
         print(bpp)
         assert bpp.break1.start == int(row['end5p'])
         assert bpp.break2.start == int(row['start3p'])
-        assert bpp.opposing_strands == False
+        assert bpp.opposing_strands is False
         assert bpp.break1.orient == ORIENT.LEFT
         assert bpp.break2.orient == ORIENT.RIGHT
-        assert bpp.stranded == False
+        assert bpp.stranded is False
 
     def test_convert_pos_neg(self):
         row = {
@@ -505,10 +505,10 @@ class TestChimerascan:
         print(bpp)
         assert bpp.break1.start == int(row['end5p'])
         assert bpp.break2.start == int(row['end3p'])
-        assert bpp.opposing_strands == True
+        assert bpp.opposing_strands is True
         assert bpp.break1.orient == ORIENT.LEFT
         assert bpp.break2.orient == ORIENT.LEFT
-        assert bpp.stranded == False
+        assert bpp.stranded is False
 
     def test_convert_neg_pos(self):
         row = {
@@ -530,10 +530,10 @@ class TestChimerascan:
         print(bpp)
         assert bpp.break1.start == int(row['start5p'])
         assert bpp.break2.start == int(row['start3p'])
-        assert bpp.opposing_strands == True
+        assert bpp.opposing_strands is True
         assert bpp.break1.orient == ORIENT.RIGHT
         assert bpp.break2.orient == ORIENT.RIGHT
-        assert bpp.stranded == False
+        assert bpp.stranded is False
 
     def test_convert_neg_neg(self):
         row = {
@@ -555,10 +555,10 @@ class TestChimerascan:
         print(bpp)
         assert bpp.break1.start == int(row['start5p'])
         assert bpp.break2.start == int(row['end3p'])
-        assert bpp.opposing_strands == False
+        assert bpp.opposing_strands is False
         assert bpp.break1.orient == ORIENT.RIGHT
         assert bpp.break2.orient == ORIENT.LEFT
-        assert bpp.stranded == False
+        assert bpp.stranded is False
 
 
 class TestPindel:
@@ -578,8 +578,8 @@ class TestPindel:
         assert bpp.break1.strand == STRAND.NS
         assert bpp.break2.orient == ORIENT.RIGHT
         assert bpp.break2.strand == STRAND.NS
-        assert bpp.stranded == False
-        assert bpp.opposing_strands == False
+        assert bpp.stranded is False
+        assert bpp.opposing_strands is False
 
     def test_convert_insertion(self):
         row = Mock(chrom='21', pos=9412306, info={'SVTYPE': 'INS'}, stop=9412400, id=None, alts=[])
@@ -597,8 +597,8 @@ class TestPindel:
         assert bpp.break1.strand == STRAND.NS
         assert bpp.break2.orient == ORIENT.RIGHT
         assert bpp.break2.strand == STRAND.NS
-        assert bpp.stranded == False
-        assert bpp.opposing_strands == False
+        assert bpp.stranded is False
+        assert bpp.opposing_strands is False
 
     def test_convert_inversion(self):
         row = Mock(chrom='21', pos=9412306, info={'SVTYPE': 'INV'}, stop=9412400, id=None, alts=[])
@@ -616,8 +616,8 @@ class TestPindel:
         assert bpp.break1.strand == STRAND.NS
         assert bpp.break2.orient == ORIENT.LEFT
         assert bpp.break2.strand == STRAND.NS
-        assert bpp.stranded == False
-        assert bpp.opposing_strands == True
+        assert bpp.stranded is False
+        assert bpp.opposing_strands is True
 
 
 class TestParseBndAlt:
@@ -726,7 +726,7 @@ class TestBreakDancer:
         assert bpps[0].break2.start == 10546
         assert bpps[0].break2.end == 10546
         assert bpps[0].break2.orient == ORIENT.LEFT
-        assert bpps[0].opposing_strands == False
+        assert bpps[0].opposing_strands is False
 
     def test_deletion(self):
         row = {
@@ -750,7 +750,7 @@ class TestBreakDancer:
         assert bpps[0].break2.start == 870225
         assert bpps[0].break2.end == 870225
         assert bpps[0].break2.orient == ORIENT.RIGHT
-        assert bpps[0].opposing_strands == False
+        assert bpps[0].opposing_strands is False
 
     def test_inversion(self):
         row = {
@@ -774,7 +774,7 @@ class TestBreakDancer:
         assert bpps[0].break2.start == 13218683
         assert bpps[0].break2.end == 13218683
         assert bpps[0].break2.orient == ORIENT.LEFT
-        assert bpps[0].opposing_strands == True
+        assert bpps[0].opposing_strands is True
 
         assert bpps[1].event_type == SVTYPE.INV
         assert bpps[1].break1.start == 13143396
@@ -783,7 +783,7 @@ class TestBreakDancer:
         assert bpps[1].break2.start == 13218683
         assert bpps[1].break2.end == 13218683
         assert bpps[1].break2.orient == ORIENT.RIGHT
-        assert bpps[1].opposing_strands == True
+        assert bpps[1].opposing_strands is True
 
     def test_insertion(self):
         row = {
@@ -807,7 +807,7 @@ class TestBreakDancer:
         assert bpps[0].break2.start == 20218060
         assert bpps[0].break2.end == 20218060
         assert bpps[0].break2.orient == ORIENT.RIGHT
-        assert bpps[0].opposing_strands == False
+        assert bpps[0].opposing_strands is False
 
 
 class TestStrelka:

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,17 +1,9 @@
-import os
-
 import pytest
 from mavis.constants import COLUMNS, ORIENT, STRAND
 from mavis.error import NotSpecifiedError
-from mavis.util import (
-    ENV_VAR_PREFIX,
-    cast,
-    get_connected_components,
-    get_env_variable,
-    read_bpp_from_input_file,
-)
+from mavis.util import cast, get_connected_components, read_bpp_from_input_file
 
-from .mock import Mock
+from ..util import todo
 
 
 class TestGetConnectedComponents:
@@ -39,12 +31,12 @@ class TestGetConnectedComponents:
 
 class TestCast:
     def test_float(self):
-        assert type(cast('1', float)) == type(1.0)
-        assert type(cast('1', int)) != type(1.0)
+        assert type(cast('1', float)) == type(1.0)  # noqa: E721
+        assert type(cast('1', int)) != type(1.0)  # noqa: E721
 
     def test_boolean(self):
-        assert type(cast('f', bool)) == type(False)
-        assert type(cast('false', bool)) == type(False)
+        assert type(cast('f', bool)) == type(False)  # noqa: E721
+        assert type(cast('false', bool)) == type(False)  # noqa: E721
         assert not cast('f', bool)
         assert not cast('false', bool)
         assert not cast('0', bool)
@@ -267,7 +259,7 @@ class TestReadBreakpointPairsFromFile:
         assert len(bpps) == 1
         assert bpps[0].break1.orient == ORIENT.LEFT
 
-    @pytest.mark.skip(reason='TODO')
+    @todo
     def test_break2_orient_ns(self, tmp_path):
         input_file = tmp_path / "inputs.tsv"
         input_file.write_text(
@@ -292,10 +284,6 @@ class TestReadBreakpointPairsFromFile:
         assert len(bpps) == 1
         assert bpps[0].break1.orient == ORIENT.LEFT
 
-    @pytest.mark.skip(reason='TODO')
-    def test_both_break_orient_ns(self, tmp_path):
-        input_file = tmp_path / "inputs.tsv"
-
     def test_base_case(self, tmp_path):
         input_file = tmp_path / "inputs.tsv"
         input_file.write_text(
@@ -319,7 +307,7 @@ class TestReadBreakpointPairsFromFile:
         bpps = read_bpp_from_input_file(input_file, expand_strand=False, expand_orient=False)
         assert len(bpps) == 1
         assert bpps[0].break1.orient == ORIENT.RIGHT
-        assert bpps[0].opposing_strands == True
+        assert bpps[0].opposing_strands is True
 
     def test_unstranded_with_strand_calls(self, tmp_path):
         input_file = tmp_path / "inputs.tsv"

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1,15 +1,12 @@
-import unittest
-
 from mavis.constants import ORIENT
-from mavis.validate.call import _call_interval_by_flanking_coverage
-from mavis.validate.evidence import GenomeEvidence
-from mavis.validate.base import Evidence
 from mavis.interval import Interval
+from mavis.validate.base import Evidence
+from mavis.validate.call import _call_interval_by_flanking_coverage
 
 from .mock import Mock
 
 
-class CallIntervalByFlankingCoverage(unittest.TestCase):
+class CallIntervalByFlankingCoverage:
     def test_invalid_input_attr(self):
         pass
 
@@ -22,8 +19,8 @@ class CallIntervalByFlankingCoverage(unittest.TestCase):
             distance=Evidence.distance,
             traverse=Evidence.traverse,
         )
-        self.assertEqual(110, i.start)
-        self.assertEqual(180, i.end)
+        assert i.start == 110
+        assert i.end == 180
 
         i = _call_interval_by_flanking_coverage(
             Mock(start=20, end=80),
@@ -33,8 +30,8 @@ class CallIntervalByFlankingCoverage(unittest.TestCase):
             distance=Evidence.distance,
             traverse=Evidence.traverse,
         )
-        self.assertEqual(80, i.start)
-        self.assertEqual(209, i.end)
+        assert i.start == 80
+        assert i.end == 209
 
     def test_right(self):
         i = _call_interval_by_flanking_coverage(
@@ -45,8 +42,8 @@ class CallIntervalByFlankingCoverage(unittest.TestCase):
             distance=Evidence.distance,
             traverse=Evidence.traverse,
         )
-        self.assertEqual(101, i.end)
-        self.assertEqual(31, i.start)
+        assert i.end == 101
+        assert i.start == 31
 
         i = _call_interval_by_flanking_coverage(
             Mock(start=150, end=200),
@@ -56,16 +53,16 @@ class CallIntervalByFlankingCoverage(unittest.TestCase):
             distance=Evidence.distance,
             traverse=Evidence.traverse,
         )
-        self.assertEqual(11, i.start)
-        self.assertEqual(150, i.end)
+        assert i.start == 11
+        assert i.end == 150
 
 
-class TestDistanceAndTraverse(unittest.TestCase):
+class TestDistanceAndTraverse:
     def test_distance(self):
-        self.assertEqual(Interval(10), Evidence.distance(1, 11))
+        assert Evidence.distance(1, 11) == Interval(10)
 
     def test_traverse_right(self):
-        self.assertEqual(Interval(11), Evidence.traverse(1, 10, ORIENT.RIGHT))
+        assert Evidence.traverse(1, 10, ORIENT.RIGHT) == Interval(11)
 
     def test_traverse_left(self):
-        self.assertEqual(Interval(10), Evidence.traverse(20, 10, ORIENT.LEFT))
+        assert Evidence.traverse(20, 10, ORIENT.LEFT) == Interval(10)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,7 +1,20 @@
 import glob
 import os
+import shutil
+
+import pytest
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+
+
+long_running_test = pytest.mark.skipif(
+    os.environ.get('RUN_FULL') != '1',
+    reason='Only running FAST tests subset',
+)
+
+bwa_only = pytest.mark.skipif(not shutil.which('bwa'), reason='missing the command')
+blat_only = pytest.mark.skipif(not shutil.which('blat'), reason='missing the command')
+todo = pytest.mark.skip(reason='TODO')
 
 
 def package_relative_file(*paths):


### PR DESCRIPTION
- #219  Convert tests to match pytest instead of unittest syntax. Use bare asserts and fixtures