### PR TITLE
#254 fix nan values confusing downstream None checks

### DIFF
--- a/src/mavis/util.py
+++ b/src/mavis/util.py
@@ -390,6 +390,7 @@ def read_bpp_from_input_file(
             comment='#',
             na_values=['None', 'none', 'N/A', 'n/a', 'null', 'NULL', 'Null', 'nan', '<NA>', 'NaN'],
         )
+        df = df.where(pd.notnull(df), None)
     except pd.errors.EmptyDataError:
         return []
 


### PR DESCRIPTION
Small bugfix to convert the default pandas nan to None values so the `is None` checks work later on.