### PR TITLE
Refactor/simplify tests

### DIFF
--- a/src/mavis/bam/read.py
+++ b/src/mavis/bam/read.py
@@ -424,7 +424,7 @@ def sequenced_strand(read: pysam.AlignedSegment, strand_determining_read: int = 
         else:
             strand = STRAND.NEG if not read.is_reverse else STRAND.POS
     elif strand_determining_read == 2:
-        if read.is_read2:
+        if not read.is_read1:
             strand = STRAND.NEG if read.is_reverse else STRAND.POS
         else:
             strand = STRAND.NEG if not read.is_reverse else STRAND.POS

--- a/src/mavis/validate/align.py
+++ b/src/mavis/validate/align.py
@@ -177,9 +177,8 @@ def query_coverage_interval(read: pysam.AlignedSegment) -> Interval:
     Returns:
         The portion of the original query sequence that is aligned by this read
     """
-    seq = read.query_sequence
     st = 0
-    end = len(seq) - 1
+    end = read.query_length - 1
     if read.cigar[0][0] == CIGAR.S:
         st += read.cigar[0][1]
     if read.cigar[-1][0] == CIGAR.S:

--- a/src/mavis/validate/align.py
+++ b/src/mavis/validate/align.py
@@ -332,7 +332,8 @@ def read_breakpoint(read):
 def call_paired_read_event(read1, read2, is_stranded=False):
     """
     For a given pair of reads call all applicable events. Assume there is a major
-    event from both reads and then call indels from the individual reads
+    event from both reads and then call indels from the individual reads. Should be alternate alignments of
+    the same read
     """
     # sort the reads so that we are calling consistently
     break1 = read_breakpoint(read1)

--- a/src/mavis/validate/call.py
+++ b/src/mavis/validate/call.py
@@ -241,8 +241,8 @@ class EventCall(BreakpointPair):
                 else:  # L R
                     if not all(
                         [
-                            read.reference_start + 1 <= self.break1.end,
-                            mate.reference_end >= self.break2.start,
+                            read.reference_end <= self.break1.end,
+                            mate.reference_start >= self.break2.start,
                         ]
                     ):
                         continue

--- a/src/mavis/validate/evidence.py
+++ b/src/mavis/validate/evidence.py
@@ -210,11 +210,14 @@ class TranscriptomeEvidence(Evidence):
         return Interval.from_iterable(genomic_end_positions)
 
     def compute_fragment_size(self, read, mate):
+        """
+        Template_length to match genome template length (aka. fragment size - 1 read length if all mapped perfectly)
+        """
         if read.reference_start > mate.reference_start:
             read, mate = mate, read
         if read.reference_name == mate.reference_name:
             start, end = self.distance(
-                read.reference_start + 1, mate.reference_end, chrom=read.reference_name
+                read.reference_start + 1, mate.reference_start + 1, chrom=read.reference_name
             )
             return Interval(start + 1, end + 1)
         return Interval(0)

--- a/src/mavis/validate/gather.py
+++ b/src/mavis/validate/gather.py
@@ -1,21 +1,22 @@
 """
 Module which contains functions related to picking reads from a BAM file which support a putative event
 """
-from .base import Evidence
 import pysam
-from ..constants import (
-    CIGAR,
-    ORIENT,
-    PYSAM_READ_FLAGS,
-    reverse_complement,
-    NA_MAPPING_QUALITY,
-    SVTYPE,
-)
+
 from ..bam import cigar as _cigar
 from ..bam import read as _read
+from ..constants import (
+    CIGAR,
+    NA_MAPPING_QUALITY,
+    ORIENT,
+    PYSAM_READ_FLAGS,
+    SVTYPE,
+    reverse_complement,
+)
+from ..error import NotSpecifiedError
 from ..interval import Interval
 from ..util import logger
-from ..error import NotSpecifiedError
+from .base import Evidence
 
 
 def collect_split_read(evidence_bpp: Evidence, read: pysam.AlignedSegment, first_breakpoint: bool):

--- a/src/mavis/validate/gather.py
+++ b/src/mavis/validate/gather.py
@@ -124,7 +124,7 @@ def collect_split_read(evidence_bpp: Evidence, read: pysam.AlignedSegment, first
         w[0] - 1 : w[1]
     ]
 
-    # figure out how much of the read must match when remaped
+    # figure out how much of the read must match when remapped
     min_match_tgt = read.cigar[-1][1] if breakpoint.orient == ORIENT.LEFT else read.cigar[0][1]
     min_match_tgt = min(
         min_match_tgt * evidence_bpp.config['validate.min_anchor_match'], min_match_tgt - 1

--- a/tests/test_mavis/mock.py
+++ b/tests/test_mavis/mock.py
@@ -1,11 +1,19 @@
 import os
 import types
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
 
 from mavis.annotate.file_io import load_annotations, load_reference_genome
 from mavis.annotate.genomic import PreTranscript, Transcript
 from mavis.annotate.protein import Translation
-from mavis.constants import CIGAR, NA_MAPPING_QUALITY
-from mavis.validate.align import query_coverage_interval
+from mavis.bam.cigar import (
+    QUERY_ALIGNED_STATES,
+    REFERENCE_ALIGNED_STATES,
+    convert_cigar_to_string,
+    convert_string_to_cigar,
+)
+from mavis.bam.read import SamRead
+from mavis.constants import CIGAR, NA_MAPPING_QUALITY, PYSAM_READ_FLAGS
 
 from ..util import get_data
 
@@ -89,151 +97,186 @@ class MockObject:
             setattr(self, arg, val)
 
 
+def flags_from_number(flag: int) -> Dict:
+    return dict(
+        is_unmapped=bool(flag & int(0x4)),
+        mate_is_unmapped=bool(flag & int(0x8)),
+        is_reverse=bool(flag & int(0x10)),
+        mate_is_reverse=bool(flag & int(0x20)),
+        is_read1=bool(flag & int(0x40)),
+        is_secondary=bool(flag & int(0x100)),
+        is_supplementary=bool(flag & int(0x400)),
+    )
+
+
+class MockString(str):
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            size = key.stop - key.start
+        else:
+            size = 1
+        return 'N' * size
+
+
+@dataclass
 class MockRead:
-    def __init__(
-        self,
-        query_name=None,
-        reference_id=0,
-        reference_start=None,
-        reference_end=None,
-        cigar=None,
-        is_reverse=False,
-        mate_is_reverse=True,
-        next_reference_start=None,
-        next_reference_id=None,
-        reference_name=None,
-        query_sequence=None,
-        template_length=None,
-        query_alignment_sequence=None,
-        query_alignment_start=None,
-        query_alignment_end=None,
-        query_alignment_length=None,
-        flag=None,
-        tags=[],
-        is_read1=True,
-        is_paired=True,
-        is_unmapped=False,
-        is_supplementary=False,
-        mate_is_unmapped=False,
-        mapping_quality=NA_MAPPING_QUALITY,
-        **kwargs
-    ):
-        for attr, val in kwargs.items():
-            setattr(self, attr, val)
-        self.mapping_quality = mapping_quality
-        self.query_name = query_name
-        self.reference_id = reference_id
-        self.reference_start = reference_start
-        self.reference_end = reference_end
-        self.cigar = cigar
-        self.query_alignment_length = query_alignment_length
-        self.query_sequence = query_sequence
-        if self.reference_end is None and cigar and reference_start is not None:
-            self.reference_end = reference_start + sum(
-                [f for v, f in cigar if v not in [CIGAR.S, CIGAR.I]]
-            )
-        if not self.query_alignment_length:
-            if cigar:
-                self.query_alignment_length = sum(
-                    [v for s, v in cigar if s not in [CIGAR.S, CIGAR.H]]
-                )
-            elif self.query_sequence:
-                self.query_alignment_length = len(self.query_sequence)
-            else:
-                self.query_alignment_length = 0
-        self.is_reverse = is_reverse
-        self.mate_is_reverse = mate_is_reverse
-        self.next_reference_start = next_reference_start
-        self.next_reference_id = next_reference_id
-        self.reference_name = reference_name
+    cigarstring: str
+    reference_start: int
+    reference_name: str = ''
+    query_sequence: str = MockString()
+    is_reverse: bool = False
+    query_name: str = ''
+    is_read1: bool = False
+    is_supplementary: bool = False
+    is_secondary: bool = False
+    is_paired: bool = True
+    template_length: Optional[int] = None
+    is_unmapped: bool = False
+    mapping_quality: int = NA_MAPPING_QUALITY
 
-        self.query_alignment_sequence = query_alignment_sequence
-        self.query_alignment_start = query_alignment_start
-        self.query_alignment_end = query_alignment_end
-        self.flag = flag
-        self.tags = tags
-        if query_alignment_sequence is None and cigar and query_sequence:
-            s = 0 if cigar[0][0] != CIGAR.S else cigar[0][1]
-            t = len(query_sequence)
-            if cigar[-1][0] == CIGAR.S:
-                t -= cigar[-1][1]
-            self.query_alignment_sequence = query_sequence[s:t]
-        if cigar and query_sequence:
-            if len(query_sequence) != sum(
-                [f for v, f in cigar if v not in [CIGAR.H, CIGAR.N, CIGAR.D]]
-            ):
-                raise AssertionError(
-                    'length of sequence does not match cigar',
-                    len(query_sequence),
-                    sum([f for v, f in cigar if v not in [CIGAR.H, CIGAR.N, CIGAR.D]]),
-                )
-        if template_length is None and reference_end and next_reference_start:
-            self.template_length = next_reference_start - reference_end
-        else:
-            self.template_length = template_length
-        self.is_read1 = is_read1
-        self.is_read2 = not is_read1
-        self.is_paired = is_paired
-        self.is_unmapped = is_unmapped
-        self.mate_is_unmapped = mate_is_unmapped
-        self.is_supplementary = is_supplementary
-        if self.reference_start and self.reference_end:
-            if not cigar:
-                self.cigar = [(CIGAR.M, self.reference_end - self.reference_start)]
-            if not self.query_sequence:
-                self.query_sequence = 'N' * (self.reference_end - self.reference_start)
-        if flag:
-            self.is_unmapped = bool(self.flag & int(0x4))
-            self.mate_is_unmapped = bool(self.flag & int(0x8))
-            self.is_reverse = bool(self.flag & int(0x10))
-            self.mate_is_reverse = bool(self.flag & int(0x20))
-            self.is_read1 = bool(self.flag & int(0x40))
-            self.is_read2 = bool(self.flag & int(0x80))
-            self.is_secondary = bool(self.flag & int(0x100))
-            self.is_qcfail = bool(self.flag & int(0x200))
-            self.is_supplementary = bool(self.flag & int(0x400))
+    # mate flags
+    next_reference_name: str = ''
+    mate_is_reverse: bool = False
+    next_reference_start: Optional[int] = None
+    mate_is_unmapped: bool = False
 
-    def query_coverage_interval(self):
-        return query_coverage_interval(self)
+    # custom flags for assembly reads
+    alignment_rank: Optional[int] = None
 
-    def set_tag(self, tag, value, value_type=None, replace=True):
-        new_tag = (tag, value)
-        if not replace and new_tag in self.tags:
-            self.tags.append(new_tag)
-        else:
-            self.tags.append(new_tag)
+    def __hash__(self):
+        return hash(SamRead.__hash__(self))
 
-    def has_tag(self, tag):
-        return tag in dict(self.tags).keys()
-
-    def get_tag(self, tag):
-        return dict(self.tags)[tag] if tag in dict(self.tags).keys() else False
-
-    def __str__(self):
-        return '{}(ref_id={}, start={}, end={}, seq={})'.format(
-            self.__class__.__name__,
-            self.reference_id,
-            self.reference_start,
-            self.reference_end,
-            self.query_sequence,
+    @property
+    def query_length(self):
+        return sum(
+            [
+                size
+                for (cigar_state, size) in self.cigar
+                if cigar_state in QUERY_ALIGNED_STATES - {CIGAR.H}
+            ]
         )
 
+    @property
+    def is_proper_pair(self):
+        return self.is_paired
+
+    @property
+    def reference_id(self):
+        try:
+            return int(self.reference_name) - 1
+        except ValueError:
+            return hash(str(self.reference_name))
+
+    @property
+    def next_reference_id(self):
+        try:
+            return int(self.next_reference_name) - 1
+        except ValueError:
+            return hash(str(self.next_reference_name))
+
+    @property
+    def seq(self):
+        return self.query_sequence
+
+    @property
+    def cigar(self) -> List[Tuple[int, int]]:
+        return convert_string_to_cigar(self.cigarstring)
+
+    @cigar.setter
+    def cigar(self, cigartuples: List[Tuple[int, int]]):
+        self.cigarstring = convert_cigar_to_string(cigartuples)
+
+    @property
+    def reference_end(self):
+        reference_pos = self.reference_start
+        for state, size in self.cigar:
+            if state in REFERENCE_ALIGNED_STATES:
+                reference_pos += size
+        return reference_pos
+
+    @property
+    def query_alignment_start(self):
+        query_pos = 0
+        for state, size in self.cigar:
+            if state == CIGAR.H:
+                continue
+            elif state in QUERY_ALIGNED_STATES - REFERENCE_ALIGNED_STATES:
+                query_pos += size
+            elif state in QUERY_ALIGNED_STATES:
+                return query_pos
+        return None
+
+    @property
+    def query_alignment_end(self):
+        query_pos = 0
+        for state, size in self.cigar[::-1]:
+            if state == CIGAR.H:
+                continue
+            elif state in QUERY_ALIGNED_STATES - REFERENCE_ALIGNED_STATES:
+                query_pos += size
+            elif state in QUERY_ALIGNED_STATES:
+                return self.query_length - query_pos
+        return None
+
+    @property
+    def query_alignment_length(self):
+        return self.query_alignment_end - self.query_alignment_start
+
+    @property
+    def query_alignment_sequence(self):
+        return self.query_sequence[self.query_alignment_start : self.query_alignment_end]
+
+    def has_tag(self, tag_name: str) -> bool:
+        return hasattr(self, tag_name)
+
+    def get_tag(self, tag_name: str) -> bool:
+        if self.has_tag(tag_name):
+            return getattr(self, tag_name)
+        return False
+
+    def set_tag(self, tag_name: str, value, value_type='') -> bool:
+        setattr(self, tag_name, value)
+
+    # SamRead methods
     def key(self):
-        """
-        uses a stored _key attribute, if available. This is to avoid the hash changing if the reference start (for example)
-        is changed but also allow this attribute to be used and calculated for non SamRead objects
+        return SamRead.key(self)
 
-        This way to change the hash behaviour the user must be explicit and use the set_key method
-        """
-        if hasattr(self, '_key') and self._key is not None:
-            return self._key
-        return (
-            self.query_name,
-            self.query_sequence,
-            self.reference_id,
-            self.reference_start,
-            self.is_supplementary,
-        )
+    @property
+    def flag(self):
+        flag = 0
+        for flag_value, attr_name in [
+            ('REVERSE', 'is_reverse'),
+            ('MATE_REVERSE', 'mate_is_reverse'),
+            ('MATE_UNMAPPED', 'mate_is_unmapped'),
+            ('UNMAPPED', 'is_unmapped'),
+            ('SECONDARY', 'is_secondary'),
+            ('SUPPLEMENTARY', 'is_supplementary'),
+        ]:
+            if getattr(self, attr_name):
+                flag |= PYSAM_READ_FLAGS[flag_value]
+
+        if self.is_paired:
+            if self.is_read1:
+                flag |= PYSAM_READ_FLAGS.FIRST_IN_PAIR
+            else:
+                flag |= PYSAM_READ_FLAGS.LAST_IN_PAIR
+        return flag
+
+    @flag.setter
+    def flag(self, value):
+        for flag_value, attr_name in [
+            ('REVERSE', 'is_reverse'),
+            ('MATE_REVERSE', 'mate_is_reverse'),
+            ('MATE_UNMAPPED', 'mate_is_unmapped'),
+            ('UNMAPPED', 'is_unmapped'),
+            ('FIRST_IN_PAIR', 'is_read1'),
+            ('SECONDARY', 'is_secondary'),
+            ('SUPPLEMENTARY', 'is_supplementary'),
+        ]:
+            if value & PYSAM_READ_FLAGS[flag_value]:
+                setattr(self, attr_name, True)
+        if value & PYSAM_READ_FLAGS.LAST_IN_PAIR:
+            self.is_read1 = False
 
 
 class MockBamFileHandle:
@@ -256,35 +299,33 @@ class MockBamFileHandle:
         raise KeyError('invalid id')
 
 
-class MockString:
-    def __init__(self, char=' '):
-        self.char = char
+def mock_read_pair(mock1: MockRead, mock2: MockRead, proper_pair=True, reverse_order=False):
+    # make sure pair flags are set
+    mock1.is_paired = True
+    mock2.is_paired = True
 
-    def __getitem__(self, index):
-        if isinstance(index, slice):
-            return self.char * (index.stop - index.start)
-        else:
-            return self.char
+    mock1.is_read1 = not reverse_order
+    mock2.is_read1 = reverse_order
 
+    if not mock1.is_reverse and proper_pair:
+        mock2.is_reverse = True
 
-def mock_read_pair(mock1, mock2):
-    if mock1.reference_id != mock2.reference_id:
+    if mock1.reference_name != mock2.reference_name:
         mock1.template_length = 0
         mock2.template_length = 0
-    mock1.next_reference_id = mock2.reference_id
+    mock1.next_reference_name = mock2.reference_name
     mock1.next_reference_start = mock2.reference_start
     mock1.mate_is_reverse = mock2.is_reverse
-    mock1.is_paired = True
-    mock1.is_read2 = not mock1.is_read1
-    if mock1.template_length is None:
-        mock1.template_length = mock2.reference_end - mock1.reference_start
 
-    mock2.next_reference_id = mock1.reference_id
+    if mock1.template_length is None:
+        # mock1.template_length = abs(mock1.reference_start - mock1.next_reference_start) + 1
+        # if reverse_order:
+        #     mock1.template_length *= -1
+        mock1.template_length = mock1.next_reference_start - mock1.reference_start + 1
+
+    mock2.next_reference_name = mock1.reference_name
     mock2.next_reference_start = mock1.reference_start
     mock2.mate_is_reverse = mock1.is_reverse
-    mock2.is_paired = True
-    mock2.is_read1 = not mock1.is_read1
-    mock2.is_read2 = not mock1.is_read2
     if mock2.query_name is None:
         mock2.query_name = mock1.query_name
     mock2.template_length = -1 * mock1.template_length

--- a/tests/test_mavis/test_align.py
+++ b/tests/test_mavis/test_align.py
@@ -717,7 +717,7 @@ class TestSelectContigAlignments:
         raw_alignments = {s: [read1, read2]}
         align.select_contig_alignments(evidence, raw_alignments)
         alignments = list(evidence.contigs[0].alignments)
-        assert len(alignments) == 2
+        assert len(alignments) == 1
 
 
 class TestGetAlignerVersion:

--- a/tests/test_mavis/test_align.py
+++ b/tests/test_mavis/test_align.py
@@ -238,7 +238,7 @@ class TestBreakpointContigRemappedDepth:
 
         b = Breakpoint('10', 1030, 1030, orient=ORIENT.LEFT)
         read = MockRead(
-            cigar=_cigar.convert_string_to_cigar('35M10D5I20M'),
+            cigarstring='35M10D5I20M',
             reference_start=999,
             reference_name='10',
         )
@@ -249,11 +249,8 @@ class TestSplitEvents:
     def test_read_with_exons(self):
         contig = MockRead(
             query_sequence='CTTGAAGGAAACTGAATTCAAAAAGATCAAAGTGCTGGGCTCCGGTGCGTTCGGCACGGTGTATAAGGGACTCTGGATCCCAGAAGGTGAGAAAGTTAAAATTCCCGTCGCTATCAAGACATCTCCGAAAGCCAACAAGGAAATCCTCGATGAAGCCTACGTGATGGCCAGCGTGGACAACCCCCACGTGTGCCGCCTGCTGGGCATCTGCCTCACCTCCACCGTGCAGCTCATCATGCAGCTCATGCCCTTCGGCTGCCTCCTGGACTATGTCCGGGAACACAAAGACAATATTGGCTCCCAGTACCTGCTCAACTGGTGTGTGCAGATCGCAAAGGGCATGAACTACTTGGAGGACCGTCGCTTGGTGCACCGCGACCTGGCAGCCAGGAACGTACTGGTGAAAACACCGCAGCATGTCAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCGGAAGAGAAAGAATACCATGCAGAAGGAGGCAAAGTGCCTATCAAGTGGATGGCATTGGAATCAATTTTACACAGAATCTATACCCACCAGAGTGATGTCTGGAGCTACGGGGTGACCGTTTGGGAGTTGATGACCTTTGGATCCAA',
-            cigar=_cigar.convert_string_to_cigar(
-                '68M678D50M15D34M6472D185M10240D158M891D74M8I5883D29M'
-            ),
+            cigarstring='68M678D50M15D34M6472D185M10240D158M891D74M8I5883D29M',
             reference_name='7',
-            reference_id=6,
             reference_start=55241669,
         )
         assert len(align.call_read_events(contig)) == 6
@@ -262,10 +259,9 @@ class TestSplitEvents:
 class TestCallBreakpointPair:
     def test_single_one_event(self):
         r = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=0,
-            cigar=[(CIGAR.M, 10), (CIGAR.I, 3), (CIGAR.D, 7), (CIGAR.M, 10)],
+            cigarstring='10M3I7D10M',
             query_sequence='ACTGAATCGTGGGTAGCTGCTAG',
         )
         bpps = align.call_read_events(r)
@@ -280,10 +276,9 @@ class TestCallBreakpointPair:
 
     def test_ins_and_del(self):
         r = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=0,
-            cigar=[(CIGAR.M, 10), (CIGAR.I, 3), (CIGAR.M, 5), (CIGAR.D, 7), (CIGAR.M, 5)],
+            cigarstring='10M3I5M7D5M',
             query_sequence='ACTGAATCGTGGGTAGCTGCTAG',
         )
         # only report the major del event for now
@@ -305,10 +300,9 @@ class TestCallBreakpointPair:
 
     def test_single_insertion(self):
         r = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=0,
-            cigar=[(CIGAR.M, 10), (CIGAR.I, 8), (CIGAR.M, 5)],
+            cigarstring='10M8I5M',
             query_sequence='ACTGAATCGTGGGTAGCTGCTAG',
         )
         bpp = align.call_read_events(r)[0]
@@ -321,10 +315,10 @@ class TestCallBreakpointPair:
 
     def test_single_duplication(self):
         r = MockRead(
-            name='seq1',
+            query_name='seq1',
             reference_name='gene3',
             reference_start=27155,
-            cigar=[(CIGAR.M, 65), (CIGAR.I, 6), (CIGAR.D, 95), (CIGAR.M, 21), (CIGAR.S, 17)],
+            cigarstring='65M6I95D21M17S',
             query_sequence='TAGTTGGATCTCTGTGCTGACTGACTGACAGACAGACTTTAGTGTCTGTGTGCTGACTGACAGACAGACTTTAGTGTCTGTGTGCTGACT'
             'GACAGACTCTAGTAGTGTC',
         )
@@ -341,10 +335,9 @@ class TestCallBreakpointPair:
                 'CTGTGGGCTCGGGCCCGACGCGCACGGAGGACTGGAGGACTGGGGCGTGTGTCTGCGGTGCAGGCGAGGCGGGGCGGGC'
             ),
             query_name='duplication_with_untemp',
-            reference_id=16,
             reference_name='reference17',
             reference_start=1882,
-            cigar=[(CIGAR.EQ, 126), (CIGAR.I, 54), (CIGAR.EQ, 93)],
+            cigarstring='126=54I93=',
             is_reverse=False,
         )
         bpp = align.call_read_events(r)[0]
@@ -359,10 +352,9 @@ class TestCallBreakpointPair:
                 'CCGGTTTAGCATTGCCATTGGTAA'
             ),
             query_name='duplication_with_untemp',
-            reference_id=2,
             reference_name='reference3',
             reference_start=1497,
-            cigar=[(CIGAR.EQ, 51), (CIGAR.I, 22), (CIGAR.EQ, 52)],
+            cigarstring='51=22I52=',
             is_reverse=False,
         )
         # repeat: GATTTTGCTGTTGTTTTTGTTC
@@ -383,10 +375,9 @@ class TestCallBreakpointPair:
                 'CAAAGTGTTTTATACTGATAAAGCAACCCCGGTTTAGCATTGCCATTGGTAA'
             ),
             query_name='duplication_with_untemp',
-            reference_id=2,
             reference_name='reference3',
             reference_start=1497,
-            cigar=[(CIGAR.EQ, 51), (CIGAR.I, 27), (CIGAR.EQ, 52)],
+            cigarstring='51=27I52=',
             is_reverse=False,
         )
         # repeat: GATTTTGCTGTTGTTTTTGTTC
@@ -410,19 +401,17 @@ class TestCallBreakpointPair:
         # i   ---------GGGAATTCCGGA--------- 10-21    n/a
         seq = 'AAATTTCCCGGGAATTCCGGATCGATCGAT'  # 30
         r1 = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=0,
-            cigar=[(CIGAR.M, 9), (CIGAR.S, 21)],
+            cigarstring='9M21S',
             query_sequence=seq,
             is_reverse=False,
         )
 
         r2 = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=99,
-            cigar=[(CIGAR.S, 21), (CIGAR.M, 9)],
+            cigarstring='21S9M',
             query_sequence=seq,
             is_reverse=False,
         )
@@ -443,19 +432,17 @@ class TestCallBreakpointPair:
         # r2  aaatttcccgggaattccggaTCGATCGAT
         seq = 'AAATTTCCCGGGAATTCCGGATCGATCGAT'  # 30
         r1 = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=0,
-            cigar=[(CIGAR.M, 21), (CIGAR.S, 9)],
+            cigarstring='21M9S',
             query_sequence=seq,
             is_reverse=False,
         )
 
         r2 = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=99,
-            cigar=[(CIGAR.S, 21), (CIGAR.M, 9)],
+            cigarstring='21S9M',
             query_sequence=seq,
             is_reverse=False,
         )
@@ -474,19 +461,17 @@ class TestCallBreakpointPair:
         # r2  aaatttcccgggaattccggaTCGATCGAT
         seq = 'AAATTTCCCGGGAATTCCGGATCGATCGAT'  # 30
         r1 = MockRead(
-            reference_id=0,
             reference_name='2',
             reference_start=0,
-            cigar=[(CIGAR.M, 21), (CIGAR.S, 9)],
+            cigarstring='21M9S',
             query_sequence=seq,
             is_reverse=False,
         )
 
         r2 = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=99,
-            cigar=[(CIGAR.S, 21), (CIGAR.M, 9)],
+            cigarstring='21S9M',
             query_sequence=seq,
             is_reverse=False,
         )
@@ -506,19 +491,17 @@ class TestCallBreakpointPair:
 
         seq = 'AAATTTCCCGGGAATTCCGGATCGATCGAT'  # 30
         r1 = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=0,
-            cigar=[(CIGAR.M, 21), (CIGAR.S, 9)],
+            cigarstring='21M9S',
             query_sequence=seq,
             is_reverse=False,
         )
 
         r2 = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=99,
-            cigar=[(CIGAR.S, 18), (CIGAR.M, 12)],
+            cigarstring='18S12M',
             query_sequence=seq,
             is_reverse=False,
         )
@@ -542,19 +525,17 @@ class TestCallBreakpointPair:
         # r2  ATCTATCGATCCggaattcccgggaaattt 100+12 = 111 - 3 = 108
         seq = 'AAATTTCCCGGGAATTCCGGATCGATCGAT'  # 30
         r1 = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=0,
-            cigar=[(CIGAR.M, 21), (CIGAR.S, 9)],
+            cigarstring='21M9S',
             query_sequence=seq,
             is_reverse=False,
         )
 
         r2 = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=99,
-            cigar=[(CIGAR.M, 12), (CIGAR.S, 18)],
+            cigarstring='12M18S',
             query_sequence=reverse_complement(seq),
             is_reverse=True,
         )
@@ -573,16 +554,16 @@ class TestCallBreakpointPair:
         s = 'CTGAGCATGAAAGCCCTGTAAACACAGAATTTGGATTCTTTCCTGTTTGGTTCCTGGTCGTGAGTGGCAGGTGCCATCATGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTGGTTATGAAATTTCAGGGTTTTCATTTCTGTATGTTAAT'
 
         read1 = MockRead(
-            reference_id=3,
+            reference_name='3',
             reference_start=1114,
-            cigar=[(CIGAR.S, 125), (CIGAR.EQ, 120)],
+            cigarstring='125S120=',
             query_sequence=s,
             is_reverse=False,
         )
         read2 = MockRead(
-            reference_id=3,
+            reference_name='3',
             reference_start=2187,
-            cigar=[(CIGAR.S, 117), (CIGAR.EQ, 8), (CIGAR.D, 1), (CIGAR.M, 120)],
+            cigarstring='117S8=1D120M',
             query_sequence=reverse_complement(s),
             is_reverse=True,
         )
@@ -613,19 +594,17 @@ class TestCallBreakpointPair:
         # r2  ATCTATCGATCCggaattcccgggaaattt 100+12 = 111 - 3 = 108
         seq = 'AAATTTCCCGGGAATTCCGGATCGATCGAT'  # 30
         r1 = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=0,
-            cigar=[(CIGAR.M, 16), (CIGAR.S, 14)],
+            cigarstring='16M14S',
             query_sequence=seq,
             is_reverse=False,
         )
 
         r2 = MockRead(
-            reference_id=0,
             reference_name='1',
             reference_start=99,
-            cigar=[(CIGAR.M, 12), (CIGAR.S, 18)],
+            cigarstring='12M18S',
             query_sequence=reverse_complement(seq),
             is_reverse=True,
         )
@@ -719,19 +698,17 @@ class TestSelectContigAlignments:
             reference_genome=None,
             bam_cache=mock.Mock(stranded=False),
         )
-        read1 = SamRead(
-            reference_id=3,
+        read1 = MockRead(
             reference_start=1114,
-            cigar=[(CIGAR.S, 125), (CIGAR.EQ, 120)],
+            cigarstring='125S120=',
             query_sequence=s,
             is_reverse=False,
             reference_name='3',
             alignment_rank=0,
         )
-        read2 = SamRead(
-            reference_id=3,
+        read2 = MockRead(
             reference_start=2187,
-            cigar=[(CIGAR.S, 117), (CIGAR.EQ, 8), (CIGAR.D, 1), (CIGAR.EQ, 120)],
+            cigarstring='117S7=1X120=',
             query_sequence=reverse_complement(s),
             is_reverse=True,
             reference_name='3',

--- a/tests/test_mavis/validate/test_call.py
+++ b/tests/test_mavis/validate/test_call.py
@@ -1701,6 +1701,7 @@ class TestCallByFlankingReadsTranscriptome:
         pre_transcript = PreTranscript(
             [(1001, 1100), (1501, 1700), (2001, 2100), (2201, 2300)], strand='+'
         )
+        pre_transcript.chr = '1'
         for patt in pre_transcript.generate_splicing_patterns():
             pre_transcript.transcripts.append(Transcript(pre_transcript, patt))
         evidence = self.build_transcriptome_evidence(

--- a/tests/test_mavis/validate/test_call.py
+++ b/tests/test_mavis/validate/test_call.py
@@ -66,7 +66,6 @@ class TestCallByContig:
                 '68M678D50M15D34M6472D185M10240D158M891D74M' '5875D' '6M' '1X' '29M'
             ),
             reference_name='7',
-            reference_id=6,
             reference_start=55241669,
             alignment_rank=0,
         )
@@ -167,26 +166,38 @@ class TestEventCall:
             mock_read_pair(
                 MockRead(
                     query_name='test1',
-                    reference_id=3,
+                    reference_name='reference3',
                     template_length=500,
                     reference_start=1150,
-                    reference_end=1200,
                     is_reverse=True,
+                    cigarstring='50M',
                 ),
-                MockRead(reference_id=3, reference_start=2200, reference_end=2250, is_reverse=True),
+                MockRead(
+                    reference_name='reference3',
+                    reference_start=2200,
+                    is_reverse=True,
+                    cigarstring='50M',
+                ),
+                proper_pair=False,
             )
         )
         ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     query_name='test2',
-                    reference_id=3,
+                    reference_name='reference3',
                     template_length=560,
                     reference_start=1150,
-                    reference_end=1200,
+                    cigarstring='50M',
                     is_reverse=True,
                 ),
-                MockRead(reference_id=3, reference_start=2200, reference_end=2250, is_reverse=True),
+                MockRead(
+                    reference_name='reference3',
+                    reference_start=2200,
+                    is_reverse=True,
+                    cigarstring='50M',
+                ),
+                proper_pair=False,
             )
         )
         median, stdev = ev.flanking_metrics()
@@ -250,8 +261,18 @@ class TestPullFlankingSupport:
         )
         flanking_pairs = [
             mock_read_pair(
-                MockRead('r1', 0, 400, 450, is_reverse=False),
-                MockRead('r1', 0, 1200, 1260, is_reverse=True),
+                MockRead(
+                    query_name='r1',
+                    reference_name='1',
+                    reference_start=400,
+                    cigarstring='50M',
+                ),
+                MockRead(
+                    query_name='r1',
+                    reference_name='1',
+                    reference_start=1200,
+                    cigarstring='60M',
+                ),
             )
         ]
         event = call.EventCall(
@@ -303,8 +324,12 @@ class TestPullFlankingSupport:
         )
         flanking_pairs = [
             mock_read_pair(
-                MockRead('r1', 0, 700, 750, is_reverse=False),
-                MockRead('r1', 0, 950, 1049, is_reverse=True),
+                MockRead(
+                    query_name='r1', reference_name='1', reference_start=700, cigarstring='50M'
+                ),
+                MockRead(
+                    query_name='r1', reference_name='1', reference_start=950, cigarstring='50M'
+                ),
             )
         ]
         print(evidence.min_expected_fragment_size)
@@ -326,8 +351,21 @@ class TestPullFlankingSupport:
         )
         flanking_pairs = [
             mock_read_pair(
-                MockRead('r1', 0, 400, 450, is_reverse=False),
-                MockRead('r1', 0, 900, 950, is_reverse=False),
+                MockRead(
+                    query_name='r1',
+                    reference_name='1',
+                    reference_start=400,
+                    cigarstring='50M',
+                    is_reverse=False,
+                ),
+                MockRead(
+                    query_name='r1',
+                    reference_name='1',
+                    reference_start=900,
+                    cigarstring='50M',
+                    is_reverse=False,
+                ),
+                proper_pair=False,
             )
         ]
         event = call.EventCall(
@@ -380,28 +418,88 @@ class TestPullFlankingSupport:
         event = call.EventCall(b1, b2, evidence, SVTYPE.TRANS, CALL_METHOD.CONTIG)
         flanking_pairs = [
             mock_read_pair(
-                MockRead('x', '11', 128675264, 128677087, is_reverse=False),
-                MockRead('x', '22', 29683030, 29683105, is_reverse=True),
+                MockRead(
+                    query_name='x1',
+                    reference_name='11',
+                    reference_start=128675264,
+                    cigarstring=str(128677087 - 128675264 - 100) + 'M',
+                ),
+                MockRead(
+                    query_name='x1',
+                    reference_name='22',
+                    reference_start=29683030,
+                    cigarstring=str(29683105 - 29683030) + 'M',
+                ),
             ),
             mock_read_pair(
-                MockRead('x', '11', 128675286, 128677109, is_reverse=False),
-                MockRead('x', '22', 29683016, 29683091, is_reverse=True),
+                MockRead(
+                    query_name='x2',
+                    reference_name='11',
+                    reference_start=128675286,
+                    cigarstring=str(128677109 - 128675286) + 'M',
+                ),
+                MockRead(
+                    query_name='x2',
+                    reference_name='22',
+                    reference_start=29683016,
+                    cigarstring=str(29683091 - 29683016) + 'M',
+                ),
             ),
             mock_read_pair(
-                MockRead('x', '11', 128675260, 128677083, is_reverse=False),
-                MockRead('x', '22', 29683049, 29683123, is_reverse=True),
+                MockRead(
+                    query_name='x3',
+                    reference_name='11',
+                    reference_start=128675260,
+                    cigarstring=str(128677083 - 128675260) + 'M',
+                ),
+                MockRead(
+                    query_name='x3',
+                    reference_name='22',
+                    reference_start=29683049,
+                    cigarstring=str(29683123 - 29683049) + 'M',
+                ),
             ),
             mock_read_pair(
-                MockRead('x', '11', 128675289, 128677110, is_reverse=False),
-                MockRead('x', '22', 29683047, 29683122, is_reverse=True),
+                MockRead(
+                    query_name='x4',
+                    reference_name='11',
+                    reference_start=128675289,
+                    cigarstring=str(128677110 - 128675289) + 'M',
+                ),
+                MockRead(
+                    query_name='x4',
+                    reference_name='22',
+                    reference_start=29683047,
+                    cigarstring=str(29683122 - 29683047) + 'M',
+                ),
             ),
             mock_read_pair(
-                MockRead('x', '11', 128675306, 128677129, is_reverse=False),
-                MockRead('x', '22', 29683039, 29683114, is_reverse=True),
+                MockRead(
+                    query_name='x5',
+                    reference_name='11',
+                    reference_start=128675306,
+                    cigarstring=str(128677129 - 128675306) + 'M',
+                ),
+                MockRead(
+                    query_name='x5',
+                    reference_name='22',
+                    reference_start=29683039,
+                    cigarstring=str(29683114 - 29683039) + 'M',
+                ),
             ),
             mock_read_pair(
-                MockRead('x', '11', 128675289, 128677110, is_reverse=False),
-                MockRead('x', '22', 29683047, 29683122, is_reverse=True),
+                MockRead(
+                    query_name='x6',
+                    reference_name='11',
+                    reference_start=128675289,
+                    cigarstring=str(128677110 - 128675289) + 'M',
+                ),
+                MockRead(
+                    query_name='x6',
+                    reference_name='22',
+                    reference_start=29683047,
+                    cigarstring=str(29683122 - 29683047) + 'M',
+                ),
             ),
         ]
         event.add_flanking_support(flanking_pairs)
@@ -413,8 +511,20 @@ class TestPullFlankingSupport:
         )
         flanking_pairs = [
             mock_read_pair(
-                MockRead('r1', 0, 1201, 1249, is_reverse=True),
-                MockRead('r1', 1, 1201, 1249, is_reverse=False),
+                MockRead(
+                    query_name='r1',
+                    reference_name='1',
+                    reference_start=1201,
+                    cigarstring='48M',
+                    is_reverse=True,
+                ),
+                MockRead(
+                    query_name='r1',
+                    reference_name='2',
+                    reference_start=1201,
+                    cigarstring='48M',
+                    is_reverse=False,
+                ),
             )
         ]
         event = call.EventCall(
@@ -447,8 +557,20 @@ class TestPullFlankingSupport:
         )
         flanking_pairs = [
             mock_read_pair(
-                MockRead('r1', 0, 1205, 1250, is_reverse=True),
-                MockRead('r1', 0, 1260, 1295, is_reverse=False),
+                MockRead(
+                    query_name='r1',
+                    reference_name='1',
+                    reference_start=1205,
+                    cigarstring='45M',
+                    is_reverse=True,
+                ),
+                MockRead(
+                    query_name='r1',
+                    reference_name='1',
+                    reference_start=1260,
+                    cigarstring='35M',
+                    is_reverse=False,
+                ),
             )
         ]
         event = call.EventCall(
@@ -501,59 +623,64 @@ class TestEvidenceConsumption:
             Breakpoint('1', 450, 500, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        r1, r2 = mock_read_pair(
-            MockRead(
-                query_name='t1',
-                reference_id=0,
-                reference_name='1',
-                reference_start=40,
-                cigar=[(CIGAR.EQ, 60), (CIGAR.S, 40)],
-                query_sequence='A' * 100,
-            ),
-            MockRead(
-                query_name='t1',
-                reference_id=0,
-                reference_name='1',
-                reference_start=460,
-                cigar=[(CIGAR.S, 40), (CIGAR.EQ, 60)],
-                query_sequence='A' * 100,
-            ),
-        )
+
         contig = mock.Mock(
             **{
                 'seq': '',
                 'complexity.return_value': 1,
-                'alignments': [call_paired_read_event(r1, r2)],
+                'alignments': [
+                    call_paired_read_event(
+                        MockRead(
+                            query_name='assembly1',
+                            reference_name='1',
+                            reference_start=40,
+                            cigarstring='60=40S',
+                            query_sequence='A' * 100,
+                        ),
+                        MockRead(
+                            query_name='assembly1',
+                            reference_name='1',
+                            reference_start=460,
+                            cigarstring='40S60=',
+                            query_sequence='A' * 100,
+                        ),
+                    )
+                ],
             }
         )
         contig.input_reads = {
-            MockRead(query_name='t1', reference_start=100, cigar=[(CIGAR.EQ, 20), (CIGAR.S, 80)])
+            MockRead(query_name='t0', reference_name='1', reference_start=100, cigarstring='20=80S')
         }
         evidence.contigs.append(contig)
 
-        evidence.split_reads[0].add(
-            MockRead(query_name='t1', reference_start=100, cigar=[(CIGAR.EQ, 20), (CIGAR.S, 80)])
+        split_read1, split_read2 = mock_read_pair(
+            MockRead(
+                query_name='t1', reference_name='1', reference_start=100, cigarstring='20=80S'
+            ),
+            MockRead(
+                query_name='t1',
+                reference_name='1',
+                reference_start=500,
+                cigarstring='50S50=',
+                query_sequence='A' * 100,
+            ),
         )
-        evidence.split_reads[1].add(
-            MockRead(query_name='t1', reference_start=500, cigar=[(CIGAR.S, 50), (CIGAR.EQ, 50)])
-        )
+
+        evidence.split_reads[0].add(split_read1)
+        evidence.split_reads[1].add(split_read2)
         evidence.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     query_name='t4',
-                    reference_id=0,
+                    reference_name='1',
                     reference_start=10,
-                    reference_end=40,
-                    is_reverse=False,
-                    query_alignment_length=30,
+                    cigarstring='30M',
                 ),
                 MockRead(
                     query_name='t4',
-                    reference_id=0,
+                    reference_name='1',
+                    cigarstring='35M',
                     reference_start=505,
-                    reference_end=540,
-                    is_reverse=True,
-                    query_alignment_length=35,
                 ),
             )
         )
@@ -561,45 +688,48 @@ class TestEvidenceConsumption:
             mock_read_pair(
                 MockRead(
                     query_name='t3',
-                    reference_id=0,
+                    reference_name='1',
                     reference_start=49,
-                    reference_end=90,
-                    is_reverse=False,
-                    query_alignment_length=41,
+                    cigarstring='41M',
                 ),
                 MockRead(
                     query_name='t3',
-                    reference_id=0,
+                    reference_name='1',
                     reference_start=805,
-                    reference_end=840,
-                    is_reverse=True,
-                    query_alignment_length=35,
+                    cigarstring='35M',
                 ),
             )
         )
 
         events = call.call_events(evidence)
-        for ev in events:
-            print(ev, ev.event_type, ev.call_method)
         assert len(events) == 4
+
         assert events[0].call_method == 'contig'
         assert events[0].break1.start == 100
         assert events[0].break2.start == 481
         assert events[0].event_type == 'deletion'
+        assert 't0' in {r.query_name for r in events[0].support()}
+        assert 't4' in {r.query_name for r in events[0].support()}
+
         assert events[1].call_method == 'split reads'
         assert events[1].break1.start == 120
         assert events[1].break2.start == 501
         assert events[1].event_type == 'deletion'
+        assert 't1' in {r.query_name for r in events[1].support()}
+
         assert events[2].call_method == 'flanking reads'
         assert events[2].break1.start == 90
         assert events[2].break1.end == 299
         assert events[2].break2.start == 591
         assert events[2].break2.end == 806
         assert events[2].event_type == 'deletion'
+        assert 't3' in {r.query_name for r in events[2].support()}
+
         assert events[3].call_method == 'split reads'
         assert events[3].break1.start == 120
         assert events[3].break2.start == 501
         assert events[3].event_type == 'insertion'
+        assert 't1' in {r.query_name for r in events[3].support()}
 
     def test_call_contig_only(self):
         # event should only be 100L+, 501R+ deletion
@@ -608,34 +738,37 @@ class TestEvidenceConsumption:
             Breakpoint('1', 450, 500, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        r1, r2 = mock_read_pair(
-            MockRead(
-                query_name='t1',
-                reference_id=0,
-                reference_name='1',
-                reference_start=40,
-                cigar=[(CIGAR.EQ, 60), (CIGAR.S, 40)],
-                query_sequence='A' * 100,
-                query_alignment_length=100,
-            ),
-            MockRead(
-                query_name='t1',
-                reference_id=0,
-                reference_name='1',
-                reference_start=480,
-                cigar=[(CIGAR.S, 40), (CIGAR.EQ, 60)],
-                query_sequence='A' * 100,
-                query_alignment_length=100,
-            ),
+
+        contig = mock.Mock(
+            **{
+                'seq': '',
+                'complexity.return_value': 1,
+                'alignments': [
+                    call_paired_read_event(
+                        MockRead(
+                            query_name='t1',
+                            reference_name='1',
+                            reference_start=40,
+                            cigarstring='60=40S',
+                            query_sequence='A' * 100,
+                        ),
+                        MockRead(
+                            query_name='t1',
+                            reference_name='1',
+                            reference_start=480,
+                            cigarstring='40S60=',
+                            query_sequence='A' * 100,
+                        ),
+                    )
+                ],
+            }
         )
-        bpp = call_paired_read_event(r1, r2)
-        contig = mock.Mock(**{'seq': '', 'complexity.return_value': 1, 'alignments': [bpp]})
         contig.input_reads = {
             MockRead(
                 query_name='t1',
                 reference_start=100,
                 reference_name='1',
-                cigar=[(CIGAR.EQ, 20), (CIGAR.S, 80)],
+                cigarstring='20=80S',
             )
         }
         evidence.contigs.append(contig)
@@ -645,7 +778,7 @@ class TestEvidenceConsumption:
                 query_name='t1',
                 reference_name='1',
                 reference_start=80,
-                cigar=[(CIGAR.EQ, 20), (CIGAR.S, 80)],
+                cigarstring='20=80S',
             )
         )
         evidence.split_reads[1].add(
@@ -653,7 +786,7 @@ class TestEvidenceConsumption:
                 query_name='t1',
                 reference_name='1',
                 reference_start=500,
-                cigar=[(CIGAR.S, 50), (CIGAR.EQ, 50)],
+                cigarstring='50S50=',
             )
         )
         evidence.split_reads[0].add(
@@ -661,7 +794,7 @@ class TestEvidenceConsumption:
                 query_name='t2',
                 reference_name='1',
                 reference_start=40,
-                cigar=[(CIGAR.EQ, 50), (CIGAR.S, 50)],
+                cigarstring='50=50S',
             )
         )
         evidence.flanking_pairs.add(
@@ -669,20 +802,16 @@ class TestEvidenceConsumption:
                 MockRead(
                     query_name='t3',
                     reference_name='1',
-                    reference_id=0,
                     reference_start=49,
-                    reference_end=90,
                     is_reverse=False,
-                    query_alignment_length=100,
+                    cigarstring='41M',
                 ),
                 MockRead(
                     query_name='t3',
                     reference_name='1',
-                    reference_id=0,
                     reference_start=505,
-                    reference_end=550,
                     is_reverse=True,
-                    query_alignment_length=100,
+                    cigarstring='100M',
                 ),
             )
         )
@@ -702,29 +831,28 @@ class TestEvidenceConsumption:
             Breakpoint('1', 450, 500, orient=ORIENT.RIGHT),
             opposing_strands=False,
         )
-        r1, r2 = mock_read_pair(
-            MockRead(
-                query_name='t1',
-                reference_id=0,
-                reference_name='1',
-                reference_start=40,
-                cigar=[(CIGAR.EQ, 60), (CIGAR.S, 40)],
-                query_sequence='A' * 100,
-            ),
-            MockRead(
-                query_name='t1',
-                reference_id=0,
-                reference_name='1',
-                reference_start=480,
-                cigar=[(CIGAR.S, 40), (CIGAR.EQ, 60)],
-                query_sequence='A' * 100,
-            ),
-        )
         contig = mock.Mock(
             **{
                 'seq': '',
                 'complexity.return_value': 1,
-                'alignments': [call_paired_read_event(r1, r2)],
+                'alignments': [
+                    call_paired_read_event(
+                        MockRead(
+                            query_name='t1',
+                            reference_name='1',
+                            reference_start=40,
+                            cigarstring='60=40S',
+                            query_sequence='A' * 100,
+                        ),
+                        MockRead(
+                            query_name='t1',
+                            reference_name='1',
+                            reference_start=480,
+                            cigarstring='40S60=',
+                            query_sequence='A' * 100,
+                        ),
+                    )
+                ],
             }
         )
         contig.input_reads = {
@@ -732,46 +860,45 @@ class TestEvidenceConsumption:
                 query_name='t1',
                 reference_name='1',
                 reference_start=100,
-                cigar=[(CIGAR.EQ, 20), (CIGAR.S, 80)],
+                cigarstring='20=80S',
             )
         }
         evidence.contigs.append(contig)
 
-        evidence.split_reads[0].add(
+        split_read1, split_read2 = mock_read_pair(
             MockRead(
-                query_name='t1',
+                query_name='t2',
                 reference_start=100,
                 reference_name='1',
-                cigar=[(CIGAR.EQ, 20), (CIGAR.S, 80)],
-            )
-        )
-        evidence.split_reads[1].add(
+                cigarstring='20=80S',
+                query_sequence='C' * 100,
+            ),
             MockRead(
-                query_name='t1',
+                query_name='t2',
                 reference_start=520,
                 reference_name='1',
-                cigar=[(CIGAR.S, 50), (CIGAR.EQ, 50)],
-            )
+                cigarstring='50S50=',
+                query_sequence='A' * 100,
+            ),
         )
+
+        evidence.split_reads[0].add(split_read1)
+        evidence.split_reads[1].add(split_read2)
         evidence.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     query_name='t3',
-                    reference_id=0,
                     reference_start=49,
                     reference_name='1',
-                    reference_end=90,
                     is_reverse=False,
-                    query_alignment_length=100,
+                    cigarstring='41M',
                 ),
                 MockRead(
                     query_name='t3',
-                    reference_id=0,
                     reference_start=505,
                     reference_name='1',
-                    reference_end=550,
                     is_reverse=True,
-                    query_alignment_length=100,
+                    cigarstring='100M',
                 ),
             )
         )
@@ -782,9 +909,11 @@ class TestEvidenceConsumption:
         assert events[0].break1.start == 100
         assert events[0].break2.start == 501
         assert events[0].call_method == 'contig'
+
         assert events[1].call_method == 'split reads'
         assert events[1].break1.start == 120
         assert events[1].break2.start == 521
+
         assert events[2].event_type == 'insertion'
         assert events[2].call_method == 'split reads'
         assert events[2].break1.start == 120
@@ -797,28 +926,22 @@ class TestEvidenceConsumption:
             opposing_strands=False,
         )
         evidence.split_reads[0].add(
-            MockRead(query_name='t1', reference_start=140, cigar=[(CIGAR.EQ, 30), (CIGAR.S, 70)])
+            MockRead(query_name='t1', reference_start=140, cigarstring='30=70S')
         )
         evidence.split_reads[1].add(
-            MockRead(query_name='t1', reference_start=870, cigar=[(CIGAR.S, 50), (CIGAR.EQ, 50)])
+            MockRead(query_name='t1', reference_start=870, cigarstring='50S50=')
         )
         evidence.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     query_name='t3',
-                    reference_id=0,
                     reference_start=42,
-                    reference_end=140,
-                    is_reverse=False,
-                    query_alignment_length=100,
+                    cigarstring='100M',
                 ),
                 MockRead(
                     query_name='t3',
-                    reference_id=0,
                     reference_start=885,
-                    reference_end=905,
-                    is_reverse=True,
-                    query_alignment_length=100,
+                    cigarstring='100M',
                 ),
             )
         )
@@ -844,19 +967,15 @@ class TestEvidenceConsumption:
             mock_read_pair(
                 MockRead(
                     query_name='t1',
-                    reference_id=0,
+                    reference_name='1',
                     reference_start=42,
-                    reference_end=140,
-                    is_reverse=False,
-                    query_alignment_length=98,
+                    cigarstring='98M',
                 ),
                 MockRead(
                     query_name='t1',
-                    reference_id=0,
+                    reference_name='1',
                     reference_start=885,
-                    reference_end=905,
-                    is_reverse=True,
-                    query_alignment_length=20,
+                    cigarstring='20M',
                 ),
             )
         )
@@ -910,7 +1029,7 @@ def inversion_evidence():
             'validate.min_flanking_pairs_resolution': 1,
             'validate.min_linking_split_reads': 1,
             'validate.min_spanning_reads_resolution': 3,
-            'validate. min_call_complexity': 0,
+            'validate.min_call_complexity': 0,
         },
     )
 
@@ -922,10 +1041,10 @@ class TestCallBySupportingReads:
 
     def test_call_no_duplication_by_split_reads(self, duplication_ev, inversion_evidence):
         duplication_ev.split_reads[0].add(
-            MockRead(query_name='t1', reference_start=30, cigar=[(CIGAR.EQ, 20), (CIGAR.S, 20)])
+            MockRead(query_name='t1', reference_start=30, cigarstring='20=20S')
         )
         duplication_ev.split_reads[1].add(
-            MockRead(query_name='t1', reference_start=90, cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)])
+            MockRead(query_name='t1', reference_start=90, cigarstring='20S20=')
         )
 
         bpps = call._call_by_split_reads(inversion_evidence, SVTYPE.DUP)
@@ -936,7 +1055,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t1',
                 reference_start=100,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='A' * 40,
             )
         )
@@ -944,7 +1063,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t1',
                 reference_start=500,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='G' * 40,
             )
         )
@@ -952,7 +1071,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t2',
                 reference_start=100,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='C' * 40,
             )
         )
@@ -960,7 +1079,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t2',
                 reference_start=500,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='A' * 40,
             )
         )
@@ -979,7 +1098,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t1',
                 reference_start=100,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='A' * 40,
             )
         )
@@ -987,7 +1106,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t1',
                 reference_start=500,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='N' * 40,
             )
         )
@@ -1006,7 +1125,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t1',
                 reference_start=100,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='TCGGCTCCCGTACTTGTGTATAAGGGGCTTCTGATGTTAT',
             )
         )
@@ -1014,7 +1133,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t1',
                 reference_start=500,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='ATAACATCAGAAGCCCCTTATACACAAGTACGGGAGCCGA',
                 is_reverse=True,
             )
@@ -1033,7 +1152,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t1',
                 reference_start=100,
-                cigar=[(CIGAR.S, 22), (CIGAR.EQ, 18)],
+                cigarstring='22S18=',
                 query_sequence='TCGGCTCCCGTACTTGTGTATAAGGGGCTTCTGATGTTAT',
             )
         )
@@ -1041,7 +1160,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t1',
                 reference_start=500,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='ATAACATCAGAAGCCCCTTATACACAAGTACGGGAGCCGA',
                 is_reverse=True,
             )
@@ -1060,7 +1179,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t1',
                 reference_start=100,
-                cigar=[(CIGAR.S, 18), (CIGAR.EQ, 22)],
+                cigarstring='18S22=',
                 query_sequence='TCGGCTCCCGTACTTGTGTATAAGGGGCTTCTGATGTTAT',
             )
         )
@@ -1068,7 +1187,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t1',
                 reference_start=500,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='ATAACATCAGAAGCCCCTTATACACAAGTACGGGAGCCGA',
                 is_reverse=True,
             )
@@ -1085,30 +1204,57 @@ class TestCallBySupportingReads:
     def test_both_by_flanking_pairs(self, inversion_evidence):
         inversion_evidence.flanking_pairs.add(
             mock_read_pair(
-                MockRead(query_name='t1', reference_id=0, reference_start=150, reference_end=150),
-                MockRead(query_name='t1', reference_id=0, reference_start=500, reference_end=520),
+                MockRead(
+                    query_name='t1',
+                    reference_name='1',
+                    reference_start=150,
+                    cigarstring='0M',
+                    is_reverse=False,
+                ),
+                MockRead(
+                    query_name='t1',
+                    reference_name='1',
+                    reference_start=500,
+                    cigarstring='20M',
+                    is_reverse=False,
+                ),
+                proper_pair=False,
             )
         )
         inversion_evidence.flanking_pairs.add(
             mock_read_pair(
-                MockRead(query_name='t2', reference_id=0, reference_start=120, reference_end=140),
-                MockRead(query_name='t2', reference_id=0, reference_start=520, reference_end=520),
+                MockRead(
+                    query_name='t2',
+                    reference_name='1',
+                    reference_start=120,
+                    cigarstring='20M',
+                    is_reverse=False,
+                ),
+                MockRead(
+                    query_name='t2',
+                    reference_name='1',
+                    reference_start=520,
+                    cigarstring='0M',
+                    is_reverse=False,
+                ),
+                proper_pair=False,
             )
         )
         bpp = call._call_by_flanking_pairs(inversion_evidence, SVTYPE.INV)
         # 120-149  ..... 500-519
         # max frag = 150 - 80 = 70
-        assert bpp.break1.start == 42
-        assert bpp.break1.end == 120
-        assert bpp.break2.start == 412  # 70 - 21 = 49
-        assert bpp.break2.end == 500
+        print(bpp)
+        assert bpp.break1.orient == ORIENT.RIGHT
+        assert bpp.break2.orient == ORIENT.RIGHT
+        assert (bpp.break1.start, bpp.break1.end) == (42, 121)
+        assert (bpp.break2.start, bpp.break2.end) == (412, 501)
 
     def test_by_split_reads_multiple_calls(self, inversion_evidence):
         inversion_evidence.split_reads[0].add(
             MockRead(
                 query_name='t1',
                 reference_start=100,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='A' * 40,
             )
         )
@@ -1116,7 +1262,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t1',
                 reference_start=500,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='T' * 40,
             )
         )
@@ -1124,7 +1270,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t2',
                 reference_start=110,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='T' * 40,
             )
         )
@@ -1132,7 +1278,7 @@ class TestCallBySupportingReads:
             MockRead(
                 query_name='t2',
                 reference_start=520,
-                cigar=[(CIGAR.S, 20), (CIGAR.EQ, 20)],
+                cigarstring='20S20=',
                 query_sequence='A' * 40,
             )
         )
@@ -1160,64 +1306,73 @@ class TestCallBySupportingReads:
         evidence.split_reads[0].add(
             MockRead(
                 query_name='test1',
-                cigar=[(CIGAR.S, 110), (CIGAR.EQ, 40)],
+                cigarstring='110S40=',
                 reference_start=1114,
-                reference_end=1150,
+                reference_name='reference3',
             )
         )
         evidence.split_reads[0].add(
             MockRead(
+                reference_name='reference3',
                 query_name='test2',
-                cigar=[(CIGAR.EQ, 30), (CIGAR.S, 120)],
+                cigarstring='30=120S',
                 reference_start=1108,
-                reference_end=1115,
             )
         )
-        evidence.split_reads[0].add(
-            MockRead(
-                query_name='test3',
-                cigar=[(CIGAR.S, 30), (CIGAR.EQ, 120)],
-                reference_start=1114,
-                reference_end=1154,
-                tags=[(PYSAM_READ_FLAGS.TARGETED_ALIGNMENT, 1)],
-            )
+        read = MockRead(
+            reference_name='reference3',
+            query_name='test3',
+            cigarstring='30S120=',
+            reference_start=1114,
         )
+        read.set_tag(PYSAM_READ_FLAGS.TARGETED_ALIGNMENT, 1)
+        evidence.split_reads[0].add(read)
         evidence.split_reads[1].add(
             MockRead(
-                query_name='test4', cigar=[(CIGAR.EQ, 30), (CIGAR.S, 120)], reference_start=2187
-            )
-        )
-        evidence.split_reads[1].add(
-            MockRead(
-                query_name='test5', cigar=[(CIGAR.S, 30), (CIGAR.EQ, 120)], reference_start=2187
-            )
-        )
-        evidence.split_reads[1].add(
-            MockRead(
-                query_name='test1',
-                cigar=[(CIGAR.S, 30), (CIGAR.EQ, 120)],
+                reference_name='reference3',
+                query_name='test4',
+                cigarstring='30=120S',
                 reference_start=2187,
-                reference_end=2307,
-                tags=[(PYSAM_READ_FLAGS.TARGETED_ALIGNMENT, 1)],
             )
         )
+        evidence.split_reads[1].add(
+            MockRead(
+                reference_name='reference3',
+                query_name='test5',
+                cigarstring='30S120=',
+                reference_start=2187,
+            )
+        )
+        read = MockRead(
+            reference_name='reference3',
+            query_name='test1',
+            cigarstring='30S120=',
+            reference_start=2187,
+        )
+        read.set_tag(PYSAM_READ_FLAGS.TARGETED_ALIGNMENT, 1)
+        evidence.split_reads[1].add(read)
 
         evidence.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     query_name='t1',
-                    reference_id=3,
+                    reference_name='reference3',
                     reference_start=1200,
-                    reference_end=1250,
+                    is_reverse=True,
+                    cigarstring='50M',
+                ),
+                MockRead(
+                    reference_name='reference3',
+                    reference_start=2250,
+                    cigarstring='50M',
                     is_reverse=True,
                 ),
-                MockRead(reference_id=3, reference_start=2250, reference_end=2300, is_reverse=True),
             )
         )
 
         events = call._call_by_split_reads(evidence, event_type=SVTYPE.INV)
         for ev in events:
-            print(ev, ev.event_type, ev.call_method)
+            print(ev, ev.event_type, ev.call_method, [r.query_name for r in ev.support()])
         assert len(events) == 1
         event = events[0]
         assert len(event.flanking_pairs) == 1
@@ -1268,34 +1423,24 @@ class TestCallByFlankingReadsGenome:
         left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
-                    reference_start=19,
-                    reference_end=60,
-                    next_reference_start=599,
-                    query_alignment_length=25,
+                    reference_start=60 - 25,
+                    cigarstring='25M',
                 ),
                 MockRead(
                     reference_start=599,
-                    reference_end=650,
-                    next_reference_start=19,
-                    query_alignment_length=25,
-                    is_reverse=True,
+                    cigarstring='25M',
                 ),
             )
         )
         left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
-                    reference_start=39,
-                    reference_end=80,
-                    next_reference_start=649,
-                    query_alignment_length=25,
+                    reference_start=80 - 25,
+                    cigarstring='25M',
                 ),
                 MockRead(
                     reference_start=649,
-                    reference_end=675,
-                    next_reference_start=39,
-                    query_alignment_length=25,
-                    is_reverse=True,
+                    cigarstring='25M',
                 ),
             )
         )
@@ -1303,62 +1448,48 @@ class TestCallByFlankingReadsGenome:
         left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
-                    reference_start=39,
-                    reference_end=50,
-                    next_reference_start=91,
-                    query_alignment_length=25,
+                    reference_start=25,
+                    cigarstring='25M',
                 ),
                 MockRead(
                     reference_start=91,
-                    reference_end=110,
-                    next_reference_start=39,
-                    query_alignment_length=25,
-                    is_reverse=True,
+                    cigarstring='25M',
                 ),
             )
         )
         bpp = call._call_by_flanking_pairs(left_right_ev, SVTYPE.DEL)
-        print(bpp, bpp.flanking_pairs)
+        print(bpp, len(bpp.flanking_pairs))
         assert bpp.break1.start == 80
-        assert bpp.break1.end == 80 + 125 - 45
-        assert bpp.break2.start == 600 - 125 + 75
+        assert bpp.break1.end == 80 + 125 - 45  # 160
+        assert bpp.break2.start == 600 - 125 + 75  # 550
         assert bpp.break2.end == 600
 
     def test_intrachromosomal_lr_coverage_overlaps_range(self, left_right_ev):
         # this test is for ensuring that if a theoretical window calculated for the
         # first breakpoint overlaps the actual coverage for the second breakpoint (or the reverse)
         # that we adjust the theoretical window accordingly
+        left_right_ev.median_fragment_size = 150
         left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=21,
-                    reference_end=60,
-                    next_reference_start=80,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
                 MockRead(
                     reference_start=80,
-                    reference_end=120,
-                    next_reference_start=21,
-                    query_alignment_length=25,
-                    is_reverse=True,
+                    cigarstring='25M',
                 ),
             )
         )
         left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
-                    reference_start=41,
-                    reference_end=80,
-                    next_reference_start=110,
-                    query_alignment_length=25,
+                    reference_start=80 - 25,
+                    cigarstring='25M',
                 ),
                 MockRead(
                     reference_start=110,
-                    reference_end=140,
-                    next_reference_start=41,
-                    query_alignment_length=25,
-                    is_reverse=True,
+                    cigarstring='25M',
                 ),
             )
         )
@@ -1367,16 +1498,11 @@ class TestCallByFlankingReadsGenome:
             mock_read_pair(
                 MockRead(
                     reference_start=39,
-                    reference_end=80,
-                    next_reference_start=649,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
                 MockRead(
                     reference_start=649,
-                    reference_end=675,
-                    next_reference_start=39,
-                    query_alignment_length=25,
-                    is_reverse=True,
+                    cigarstring='25M',
                 ),
             )
         )
@@ -1387,19 +1513,19 @@ class TestCallByFlankingReadsGenome:
         assert break2.end == 81
 
     def test_intrachromosomal_flanking_coverage_overlap_error(self, left_right_ev):
+        """
+        Cannot call with the flanking reads together since their coverage intervals overlap at the wrong ends
+        """
+        left_right_ev.config['validate.min_flanking_pairs_resolution'] = 2
         left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=19,
-                    reference_end=60,
-                    next_reference_start=599,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
                 MockRead(
                     reference_start=599,
-                    reference_end=650,
-                    next_reference_start=19,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
             )
         )
@@ -1407,35 +1533,35 @@ class TestCallByFlankingReadsGenome:
             mock_read_pair(
                 MockRead(
                     reference_start=620,
-                    reference_end=80,
-                    next_reference_start=780,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
                 MockRead(
                     reference_start=780,
-                    reference_end=820,
-                    next_reference_start=620,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
             )
         )
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError) as e_info:
             call._call_by_flanking_pairs(left_right_ev, SVTYPE.DEL)
+        assert (
+            e_info.value.args[0]
+            == 'insufficient flanking pairs (1) to call deletion by flanking reads'
+        )
 
     def test_coverage_larger_than_max_expected_variance_error(self, left_right_ev):
+        """
+        Cannot group the reads to make a single call so the flanking call is below the acceptable resolution
+        """
+        left_right_ev.config['validate.min_flanking_pairs_resolution'] = 2
         left_right_ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
                     reference_start=19,
-                    reference_end=60,
-                    next_reference_start=599,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
                 MockRead(
                     reference_start=599,
-                    reference_end=650,
-                    next_reference_start=19,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
             )
         )
@@ -1443,20 +1569,20 @@ class TestCallByFlankingReadsGenome:
             mock_read_pair(
                 MockRead(
                     reference_start=301,
-                    reference_end=350,
-                    next_reference_start=780,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
                 MockRead(
                     reference_start=780,
-                    reference_end=820,
-                    next_reference_start=301,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
             )
         )
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError) as e_info:
             call._call_by_flanking_pairs(left_right_ev, SVTYPE.DEL)
+        assert (
+            e_info.value.args[0]
+            == 'insufficient flanking pairs (1) to call deletion by flanking reads'
+        )
 
     def test_close_to_zero(self, left_right_ev):
         # this test is for ensuring that if a theoretical window calculated for the
@@ -1479,33 +1605,23 @@ class TestCallByFlankingReadsGenome:
         ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
-                    reference_start=19,
-                    reference_end=60,
-                    next_reference_start=149,
-                    query_alignment_length=25,
+                    reference_name='fake', reference_start=19, cigarstring='25M', is_reverse=True
                 ),
                 MockRead(
-                    reference_start=149,
-                    reference_end=150,
-                    next_reference_start=19,
-                    query_alignment_length=25,
+                    reference_name='fake', reference_start=149, cigarstring='25M', is_reverse=True
                 ),
+                proper_pair=False,
             )
         )
         ev.flanking_pairs.add(
             mock_read_pair(
                 MockRead(
-                    reference_start=39,
-                    reference_end=80,
-                    next_reference_start=199,
-                    query_alignment_length=25,
+                    reference_name='fake', reference_start=39, cigarstring='25M', is_reverse=True
                 ),
                 MockRead(
-                    reference_start=199,
-                    reference_end=200,
-                    next_reference_start=39,
-                    query_alignment_length=25,
+                    reference_name='fake', reference_start=199, cigarstring='25M', is_reverse=True
                 ),
+                proper_pair=False,
             )
         )
         break1, break2 = call._call_by_flanking_pairs(ev, SVTYPE.INV)
@@ -1531,15 +1647,11 @@ class TestCallByFlankingReadsGenome:
             mock_read_pair(
                 MockRead(
                     reference_start=76186159,
-                    reference_end=76186309,
-                    next_reference_start=76186000,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
                 MockRead(
                     reference_start=76186000,
-                    reference_end=76186150,
-                    next_reference_start=76186159,
-                    query_alignment_length=25,
+                    cigarstring='25M',
                 ),
             )
         )
@@ -1597,18 +1709,28 @@ class TestCallByFlankingReadsTranscriptome:
         # now add the flanking pairs
         pair = mock_read_pair(
             MockRead(
-                'name', '1', 951, 1051, is_reverse=False, query_alignment_length=50, is_read1=False
+                query_name='name',
+                reference_name='1',
+                reference_start=1001,
+                is_reverse=False,
+                cigarstring='50M',
             ),
-            MockRead('name', '1', 2299, 2399, is_reverse=True, query_alignment_length=50),
+            MockRead(
+                query_name='name',
+                reference_name='1',
+                reference_start=2299,
+                is_reverse=True,
+                cigarstring='50M',
+            ),
+            proper_pair=False,
+            reverse_order=True,
         )
         print(read_pair_type(pair[0]))
         # following help in debugging the mockup
         assert not pair[0].is_reverse
         assert not pair[0].is_read1
-        assert pair[0].is_read2
         assert pair[1].is_reverse
         assert pair[1].is_read1
-        assert not pair[1].is_read2
         assert sequenced_strand(pair[0], 2) == STRAND.POS
         assert evidence.decide_sequenced_strand([pair[0]]) == STRAND.POS
         assert sequenced_strand(pair[1], 2) == STRAND.POS

--- a/tests/test_mavis/validate/test_evidence.py
+++ b/tests/test_mavis/validate/test_evidence.py
@@ -11,8 +11,8 @@ from mavis.constants import ORIENT, STRAND
 from mavis.interval import Interval
 from mavis.validate.base import Evidence
 from mavis.validate.evidence import GenomeEvidence, TranscriptomeEvidence
-from mavis_config import DEFAULTS
 from mavis.validate.gather import collect_flanking_pair
+from mavis_config import DEFAULTS
 
 from ..mock import MockBamFileHandle, MockObject, MockRead, mock_read_pair
 
@@ -203,8 +203,18 @@ class TestComputeFragmentSizes:
     def test_genomic_vs_trans_no_annotations(self, genomic_evidence, read_length, trans_evidence):
         # should be identical
         read, mate = mock_read_pair(
-            MockRead('name', '1', 1051 - read_length + 1, 1051, is_reverse=False),
-            MockRead('name', '1', 2300, 2300 + read_length - 1, is_reverse=True),
+            MockRead(
+                query_name='name',
+                reference_name='1',
+                reference_start=1051 - read_length + 1,
+                cigarstring=str(read_length) + 'M',
+            ),
+            MockRead(
+                query_name='name',
+                reference_name='1',
+                reference_start=2300,
+                cigarstring=str(read_length) + 'M',
+            ),
         )
         assert genomic_evidence.compute_fragment_size(
             read, mate
@@ -212,8 +222,18 @@ class TestComputeFragmentSizes:
 
     def test_reverse_reads(self, genomic_evidence, trans_evidence):
         read, mate = mock_read_pair(
-            MockRead('name', '1', 1001, 1100, is_reverse=False),
-            MockRead('name', '1', 2201, 2301, is_reverse=True),
+            MockRead(
+                query_name='name',
+                reference_name='1',
+                reference_start=1001,
+                cigarstring='99M',
+            ),
+            MockRead(
+                query_name='name',
+                reference_name='1',
+                reference_start=2300,
+                cigarstring='100M',
+            ),
         )
         assert genomic_evidence.compute_fragment_size(read, mate) == Interval(1300)
         assert genomic_evidence.compute_fragment_size(mate, read) == Interval(1300)
@@ -614,8 +634,20 @@ def flanking_ge(read_length):
 class TestGenomeEvidenceAddReads:
     def test_collect_flanking_pair_error_unmapped_read(self, flanking_ge):
         read, mate = mock_read_pair(
-            MockRead('test', 0, 900, 1000, is_reverse=False),
-            MockRead('test', 0, 6000, 6099, is_reverse=True),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=900,
+                cigarstring='100M',
+                is_reverse=False,
+            ),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=6000,
+                cigarstring=str(6099 - 6000) + 'M',
+                is_reverse=True,
+            ),
         )
         read.is_unmapped = True
         with pytest.raises(ValueError):
@@ -623,8 +655,20 @@ class TestGenomeEvidenceAddReads:
 
     def test_collect_flanking_pair_error_mate_unmapped(self, flanking_ge):
         read, mate = mock_read_pair(
-            MockRead('test', 0, 900, 1000, is_reverse=False),
-            MockRead('test', 0, 6000, 6099, is_reverse=True),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=900,
+                cigarstring=str(1000 - 900) + 'M',
+                is_reverse=False,
+            ),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=6000,
+                cigarstring=str(6099 - 6000) + 'M',
+                is_reverse=True,
+            ),
         )
         mate.is_unmapped = True
         with pytest.raises(ValueError):
@@ -632,16 +676,41 @@ class TestGenomeEvidenceAddReads:
 
     def test_collect_flanking_pair_error_query_names_dont_match(self, flanking_ge):
         read, mate = mock_read_pair(
-            MockRead('test1', 0, 900, 1000, is_reverse=False),
-            MockRead('test', 0, 6000, 6099, is_reverse=True),
+            MockRead(
+                query_name='test1',
+                reference_name='1',
+                reference_start=900,
+                cigarstring=str(1000 - 900) + 'M',
+                is_reverse=False,
+            ),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=6000,
+                cigarstring=str(6099 - 6000) + 'M',
+                is_reverse=True,
+            ),
         )
         with pytest.raises(ValueError):
             collect_flanking_pair(flanking_ge, read, mate)
 
     def test_collect_flanking_pair_error_template_lengths_dont_match(self, flanking_ge):
         read, mate = mock_read_pair(
-            MockRead('test', 0, 900, 1000, is_reverse=False, template_length=50),
-            MockRead('test', 0, 6000, 6099, is_reverse=True),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=900,
+                cigarstring=str(1000 - 900) + 'M',
+                is_reverse=False,
+                template_length=50,
+            ),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=6000,
+                cigarstring=str(6099 - 6000) + 'M',
+                is_reverse=True,
+            ),
         )
         mate.template_length = 55
         with pytest.raises(ValueError):
@@ -649,23 +718,59 @@ class TestGenomeEvidenceAddReads:
 
     def test_collect_flanking_pair_read_low_mq(self, flanking_ge):
         read, mate = mock_read_pair(
-            MockRead('test', 0, 900, 1000, is_reverse=False),
-            MockRead('test', 0, 6000, 6099, is_reverse=True),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=900,
+                cigarstring=str(1000 - 900) + 'M',
+                is_reverse=False,
+            ),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=6000,
+                cigarstring=str(6099 - 6000) + 'M',
+                is_reverse=True,
+            ),
         )
         read.mapping_quality = 0
         assert not collect_flanking_pair(flanking_ge, read, mate)
 
     def test_collect_flanking_pair_mate_low_mq(self, flanking_ge):
         read, mate = mock_read_pair(
-            MockRead('test', 0, 900, 1000, is_reverse=False),
-            MockRead('test', 0, 6000, 6099, is_reverse=True),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=900,
+                cigarstring=str(1000 - 900) + 'M',
+                is_reverse=False,
+            ),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=6000,
+                cigarstring=str(6099 - 6000) + 'M',
+                is_reverse=True,
+            ),
         )
         mate.mapping_quality = 0
         assert not collect_flanking_pair(flanking_ge, read, mate)
 
     def test_collect_flanking_pair_interchromosomal(self, flanking_ge):
         read, mate = mock_read_pair(
-            MockRead('test', 1, 900, 1000, is_reverse=False),
-            MockRead('test', 0, 6000, 6099, is_reverse=True),
+            MockRead(
+                query_name='test',
+                reference_name='2',
+                reference_start=900,
+                cigarstring=str(1000 - 900) + 'M',
+                is_reverse=False,
+            ),
+            MockRead(
+                query_name='test',
+                reference_name='1',
+                reference_start=6000,
+                cigarstring=str(6099 - 6000) + 'M',
+                is_reverse=True,
+            ),
         )
         assert not collect_flanking_pair(flanking_ge, read, mate)

--- a/tests/test_mavis/validate/test_validate2.py
+++ b/tests/test_mavis/validate/test_validate2.py
@@ -7,13 +7,21 @@ from mavis.breakpoint import Breakpoint
 from mavis.constants import NA_MAPPING_QUALITY, ORIENT, PYSAM_READ_FLAGS
 from mavis.validate.base import Evidence
 from mavis.validate.evidence import GenomeEvidence
-from mavis.validate.gather import collect_split_read, collect_flanking_pair, load_evidence
+from mavis.validate.gather import collect_flanking_pair, collect_split_read, load_evidence
 from mavis_config import DEFAULTS
 
 from ...util import get_data, long_running_test
-from ..mock import MockLongString, MockObject, MockRead, mock_read_pair
+from ..mock import MockLongString, MockObject, MockRead, flags_from_number, mock_read_pair
 
 REFERENCE_GENOME = None
+
+
+class MockBamCache(BamCache):
+    def get_read_reference_name(self, read):
+        if isinstance(read, MockRead):
+            return read.reference_name
+        else:
+            return BamCache.get_read_reference_name(self, read)
 
 
 def setUpModule():
@@ -25,9 +33,9 @@ def setUpModule():
     ):
         raise AssertionError('fake genome file does not have the expected contents')
     global BAM_CACHE
-    BAM_CACHE = BamCache(get_data('mini_mock_reads_for_events.sorted.bam'))
+    BAM_CACHE = MockBamCache(get_data('mini_mock_reads_for_events.sorted.bam'))
     global FULL_BAM_CACHE
-    FULL_BAM_CACHE = BamCache(get_data('mock_reads_for_events.sorted.bam'))
+    FULL_BAM_CACHE = MockBamCache(get_data('mock_reads_for_events.sorted.bam'))
     global READS
     READS = {}
     for read in BAM_CACHE.fetch('reference3', 1, 8000):

--- a/tests/test_mavis/validate/test_validate2.py
+++ b/tests/test_mavis/validate/test_validate2.py
@@ -577,33 +577,28 @@ class TestEvidenceGathering:
     def test_collect_split_read(self, ev_gathering_setup):
         ev1_sr = MockRead(
             query_name='HISEQX1_11:3:1105:15351:25130:split',
-            reference_id=1,
-            cigar=[(4, 68), (7, 82)],
+            reference_name='reference3',
+            cigarstring='68S82=',
             reference_start=1114,
-            reference_end=1154,
-            query_alignment_start=110,
             query_sequence='TCGTGAGTGGCAGGTGCCATCGTGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTG',
-            query_alignment_end=150,
-            flag=113,
-            next_reference_id=1,
+            **flags_from_number(113),
+            next_reference_name='1',
             next_reference_start=2341,
         )
         collect_split_read(ev_gathering_setup, ev1_sr, True)
+        assert len(ev_gathering_setup.split_reads[0]) > 0
         assert list(ev_gathering_setup.split_reads[0])[0] == ev1_sr
 
     def test_collect_split_read_failure(self, ev_gathering_setup):
         # wrong cigar string
         ev1_sr = MockRead(
             query_name='HISEQX1_11:4:1203:3062:55280:split',
-            reference_id=1,
-            cigar=[(7, 110), (7, 40)],
+            reference_name='reference3',
+            cigarstring='40=110S',
             reference_start=1114,
-            reference_end=1154,
-            query_alignment_start=110,
             query_sequence='CTGTAAACACAGAATTTGGATTCTTTCCTGTTTGGTTCCTGGTCGTGAGTGGCAGGTGCCATCGTGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATG',
-            query_alignment_end=150,
-            flag=371,
-            next_reference_id=1,
+            **flags_from_number(371),
+            next_reference_name='1',
             next_reference_start=2550,
         )
         assert not collect_split_read(ev_gathering_setup, ev1_sr, True)
@@ -611,24 +606,20 @@ class TestEvidenceGathering:
     def test_collect_flanking_pair(self, ev_gathering_setup):
         collect_flanking_pair(
             ev_gathering_setup,
-            MockRead(
-                reference_id=1,
-                reference_start=2214,
-                reference_end=2364,
-                is_reverse=True,
-                next_reference_id=1,
-                next_reference_start=1120,
-                mate_is_reverse=True,
-            ),
-            MockRead(
-                reference_id=1,
-                reference_start=1120,
-                reference_end=2364,
-                is_reverse=True,
-                next_reference_id=1,
-                next_reference_start=1120,
-                mate_is_reverse=True,
-                is_read1=False,
+            *mock_read_pair(
+                MockRead(
+                    reference_name='reference3',
+                    reference_start=2214,
+                    cigarstring=str(2364 - 2214) + 'M',
+                    is_reverse=True,
+                ),
+                MockRead(
+                    reference_name='reference3',
+                    reference_start=1120,
+                    cigarstring=str(2364 - 1120) + 'M',
+                    is_reverse=True,
+                ),
+                proper_pair=False,
             ),
         )
         assert len(ev_gathering_setup.flanking_pairs) == 1
@@ -637,8 +628,19 @@ class TestEvidenceGathering:
         # first read in pair does not overlap the first evidence window
         # therefore this should return False and not add to the flanking_pairs
         pair = mock_read_pair(
-            MockRead(reference_id=1, reference_start=1903, reference_end=2053, is_reverse=True),
-            MockRead(reference_id=1, reference_start=2052, reference_end=2053, is_reverse=True),
+            MockRead(
+                reference_name='reference3',
+                reference_start=1903,
+                cigarstring=str(2053 - 1903) + 'M',
+                is_reverse=True,
+            ),
+            MockRead(
+                reference_name='reference3',
+                reference_start=2052,
+                cigarstring=str(2053 - 2052) + 'M',
+                is_reverse=True,
+            ),
+            proper_pair=False,
         )
         assert not collect_flanking_pair(ev_gathering_setup, *pair)
         assert len(ev_gathering_setup.flanking_pairs) == 0
@@ -671,41 +673,59 @@ class TestEvidenceGathering:
 
     def test_assemble_split_reads(self, ev_gathering_setup):
         sr1 = MockRead(
+            cigarstring='150M',
+            reference_start=1,
             query_name='HISEQX1_11:3:1105:15351:25130:split',
             query_sequence='TCGTGAGTGGCAGGTGCCATCGTGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTG',
-            flag=113,
+            **flags_from_number(113),
         )
         sr2 = MockRead(
+            cigarstring='150M',
+            reference_start=1,
             query_sequence='GTCGTGAGTGGCAGGTGCCATCGTGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTT',
-            flag=121,
+            **flags_from_number(121),
         )
         sr3 = MockRead(
+            cigarstring='150M',
+            reference_start=1,
             query_sequence='TCGTGAGTGGCAGGTGCCATCGTGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTG',
-            flag=113,
+            **flags_from_number(113),
         )
         sr7 = MockRead(
+            cigarstring='150M',
+            reference_start=1,
             query_sequence='TGAAAGCCCTGTAAACACAGAATTTGGATTCTTTCCTGTTTGGTTCCTGGTCGTGAGTGGCAGGTGCCATCATGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATA',
-            flag=113,
+            **flags_from_number(113),
         )
         sr9 = MockRead(
+            cigarstring='150M',
+            reference_start=1,
             query_sequence='TGTAAACACAGAATTTGGATTCTTTCCTGTTTGGTTCCTGGTCGTGAGTGGCAGGTGCCATCATGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGC',
-            flag=113,
+            **flags_from_number(113),
         )
         sr12 = MockRead(
+            cigarstring='150M',
+            reference_start=1,
             query_sequence='GATTCTTTCCTGTTTGGTTCCTGGTCGTGAGTGGCAGGTGCCATCATGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAG',
-            flag=113,
+            **flags_from_number(113),
         )
         sr15 = MockRead(
+            cigarstring='150M',
+            reference_start=1,
             query_sequence='GTTCCTGGTCGTGAGTGGCAGGTGCCATCATGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACA',
-            flag=113,
+            **flags_from_number(113),
         )
         sr19 = MockRead(
+            cigarstring='150M',
+            reference_start=1,
             query_sequence='TGCCATCATGTTTCATTCTGCCTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTGGTTATGAAATTTCA',
-            flag=113,
+            **flags_from_number(113),
         )
         sr24 = MockRead(
+            cigarstring='150M',
+            reference_start=1,
             query_sequence='CTGAGAGCAGTCTACCTAAATATATAGCTCTGCTCACAGTTTCCCTGCAATGCATAATTAAAATAGCACTATGCAGTTGCTTACACTTCAGATAATGGCTTCCTACATATTGTTGGTTATGAAATTTCAGGGTTTTCATTTCTGTATGTT',
-            flag=113,
+            **flags_from_number(113),
         )
         ev_gathering_setup.split_reads = (
             {sr1},


### PR DESCRIPTION
The purpose of this PR is to change our Read mock so that we are always using sensible/possible reads in our tests. The previous mock let you avoid things like cigar string and set things like reference_end directly which ended up with some strange behaviour and meant some of our tests were throwing the error we expected for the wrong reason.

The new Mock is a little bit more a pain to use b/c you can't skip fields but ensures our tests are always testing what we intend them to

It also is more readable and shorter since it uses the cigar string instead of the cigartuples as input