### PR TITLE
Feature/simplify split algn

### DIFF
--- a/src/mavis/main.py
+++ b/src/mavis/main.py
@@ -14,7 +14,6 @@ from mavis_config.constants import SUBCOMMAND
 from . import __version__
 from . import config as _config
 from . import util as _util
-from .align import get_aligner_version
 from .annotate import main as annotate_main
 from .cluster import main as cluster_main
 from .convert import SUPPORTED_TOOL, convert_tool_output
@@ -24,6 +23,7 @@ from .pairing import main as pairing_main
 from .summary import main as summary_main
 from .util import filepath
 from .validate import main as validate_main
+from .validate.align import get_aligner_version
 
 
 def convert_main(inputs, outputfile, file_type, strand_specific=False, assume_no_untemplated=True):

--- a/src/mavis/validate/align.py
+++ b/src/mavis/validate/align.py
@@ -9,16 +9,16 @@ from typing import TYPE_CHECKING, Dict, List
 
 import pysam
 
-from .bam import cigar as _cigar
-from .bam import read as _read
-from .breakpoint import Breakpoint, BreakpointPair
-from .constants import CIGAR, ORIENT, STRAND, SVTYPE, MavisNamespace, reverse_complement
-from .interval import Interval
-from .types import ReferenceGenome
-from .util import logger
+from ..bam import cigar as _cigar
+from ..bam import read as _read
+from ..breakpoint import Breakpoint, BreakpointPair
+from ..constants import CIGAR, ORIENT, STRAND, SVTYPE, MavisNamespace, reverse_complement
+from ..interval import Interval
+from ..types import ReferenceGenome
+from ..util import logger
 
 if TYPE_CHECKING:
-    from .bam.cache import BamCache
+    from ..bam.cache import BamCache
 
 
 class SUPPORTED_ALIGNER(MavisNamespace):
@@ -34,7 +34,7 @@ class SUPPORTED_ALIGNER(MavisNamespace):
     BLAT = 'blat'
 
 
-class SplitAlignment(BreakpointPair):
+class DiscontinuousAlignment(BreakpointPair):
     def __init__(self, *pos, **kwargs):
         self.read1 = kwargs.pop('read1')
         self.read2 = kwargs.pop('read2', None)
@@ -210,7 +210,7 @@ def convert_to_duplication(alignment, reference_genome: ReferenceGenome):
             if refseq != alignment.untemplated_seq[:dup_len]:
                 continue
 
-            result = SplitAlignment(
+            result = DiscontinuousAlignment(
                 Breakpoint(
                     alignment.break2.chr,
                     alignment.break2.start - dup_len,
@@ -280,7 +280,7 @@ def call_read_events(read, secondary_read=None, is_stranded=False):
     result = []
     strand = STRAND.NEG if read.is_reverse else STRAND.POS
     for ref_start, delsize, insseq in events:
-        bpp = SplitAlignment(
+        bpp = DiscontinuousAlignment(
             Breakpoint(
                 read.reference_name,
                 ref_start,
@@ -383,7 +383,9 @@ def call_paired_read_event(read1, read2, is_stranded=False):
     if not is_stranded:
         break1.strand = STRAND.NS
         break2.strand = STRAND.NS
-    return SplitAlignment(break1, break2, untemplated_seq=untemplated_seq, read1=read1, read2=read2)
+    return DiscontinuousAlignment(
+        break1, break2, untemplated_seq=untemplated_seq, read1=read1, read2=read2
+    )
 
 
 def align_sequences(

--- a/src/mavis/validate/assemble.py
+++ b/src/mavis/validate/assemble.py
@@ -4,11 +4,11 @@ from typing import List, Optional
 import distance
 import networkx as nx
 
-from .bam import cigar as _cigar
-from .bam.read import calculate_alignment_score, nsb_align, sequence_complexity
-from .constants import reverse_complement
-from .interval import Interval
-from .util import logger
+from ..bam import cigar as _cigar
+from ..bam.read import calculate_alignment_score, nsb_align, sequence_complexity
+from ..constants import reverse_complement
+from ..interval import Interval
+from ..util import logger
 
 
 class Contig:

--- a/src/mavis/validate/base.py
+++ b/src/mavis/validate/base.py
@@ -5,22 +5,15 @@ from typing import Dict, List, Optional, Set, Tuple
 import pysam
 from mavis_config import DEFAULTS
 
-from ..assemble import assemble
 from ..bam import cigar as _cigar
 from ..bam import read as _read
 from ..bam.cache import BamCache
 from ..breakpoint import Breakpoint, BreakpointPair
-from ..constants import (
-    COLUMNS,
-    ORIENT,
-    PYSAM_READ_FLAGS,
-    STRAND,
-    SVTYPE,
-    reverse_complement,
-)
+from ..constants import COLUMNS, ORIENT, PYSAM_READ_FLAGS, STRAND, SVTYPE, reverse_complement
 from ..error import NotSpecifiedError
 from ..interval import Interval
 from ..util import logger
+from .assemble import Contig, assemble
 
 
 class Evidence(BreakpointPair):
@@ -31,7 +24,7 @@ class Evidence(BreakpointPair):
     compatible_window1: Optional[Interval]
     compatible_window2: Optional[Interval]
     config: Dict
-    contigs: List
+    contigs: List[Contig]
     counts: List[int]
     flanking_pairs: Set
     half_mapped: Tuple[Set, Set]

--- a/src/mavis/validate/blat.py
+++ b/src/mavis/validate/blat.py
@@ -15,12 +15,11 @@ from typing import Dict, List, Tuple
 
 import pandas as pd
 
-from .align import query_coverage_interval
-from .bam import cigar as _cigar
-from .bam.cache import BamCache
-from .bam.cigar import QUERY_ALIGNED_STATES
-from .bam.read import SamRead
-from .constants import (
+from ..bam import cigar as _cigar
+from ..bam.cache import BamCache
+from ..bam.cigar import QUERY_ALIGNED_STATES
+from ..bam.read import SamRead
+from ..constants import (
     CIGAR,
     DNA_ALPHABET,
     NA_MAPPING_QUALITY,
@@ -28,9 +27,10 @@ from .constants import (
     STRAND,
     reverse_complement,
 )
-from .interval import Interval
-from .types import ReferenceGenome
-from .util import logger
+from ..interval import Interval
+from ..types import ReferenceGenome
+from ..util import logger
+from .align import query_coverage_interval
 
 
 class Blat:

--- a/src/mavis/validate/call.py
+++ b/src/mavis/validate/call.py
@@ -3,8 +3,6 @@ import math
 import statistics
 from typing import List, Optional, Set
 
-from ..align import SplitAlignment, call_paired_read_event, call_read_events, convert_to_duplication
-from ..assemble import Contig
 from ..bam import read as _read
 from ..breakpoint import Breakpoint, BreakpointPair
 from ..constants import (
@@ -18,6 +16,13 @@ from ..constants import (
 )
 from ..interval import Interval
 from ..validate.base import Evidence
+from .align import (
+    DiscontinuousAlignment,
+    call_paired_read_event,
+    call_read_events,
+    convert_to_duplication,
+)
+from .assemble import Contig
 
 
 class EventCall(BreakpointPair):
@@ -34,7 +39,7 @@ class EventCall(BreakpointPair):
     compatible_flanking_pairs: Set
     compatible_type: Optional[str]
     contig: Optional[Contig]
-    contig_alignment: Optional[SplitAlignment]
+    contig_alignment: Optional[DiscontinuousAlignment]
 
     @property
     def has_compatible(self):
@@ -48,7 +53,7 @@ class EventCall(BreakpointPair):
         event_type: str,
         call_method: str,
         contig: Optional[Contig] = None,
-        contig_alignment: Optional[SplitAlignment] = None,
+        contig_alignment: Optional[DiscontinuousAlignment] = None,
         untemplated_seq: Optional[str] = None,
     ):
         """
@@ -515,13 +520,13 @@ class EventCall(BreakpointPair):
         if self.contig:
             cseq = self.contig_alignment.query_sequence
             try:
-                break1_read_depth = SplitAlignment.breakpoint_contig_remapped_depth(
+                break1_read_depth = DiscontinuousAlignment.breakpoint_contig_remapped_depth(
                     self.break1, self.contig, self.contig_alignment.read1
                 )
             except AssertionError:
                 break1_read_depth = None
             try:
-                break2_read_depth = SplitAlignment.breakpoint_contig_remapped_depth(
+                break2_read_depth = DiscontinuousAlignment.breakpoint_contig_remapped_depth(
                     self.break2,
                     self.contig,
                     self.contig_alignment.read1
@@ -1076,7 +1081,7 @@ def _call_by_split_reads(evidence, event_type, consumed_evidence=None):
                     event_type,
                     call_method=CALL_METHOD.SPLIT,
                     untemplated_seq=call.untemplated_seq,
-                    contig_alignment=None if not isinstance(call, SplitAlignment) else call,
+                    contig_alignment=None if not isinstance(call, DiscontinuousAlignment) else call,
                 )
             except ValueError:  # incompatible types
                 continue

--- a/src/mavis/validate/main.py
+++ b/src/mavis/validate/main.py
@@ -8,7 +8,6 @@ from typing import Dict, List
 import pysam
 from shortuuid import uuid
 
-from ..align import SUPPORTED_ALIGNER, align_sequences, select_contig_alignments
 from ..annotate.base import BioInterval
 from ..annotate.file_io import ReferenceFile
 from ..bam import cigar as _cigar
@@ -24,6 +23,7 @@ from ..util import (
     read_inputs,
     write_bed_file,
 )
+from .align import SUPPORTED_ALIGNER, align_sequences, select_contig_alignments
 from .call import call_events
 from .constants import PASS_FILENAME
 from .evidence import GenomeEvidence, TranscriptomeEvidence

--- a/tests/test_mavis/bam/test_bam_cigar.py
+++ b/tests/test_mavis/bam/test_bam_cigar.py
@@ -24,80 +24,54 @@ from mavis.constants import CIGAR
 from ...util import get_data
 from ..mock import MockObject, MockRead
 
-REFERENCE_GENOME = None
+# get_mapped_cigar_segments
 
 
-def setUpModule():
+@pytest.fixture(scope='module')
+def mock_reference_genome():
     warnings.simplefilter('ignore')
-    global REFERENCE_GENOME
-    REFERENCE_GENOME = load_reference_genome(get_data('mock_reference_genome.fa'))
-    if (
-        'CTCCAAAGAAATTGTAGTTTTCTTCTGGCTTAGAGGTAGATCATCTTGGT'
-        != REFERENCE_GENOME['fake'].seq[0:50].upper()
-    ):
+    ref = load_reference_genome(get_data('mock_reference_genome.fa'))
+    if 'CTCCAAAGAAATTGTAGTTTTCTTCTGGCTTAGAGGTAGATCATCTTGGT' != ref['fake'].seq[0:50].upper():
         raise AssertionError('fake genome file does not have the expected contents')
+    return ref
 
 
-class TestRecomputeCigarMismatch:
-    def test_simple(self):
-        r = MockRead(
-            reference_start=1456,
-            query_sequence='CCCAAACAAC' 'TATAAATTTT' 'GTAATACCTA' 'GAACAATATA' 'AATAT',
-            cigar=[(CIGAR.M, 45)],
-        )
-        assert recompute_cigar_mismatch(r, REFERENCE_GENOME['fake']) == [(CIGAR.EQ, 45)]
-
-    def test_hardclipping(self):
-        r = MockRead(
-            reference_start=1456,
-            query_sequence='CCCAAACAAC' 'TATAAATTTT' 'GTAATACCTA' 'GAACAATATA' 'AATAT',
-            cigar=[(CIGAR.H, 20), (CIGAR.M, 45)],
-        )
-        assert [(CIGAR.H, 20), (CIGAR.EQ, 45)] == recompute_cigar_mismatch(
-            r, REFERENCE_GENOME['fake']
-        )
-
-    def test_with_events(self):
-        r = MockRead(
-            reference_start=1456,
-            query_sequence='TATA' 'CCCAAACAAC' 'TATAAATTTT' 'GTAATACCTA' 'GAACAATATA' 'AATAT',
-            cigar=[(CIGAR.S, 4), (CIGAR.M, 10), (CIGAR.D, 10), (CIGAR.I, 10), (CIGAR.M, 25)],
-        )
-        assert [
-            (CIGAR.S, 4),
-            (CIGAR.EQ, 10),
-            (CIGAR.D, 10),
-            (CIGAR.I, 10),
-            (CIGAR.EQ, 25),
-        ] == recompute_cigar_mismatch(r, REFERENCE_GENOME['fake'])
-
-    def test_mismatch_to_mismatch(self):
-        r = MockRead(
-            reference_start=1452,
-            query_sequence='CAGC' 'CCCAAACAAC' 'TATAAATTTT' 'GTAATACCTA' 'GAACAATATA' 'AATAT',
-            cigar=[(CIGAR.X, 4), (CIGAR.M, 10), (CIGAR.D, 10), (CIGAR.I, 10), (CIGAR.M, 25)],
-        )
-        assert [
-            (CIGAR.X, 4),
-            (CIGAR.EQ, 10),
-            (CIGAR.D, 10),
-            (CIGAR.I, 10),
-            (CIGAR.EQ, 25),
-        ] == recompute_cigar_mismatch(r, REFERENCE_GENOME['fake'])
-
-    def test_m_to_mismatch(self):
-        r = MockRead(
-            reference_start=1452,
-            query_sequence='CAGC' 'CCCAAACAAC' 'TATAAATTTT' 'GTAATACCTA' 'GAACAATATA' 'AATAT',
-            cigar=[(CIGAR.M, 14), (CIGAR.D, 10), (CIGAR.I, 10), (CIGAR.M, 25)],
-        )
-        assert [
-            (CIGAR.X, 4),
-            (CIGAR.EQ, 10),
-            (CIGAR.D, 10),
-            (CIGAR.I, 10),
-            (CIGAR.EQ, 25),
-        ] == recompute_cigar_mismatch(r, REFERENCE_GENOME['fake'])
+@pytest.mark.parametrize(
+    'reference_start,query_sequence,cigar_in,cigar_out',
+    [
+        [1456, 'CCCAAACAAC' 'TATAAATTTT' 'GTAATACCTA' 'GAACAATATA' 'AATAT', '45M', '45='],
+        [1456, 'CCCAAACAAC' 'TATAAATTTT' 'GTAATACCTA' 'GAACAATATA' 'AATAT', '20H45M', '20H45='],
+        [
+            1456,
+            'TATA' 'CCCAAACAAC' 'TATAAATTTT' 'GTAATACCTA' 'GAACAATATA' 'AATAT',
+            '4S10M10D10I25M',
+            '4S10=10D10I25=',
+        ],
+        [
+            1452,
+            'CAGC' 'CCCAAACAAC' 'TATAAATTTT' 'GTAATACCTA' 'GAACAATATA' 'AATAT',
+            '4X10M10D10I25M',
+            '4X10=10D10I25=',
+        ],
+        [
+            1452,
+            'CAGC' 'CCCAAACAAC' 'TATAAATTTT' 'GTAATACCTA' 'GAACAATATA' 'AATAT',
+            '14M10D10I25M',
+            '4X10=10D10I25=',
+        ],
+    ],
+)
+def test_recompute_cigar_mismatch(
+    reference_start, query_sequence, cigar_in, cigar_out, mock_reference_genome
+):
+    r = MockRead(
+        reference_start=reference_start,
+        query_sequence=query_sequence,
+        cigar=convert_string_to_cigar(cigar_in),
+    )
+    assert recompute_cigar_mismatch(r, mock_reference_genome['fake']) == convert_string_to_cigar(
+        cigar_out
+    )
 
 
 class TestExtendSoftclipping:
@@ -108,22 +82,64 @@ class TestExtendSoftclipping:
         assert cnew == convert_string_to_cigar('70=80S')
 
 
+@pytest.mark.parametrize(
+    'input_cigars,output_cigar',
+    [
+        [['10M10X10X'], '10M20X'],
+        [['10X10M10X'], '10X10M10X'],
+        [['10M10X10X', '10X10M10X'], '10M30X10M10X'],
+        [['1S2S5=7X2=5X28=1X99='], '3S5=7X2=5X28=1X99='],
+        [['10H10M10X10X'], '10H10M20X'],
+    ],
+)
+def test_join(input_cigars, output_cigar):
+    assert join(*[convert_string_to_cigar(c) for c in input_cigars]) == convert_string_to_cigar(
+        output_cigar
+    )
+
+
+@pytest.mark.parametrize(
+    'seq1,seq2,opt,cigar_string,ref_start',
+    [
+        ['GTGAGTAAATTCAACATCGTTTTT', 'AACTTAGAATTCAAC---------', {}, '7S8=', 7],
+        ['GTGAGTAAATTCAACATCGTTTTT', '--CTTAGAATTCAAC---------', {}, '5S8=', 7],
+        [
+            'GTGAGTAAATTCAACATCGTTTTT',
+            '--CTTAGAATTCAAC---------',
+            dict(force_softclipping=False),
+            '5S8=',
+            7,
+        ],
+        [
+            'GTGAGTAAATTC--CATCGTTTTT',
+            '--CTTAGAATTCAAC---------',
+            dict(force_softclipping=False),
+            '5S5=2I1=',
+            7,
+        ],
+        ['CCTG', 'CCGT', dict(min_exact_to_stop_softclipping=10), '2=2X', 0],
+        [
+            '--GAGTAAATTCAACATCGTTTTT',
+            '--CTTAGAATTCAAC---------',
+            dict(force_softclipping=False),
+            '5S8=',
+            5,
+        ],
+    ],
+)
+def test_compute(seq1, seq2, opt, cigar_string, ref_start):
+    assert compute(seq1, seq2, **opt) == (convert_string_to_cigar(cigar_string), ref_start)
+
+
+def test_compute_error():
+    with pytest.raises(AttributeError):
+        compute('CCTG', 'CCG')
+
+
 class TestCigarTools:
     def test_alignment_matches(self):
         c = [(CIGAR.M, 10), (CIGAR.EQ, 10), (CIGAR.X, 10)]
         assert alignment_matches(c) == 30
-
-    def test_join(self):
-        c = [(CIGAR.M, 10), (CIGAR.X, 10), (CIGAR.X, 10)]
-        assert join(c) == [(CIGAR.M, 10), (CIGAR.X, 20)]
-        k = [(CIGAR.X, 10), (CIGAR.M, 10), (CIGAR.X, 10)]
-        assert join(c, k) == [(CIGAR.M, 10), (CIGAR.X, 30), (CIGAR.M, 10), (CIGAR.X, 10)]
-        k = [(4, 1), (4, 2), (7, 5), (8, 7), (7, 2), (8, 5), (7, 28), (8, 1), (7, 99)]
-        assert [(4, 3), (7, 5), (8, 7), (7, 2), (8, 5), (7, 28), (8, 1), (7, 99)] == join(k)
-
-    def test_join_hardclipping(self):
-        c = [(CIGAR.H, 10), (CIGAR.M, 10), (CIGAR.X, 10), (CIGAR.X, 10)]
-        assert join(c) == [(CIGAR.H, 10), (CIGAR.M, 10), (CIGAR.X, 20)]
 
     def test_longest_fuzzy_match(self):
         c = [
@@ -169,34 +185,6 @@ class TestCigarTools:
             match_percent([(CIGAR.M, 100)])
         with pytest.raises(AttributeError):
             match_percent([(CIGAR.S, 100)])
-
-    def test_compute(self):
-        # GTGAGTAAATTCAACATCGTTTTT
-        # aacttagAATTCAAC---------
-        assert ([(CIGAR.S, 7), (CIGAR.EQ, 8)], 7) == compute(
-            'GTGAGTAAATTCAACATCGTTTTT', 'AACTTAGAATTCAAC---------'
-        )
-        assert ([(CIGAR.S, 5), (CIGAR.EQ, 8)], 7) == compute(
-            'GTGAGTAAATTCAACATCGTTTTT', '--CTTAGAATTCAAC---------'
-        )
-        assert ([(CIGAR.S, 5), (CIGAR.EQ, 8)], 7) == compute(
-            'GTGAGTAAATTCAACATCGTTTTT', '--CTTAGAATTCAAC---------', False
-        )
-
-        assert ([(CIGAR.S, 5), (CIGAR.EQ, 5), (CIGAR.I, 2), (CIGAR.EQ, 1)], 7) == compute(
-            'GTGAGTAAATTC--CATCGTTTTT', '--CTTAGAATTCAAC---------', False
-        )
-
-        with pytest.raises(AttributeError):
-            compute('CCTG', 'CCG')
-
-        assert ([(CIGAR.EQ, 2), (CIGAR.X, 2)], 0) == compute(
-            'CCTG', 'CCGT', min_exact_to_stop_softclipping=10
-        )
-
-        assert ([(CIGAR.S, 5), (CIGAR.EQ, 8)], 5) == compute(
-            '--GAGTAAATTCAACATCGTTTTT', '--CTTAGAATTCAAC---------', False
-        )
 
     def test_convert_for_igv(self):
         c = [(CIGAR.M, 10), (CIGAR.EQ, 10), (CIGAR.X, 10)]
@@ -524,7 +512,7 @@ class TestHgvsStandardizeCigars:
         read.cigar = new_cigar
         assert new_cigar == exp
 
-    def test_deletion_repeat(self):
+    def test_deletion_repeat(self, mock_reference_genome):
         qseq = (
             'GAGT'
             'GAGACTCTGT'
@@ -568,10 +556,10 @@ class TestHgvsStandardizeCigars:
             (CIGAR.D, 27),
             (CIGAR.EQ, 74 - 30),
         ]
-        std_cigar = hgvs_standardize_cigar(read, REFERENCE_GENOME[read.reference_name].seq)
-        print(SamRead.deletion_sequences(read, REFERENCE_GENOME))
+        std_cigar = hgvs_standardize_cigar(read, mock_reference_genome[read.reference_name].seq)
+        print(SamRead.deletion_sequences(read, mock_reference_genome))
         read.cigar = std_cigar
-        print(SamRead.deletion_sequences(read, REFERENCE_GENOME))
+        print(SamRead.deletion_sequences(read, mock_reference_genome))
         assert std_cigar == expected_cigar
 
     @timeout_decorator.timeout(1)
@@ -705,21 +693,34 @@ class TestMergeInternalEvents:
         assert new_cigar == exp
 
 
-class TestConvertStringToCigar:
-    def test(self):
-        string = '283M' '17506D' '5M' '21275D' '596M' '17506D' '5M' '21275D' '313M'
-        exp = [
-            (CIGAR.M, 283),
-            (CIGAR.D, 17506),
-            (CIGAR.M, 5),
-            (CIGAR.D, 21275),
-            (CIGAR.M, 596),
-            (CIGAR.D, 17506),
-            (CIGAR.M, 5),
-            (CIGAR.D, 21275),
-            (CIGAR.M, 313),
-        ]
-        assert convert_string_to_cigar(string) == exp
+@pytest.mark.parametrize(
+    'string,cigartuples',
+    [
+        [
+            '283M' '17506D' '5M' '21275D' '596M' '17506D' '5M' '21275D' '313M',
+            [
+                (CIGAR.M, 283),
+                (CIGAR.D, 17506),
+                (CIGAR.M, 5),
+                (CIGAR.D, 21275),
+                (CIGAR.M, 596),
+                (CIGAR.D, 17506),
+                (CIGAR.M, 5),
+                (CIGAR.D, 21275),
+                (CIGAR.M, 313),
+            ],
+        ],
+        [
+            '42H25M',
+            [
+                (CIGAR.H, 42),
+                (CIGAR.M, 25),
+            ],
+        ],
+    ],
+)
+def test_convert_string_to_cigar(string, cigartuples):
+    assert convert_string_to_cigar(string) == cigartuples
 
 
 class TestGetSequences:

--- a/tests/test_mavis/bam/test_cigar.py
+++ b/tests/test_mavis/bam/test_cigar.py
@@ -24,8 +24,6 @@ from mavis.constants import CIGAR
 from ...util import get_data
 from ..mock import MockObject, MockRead
 
-# get_mapped_cigar_segments
-
 
 @pytest.fixture(scope='module')
 def mock_reference_genome():

--- a/tests/test_mavis/mock.py
+++ b/tests/test_mavis/mock.py
@@ -1,11 +1,11 @@
 import os
 import types
 
-from mavis.align import query_coverage_interval
 from mavis.annotate.file_io import load_annotations, load_reference_genome
 from mavis.annotate.genomic import PreTranscript, Transcript
 from mavis.annotate.protein import Translation
 from mavis.constants import CIGAR, NA_MAPPING_QUALITY
+from mavis.validate.align import query_coverage_interval
 
 from ..util import get_data
 

--- a/tests/test_mavis/test_align.py
+++ b/tests/test_mavis/test_align.py
@@ -1,14 +1,14 @@
 from unittest import mock
 
 import mavis.bam.cigar as _cigar
-from mavis import align
 from mavis.annotate.file_io import load_reference_genome
-from mavis.assemble import Contig
 from mavis.bam.cache import BamCache
 from mavis.bam.read import SamRead
 from mavis.breakpoint import Breakpoint, BreakpointPair
 from mavis.constants import CIGAR, ORIENT, STRAND, reverse_complement
 from mavis.interval import Interval
+from mavis.validate import align
+from mavis.validate.assemble import Contig
 from mavis.validate.evidence import GenomeEvidence
 from mavis_config import DEFAULTS
 
@@ -242,7 +242,7 @@ class TestBreakpointContigRemappedDepth:
             reference_start=999,
             reference_name='10',
         )
-        align.SplitAlignment.breakpoint_contig_remapped_depth(b, contig, read)
+        align.DiscontinuousAlignment.breakpoint_contig_remapped_depth(b, contig, read)
 
 
 class TestSplitEvents:

--- a/tests/test_mavis/test_assemble.py
+++ b/tests/test_mavis/test_assemble.py
@@ -2,8 +2,8 @@ import itertools
 import random
 
 import pytest
-from mavis.assemble import Contig, DeBruijnGraph, assemble, filter_contigs, kmers
 from mavis.constants import DNA_ALPHABET
+from mavis.validate.assemble import Contig, DeBruijnGraph, assemble, filter_contigs, kmers
 
 from ..util import get_data, long_running_test
 

--- a/tests/test_mavis/test_assemble2.py
+++ b/tests/test_mavis/test_assemble2.py
@@ -2,9 +2,9 @@ import time
 
 import pytest
 import timeout_decorator
-from mavis.assemble import Contig, assemble, filter_contigs
 from mavis.constants import reverse_complement
 from mavis.interval import Interval
+from mavis.validate.assemble import Contig, assemble, filter_contigs
 from mavis_config import DEFAULTS
 
 from ..util import get_data, long_running_test

--- a/tests/test_mavis/test_blat.py
+++ b/tests/test_mavis/test_blat.py
@@ -1,6 +1,6 @@
 import pytest
-from mavis.blat import Blat
 from mavis.constants import CIGAR, reverse_complement
+from mavis.validate.blat import Blat
 
 from .mock import Mock, MockFunction, MockLongString
 

--- a/tests/test_mavis/test_blat2.py
+++ b/tests/test_mavis/test_blat2.py
@@ -1,12 +1,12 @@
 import mavis.bam.cigar as _cigar
 import pytest
 from Bio import SeqIO
-from mavis.align import query_coverage_interval
 from mavis.annotate.file_io import load_reference_genome
 from mavis.bam.cache import BamCache
-from mavis.blat import Blat
 from mavis.constants import CIGAR, reverse_complement
 from mavis.interval import Interval
+from mavis.validate.align import query_coverage_interval
+from mavis.validate.blat import Blat
 
 from ..util import get_data
 from .mock import MockBamFileHandle, MockLongString, MockObject

--- a/tests/test_mavis/validate/test_call.py
+++ b/tests/test_mavis/validate/test_call.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-from mavis.align import call_paired_read_event, select_contig_alignments
 from mavis.annotate.file_io import load_reference_genome
 from mavis.annotate.genomic import PreTranscript, Transcript
 from mavis.bam import cigar as _cigar
@@ -12,6 +11,7 @@ from mavis.breakpoint import Breakpoint, BreakpointPair
 from mavis.constants import CALL_METHOD, CIGAR, ORIENT, PYSAM_READ_FLAGS, STRAND, SVTYPE
 from mavis.interval import Interval
 from mavis.validate import call
+from mavis.validate.align import call_paired_read_event, select_contig_alignments
 from mavis.validate.base import Evidence
 from mavis.validate.evidence import GenomeEvidence, TranscriptomeEvidence
 


### PR DESCRIPTION
No functionality changes

- moved top-level modules only used by validate into the validate subpackage
- cleaned up some overly verbose tests to use parametrize for the different test cases
- renamed SplitAlignment to DiscontinuousAlignment in prep for long-read changes