### PR TITLE
Fix mavis config TypeError when invalid tool is given 

### DIFF
--- a/mavis/constants.py
+++ b/mavis/constants.py
@@ -258,7 +258,7 @@ class MavisNamespace:
             ....
         """
         if value not in self.values():
-            raise KeyError('value {0} is not a valid member of '.format(repr(value)), self.values())
+            raise KeyError('value {0} is not a valid member of {1}'.format(repr(value), self.values()))
         return value
 
     def reverse(self, value):

--- a/mavis/constants.py
+++ b/mavis/constants.py
@@ -258,7 +258,9 @@ class MavisNamespace:
             ....
         """
         if value not in self.values():
-            raise KeyError('value {0} is not a valid member of {1}'.format(repr(value), self.values()))
+            raise KeyError(
+                'value {0} is not a valid member of {1}'.format(repr(value), self.values())
+            )
         return value
 
     def reverse(self, value):


### PR DESCRIPTION
Instead of raising the intended KeyError, a TypeError was being raised when 'self.values()' is None. This happens when a single tool is given as input and that tool is invalid. 