### PR TITLE
Add wheel upgrade recommendations for users

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ The simplest way to use MAVIS is via Singularity. The MAVIS docker container use
 by singularity will take care of installing the aligner as well.
 
 ```bash
-pip install -U setuptools pip
+pip install -U setuptools pip wheel
 pip install mavis_config  # also installs snakemake
 ```
 


### PR DESCRIPTION
Similar to issues brought [here](https://stackoverflow.com/questions/61365790/error-could-not-build-wheels-for-scipy-which-use-pep-517-and-cannot-be-installe), if wheel is not upgraded, Numpy installation will freeze. 