### PR TITLE
Edited docker container needed for long reads support and added to documentation 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,8 +43,13 @@ markdown_refdocs mavis -o docs/package --link
 mkdocs build
 ```
 
-The contents of the user manual can then be viewed by opening the build-docs/index.html
-in any available web browser (i.e. google-chrome, firefox, etc.)
+The contents of the user manual can then be viewed by opening the build-docs/index.html in any available web browser 
+(i.e. google-chrome, firefox, etc.). Future development to build the Markdown files into HTML and start a development 
+server to browse the documentation can be done using: 
+
+```bash
+mkdocs serve
+```
 
 ## Deploy to PyPi
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,6 +43,9 @@ markdown_refdocs mavis -o docs/package --link
 mkdocs build
 ```
 
+The contents of the user manual can then be viewed by opening the build-docs/index.html
+in any available web browser (i.e. google-chrome, firefox, etc.)
+
 ## Deploy to PyPi
 
 Install deployment dependencies

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,14 +43,6 @@ markdown_refdocs mavis -o docs/package --link
 mkdocs build
 ```
 
-The contents of the user manual can then be viewed by opening the build-docs/index.html in any available web browser 
-(i.e. google-chrome, firefox, etc.). Future development to build the Markdown files into HTML and start a development 
-server to browse the documentation can be done using: 
-
-```bash
-mkdocs serve
-```
-
 ## Deploy to PyPi
 
 Install deployment dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,13 @@ RUN git clone https://github.com/lh3/bwa.git && \
     cd .. && \
     mv bwa/bwa /usr/local/bin
 
+# install minimap2
+RUN git clone https://github.com/lh3/minimap2.git && \
+    cd minimap2 && \
+    git checkout v2.24 && \
+    make && \
+    cd .. && \
+    mv minimap2/minimap2.1 /usr/local/bin
 
 # install blat dependencies
 RUN apt-get install -y libcurl4
@@ -25,6 +32,13 @@ RUN apt-get install -y libcurl4
 RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/blat/blat && \
     chmod a+x blat && \
     mv blat /usr/local/bin
+
+# install wtdbg2
+RUN git clone https://github.com/ruanjue/wtdbg2.git && \
+    cd wtdbg2 && \
+    make && \
+    cd .. && \
+    mv wtdbg2/wtdbg2 /usr/local/bin
 
 COPY setup.py setup.py
 COPY setup.cfg setup.cfg

--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -8,7 +8,7 @@ The pipeline can be run in steps or it can be configured using a JSON
 configuration file and setup in a single step. Scripts will be generated
 to run all steps following clustering.
 
-The config schema is found in the mavis package under `mavis/schemas/config.json`
+The config schema is found in the mavis package under `src/mavis/schemas/config.json`
 
 Top level settings follow the pattern `<section>.<setting>`. The convert and library
 sections are nested objects.

--- a/docs/tutorials/mini.md
+++ b/docs/tutorials/mini.md
@@ -3,7 +3,7 @@
 This tutorial is based on the data included in the tests folder of
 MAVIS. The data files are very small and this tutorial is really only
 intended for testing a MAVIS install. The data here is simulated and
-results are not representitive of the typical events you would see
+results are not representative of the typical events you would see
 reported from MAVIS. For a more complete tutorial with actual fusion
 gene examples, please see the [full tutorial](../../tutorials/full/).
 


### PR DESCRIPTION
Integration of dependencies (minimap2 + wtdbg2) for long read support into develop_v3

**Improvements**

- Added minimap2 and wtdbg2 support into Dockerfile 
- Fixed typos in `docs/configuration/general.md` and `docs/tutorials/mini.md`
- Added section on `CONTRIBUTING.md` file to make hosting docs easier 

