### PR TITLE
#355 fix chromosome comparison check

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -11,7 +11,7 @@ from mavis_config import (
 from mavis_config.constants import SUBCOMMAND
 
 # env variable mainly for CI/CD
-CONTAINER = os.environ.get('SNAKEMAKE_CONTAINER', 'docker://bcgsc/mavis:v3.0.0')
+CONTAINER = os.environ.get('SNAKEMAKE_CONTAINER', 'docker://bcgsc/mavis:v3.1.1')
 MAX_TIME = 57600
 DEFAULT_MEMORY_MB = 16000
 
@@ -38,7 +38,7 @@ except Exception as err:
     raise WorkflowError(short_msg)
 
 # ADD bindings for singularity
-workflow.singularity_args = f'-B {",".join(get_singularity_bindings(config))}'
+workflow._singularity_args = f'-B {",".join(get_singularity_bindings(config))}'
 
 libraries = sorted(list(config['libraries']))
 VALIDATE_OUTPUT = output_dir('{library}/validate/batch-{job_id}/validation-passed.tab')

--- a/src/mavis/validate/align.py
+++ b/src/mavis/validate/align.py
@@ -563,7 +563,10 @@ def select_contig_alignments(evidence, reads_by_query):
         std_reads = set()
         alignments = []
         for raw_read in reads_by_query.get(contig.seq, []):
-            if raw_read.reference_name != evidence.break1.chr and raw_read.reference_name != evidence.break2.chr:
+            if (
+                raw_read.reference_name != evidence.break1.chr
+                and raw_read.reference_name != evidence.break2.chr
+            ):
                 continue
             read = evidence.standardize_read(raw_read)
             read.cigar = _cigar.merge_internal_events(

--- a/src/mavis/validate/align.py
+++ b/src/mavis/validate/align.py
@@ -563,7 +563,7 @@ def select_contig_alignments(evidence, reads_by_query):
         std_reads = set()
         alignments = []
         for raw_read in reads_by_query.get(contig.seq, []):
-            if raw_read.reference_name not in {evidence.break1.chr, evidence.break2.chr}:
+            if raw_read.reference_name != evidence.break1.chr and raw_read.reference_name != evidence.break2.chr:
                 continue
             read = evidence.standardize_read(raw_read)
             read.cigar = _cigar.merge_internal_events(


### PR DESCRIPTION
Fix to get the chromosomes with a "chr" and without a "chr" to compare properly when aligning reads