### PR TITLE
Move class method off of class definition

### DIFF
--- a/src/mavis/convert/__init__.py
+++ b/src/mavis/convert/__init__.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 import pandas as pd
 from shortuuid import uuid
 
-from ..breakpoint import Breakpoint, BreakpointPair
+from ..breakpoint import Breakpoint, BreakpointPair, classify_breakpoint_pair
 from ..constants import COLUMNS, ORIENT, STRAND, SVTYPE
 from ..error import InvalidRearrangement
 from ..util import logger, read_bpp_from_input_file
@@ -232,7 +232,7 @@ def _convert_tool_row(
             for col, value in std_row.items():
                 if col not in COLUMNS and col not in bpp.data:
                     bpp.data[col] = value
-            if not event_type or event_type in BreakpointPair.classify(bpp):
+            if not event_type or event_type in classify_breakpoint_pair(bpp):
                 result.append(bpp)
 
         except (InvalidRearrangement, AssertionError):

--- a/src/mavis/util.py
+++ b/src/mavis/util.py
@@ -10,7 +10,7 @@ import pandas as pd
 from mavis_config import bash_expands
 from shortuuid import uuid
 
-from .breakpoint import Breakpoint, BreakpointPair
+from .breakpoint import Breakpoint, BreakpointPair, classify_breakpoint_pair
 from .constants import (
     COLUMNS,
     FLOAT_COLUMNS,
@@ -511,17 +511,17 @@ def read_bpp_from_input_file(
                 bpp.data.update(data)
                 if putative_event_type:
                     bpp.data[COLUMNS.event_type] = putative_event_type
-                    if putative_event_type not in BreakpointPair.classify(bpp):
+                    if putative_event_type not in classify_breakpoint_pair(bpp):
                         raise InvalidRearrangement(
                             'error: expected one of',
-                            BreakpointPair.classify(bpp),
+                            classify_breakpoint_pair(bpp),
                             'but found',
                             putative_event_type,
                             str(bpp),
                             row,
                         )
                 if expand_svtype and not putative_event_type:
-                    for svtype in BreakpointPair.classify(
+                    for svtype in classify_breakpoint_pair(
                         bpp, distance=lambda x, y: Interval(y - x)
                     ):
                         new_bpp = bpp.copy()

--- a/src/mavis/validate/align.py
+++ b/src/mavis/validate/align.py
@@ -11,7 +11,7 @@ import pysam
 
 from ..bam import cigar as _cigar
 from ..bam import read as _read
-from ..breakpoint import Breakpoint, BreakpointPair
+from ..breakpoint import Breakpoint, BreakpointPair, classify_breakpoint_pair
 from ..constants import CIGAR, ORIENT, STRAND, SVTYPE, MavisNamespace, reverse_complement
 from ..interval import Interval
 from ..types import ReferenceGenome
@@ -523,7 +523,7 @@ def select_contig_alignments(evidence, reads_by_query):
     standardize/simplify reads and filter bad/irrelevant alignments
     adds the contig alignments to the contigs
     """
-    putative_types = BreakpointPair.classify(evidence)
+    putative_types = classify_breakpoint_pair(evidence)
     if {SVTYPE.DUP, SVTYPE.INS} & putative_types:
         putative_types.update({SVTYPE.DUP, SVTYPE.INS})
 
@@ -543,7 +543,7 @@ def select_contig_alignments(evidence, reads_by_query):
     def supports_primary_event(alignment):
         return all(
             [
-                BreakpointPair.classify(alignment) & putative_types,
+                classify_breakpoint_pair(alignment) & putative_types,
                 alignment.break1.chr == evidence.break1.chr,
                 alignment.break2.chr == evidence.break2.chr,
                 alignment.break1 & evidence.outer_window1,

--- a/src/mavis/validate/base.py
+++ b/src/mavis/validate/base.py
@@ -8,7 +8,7 @@ from mavis_config import DEFAULTS
 from ..bam import cigar as _cigar
 from ..bam import read as _read
 from ..bam.cache import BamCache
-from ..breakpoint import Breakpoint, BreakpointPair
+from ..breakpoint import Breakpoint, BreakpointPair, classify_breakpoint_pair
 from ..constants import COLUMNS, ORIENT, PYSAM_READ_FLAGS, STRAND, SVTYPE, reverse_complement
 from ..error import NotSpecifiedError
 from ..interval import Interval
@@ -151,12 +151,12 @@ class Evidence(BreakpointPair):
         self.stdev_fragment_size = stdev_fragment_size
         self.strand_determining_read = strand_determining_read
 
-        if self.classification is not None and self.classification not in BreakpointPair.classify(
+        if self.classification is not None and self.classification not in classify_breakpoint_pair(
             self
         ):
             raise AttributeError(
                 'breakpoint pair improper classification',
-                BreakpointPair.classify(self),
+                classify_breakpoint_pair(self),
                 self.classification,
             )
 
@@ -243,7 +243,7 @@ class Evidence(BreakpointPair):
         """
         if self.classification:
             return {self.classification}
-        return BreakpointPair.classify(self)
+        return classify_breakpoint_pair(self)
 
     @property
     def compatible_type(self):

--- a/src/mavis/validate/main.py
+++ b/src/mavis/validate/main.py
@@ -12,7 +12,7 @@ from ..annotate.base import BioInterval
 from ..annotate.file_io import ReferenceFile
 from ..bam import cigar as _cigar
 from ..bam.cache import BamCache
-from ..breakpoint import BreakpointPair
+from ..breakpoint import classify_breakpoint_pair
 from ..constants import CALL_METHOD, COLUMNS, PROTOCOL
 from ..util import (
     filter_on_overlap,
@@ -165,7 +165,7 @@ def main(
             ),
         )
         logger.info(str(evidence))
-        logger.info(f'possible event type(s): {BreakpointPair.classify(evidence)}')
+        logger.info(f'possible event type(s): {classify_breakpoint_pair(evidence)}')
         logger.info(
             f'outer window regions: {evidence.break1.chr}:{evidence.outer_window1[0]}-{evidence.outer_window1[1]}  {evidence.break2.chr}:{evidence.outer_window2[0]}-{evidence.outer_window2[1]}'
         )

--- a/tests/test_mavis/test_breakpoint.py
+++ b/tests/test_mavis/test_breakpoint.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
-from mavis.breakpoint import Breakpoint, BreakpointPair
+from mavis.breakpoint import Breakpoint, BreakpointPair, classify_breakpoint_pair
 from mavis.constants import ORIENT, STRAND, SVTYPE
 from mavis.error import InvalidRearrangement, NotSpecifiedError
 from mavis.interval import Interval
@@ -206,7 +206,7 @@ class TestClassifyBreakpointPair:
             Breakpoint(2, 1, 2, ORIENT.LEFT),
             opposing_strands=True,
         )
-        BreakpointPair.classify(b)
+        classify_breakpoint_pair(b)
 
     def test_translocation(self):
         b = BreakpointPair(
@@ -214,123 +214,123 @@ class TestClassifyBreakpointPair:
             Breakpoint(2, 1, 2, ORIENT.LEFT),
             opposing_strands=False,
         )
-        BreakpointPair.classify(b)
+        classify_breakpoint_pair(b)
 
     def test_inversion(self):
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.RIGHT),
         )
-        assert BreakpointPair.classify(b) == {SVTYPE.INV}
+        assert classify_breakpoint_pair(b) == {SVTYPE.INV}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.RIGHT),
         )
-        assert BreakpointPair.classify(b) == {SVTYPE.INV}
+        assert classify_breakpoint_pair(b) == {SVTYPE.INV}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.NS),
         )
-        assert BreakpointPair.classify(b) == {SVTYPE.INV}
+        assert classify_breakpoint_pair(b) == {SVTYPE.INV}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.NS),
         )
-        assert BreakpointPair.classify(b) == {SVTYPE.INV}
+        assert classify_breakpoint_pair(b) == {SVTYPE.INV}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.LEFT),
         )
-        assert BreakpointPair.classify(b) == {SVTYPE.INV}
+        assert classify_breakpoint_pair(b) == {SVTYPE.INV}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.LEFT),
         )
-        assert BreakpointPair.classify(b) == {SVTYPE.INV}
+        assert classify_breakpoint_pair(b) == {SVTYPE.INV}
 
     def test_duplication(self):
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.LEFT),
         )
-        assert BreakpointPair.classify(b) == {SVTYPE.DUP}
+        assert classify_breakpoint_pair(b) == {SVTYPE.DUP}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.LEFT),
         )
-        assert BreakpointPair.classify(b) == {SVTYPE.DUP}
+        assert classify_breakpoint_pair(b) == {SVTYPE.DUP}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.LEFT),
         )
-        assert BreakpointPair.classify(b) == {SVTYPE.DUP}
+        assert classify_breakpoint_pair(b) == {SVTYPE.DUP}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.NS),
         )
-        assert BreakpointPair.classify(b) == {SVTYPE.DUP}
+        assert classify_breakpoint_pair(b) == {SVTYPE.DUP}
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.RIGHT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.NS),
         )
-        assert BreakpointPair.classify(b) == {SVTYPE.DUP}
+        assert classify_breakpoint_pair(b) == {SVTYPE.DUP}
 
     def test_deletion_or_insertion(self):
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.RIGHT),
         )
-        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
+        assert sorted(classify_breakpoint_pair(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.POS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NS, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
+        assert sorted(classify_breakpoint_pair(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.RIGHT),
         )
-        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
+        assert sorted(classify_breakpoint_pair(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NEG, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NS, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
+        assert sorted(classify_breakpoint_pair(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.POS, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
+        assert sorted(classify_breakpoint_pair(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NEG, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
+        assert sorted(classify_breakpoint_pair(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         b = BreakpointPair(
             Breakpoint(1, 1, 2, strand=STRAND.NS, orient=ORIENT.LEFT),
             Breakpoint(1, 10, 11, strand=STRAND.NS, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
+        assert sorted(classify_breakpoint_pair(b)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
     def test_insertion(self):
         b = BreakpointPair(
@@ -338,7 +338,7 @@ class TestClassifyBreakpointPair:
             Breakpoint(1, 2, 2, strand=STRAND.NS, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.INS])
+        assert sorted(classify_breakpoint_pair(b)) == sorted([SVTYPE.INS])
 
     def test_no_type(self):
         b = BreakpointPair(
@@ -347,7 +347,7 @@ class TestClassifyBreakpointPair:
             opposing_strands=False,
             untemplated_seq='',
         )
-        assert BreakpointPair.classify(b) == set()
+        assert classify_breakpoint_pair(b) == set()
 
     def test_deletion(self):
         b = BreakpointPair(
@@ -356,7 +356,7 @@ class TestClassifyBreakpointPair:
             opposing_strands=False,
             untemplated_seq='',
         )
-        assert sorted(BreakpointPair.classify(b)) == sorted([SVTYPE.DEL])
+        assert sorted(classify_breakpoint_pair(b)) == sorted([SVTYPE.DEL])
 
     def test_deletion_with_useq(self):
         bpp = BreakpointPair(
@@ -365,20 +365,20 @@ class TestClassifyBreakpointPair:
             opposing=False,
             untemplated_seq='CCCT',
         )
-        assert sorted(BreakpointPair.classify(bpp)) == sorted([SVTYPE.DEL, SVTYPE.INS])
+        assert sorted(classify_breakpoint_pair(bpp)) == sorted([SVTYPE.DEL, SVTYPE.INS])
 
         def distance(x, y):
             return Interval(abs(x - y))
 
         net_size = BreakpointPair.net_size(bpp, distance)
         assert net_size == Interval(-71)
-        assert sorted(BreakpointPair.classify(bpp, distance)) == sorted([SVTYPE.DEL])
+        assert sorted(classify_breakpoint_pair(bpp, distance)) == sorted([SVTYPE.DEL])
 
     def test_deletion_no_distance_error(self):
         bpp = BreakpointPair(
             Breakpoint('1', 7039, orient='L'), Breakpoint('1', 7040, orient='R'), opposing=False
         )
-        assert sorted(BreakpointPair.classify(bpp)) == sorted([SVTYPE.INS])
+        assert sorted(classify_breakpoint_pair(bpp)) == sorted([SVTYPE.INS])
 
 
 class TestNetSize:


### PR DESCRIPTION
Refactor
- Move the BreakpointPair.classify function off the BreakpointPair class to improve readability of downstream code in future refactors

Note: there are no functionality changes in this PR